### PR TITLE
*: cistern/drainer/pump -h or -help flag print usage info

### DIFF
--- a/cistern/config.go
+++ b/cistern/config.go
@@ -55,7 +55,8 @@ func NewConfig() *Config {
 	cfg.FlagSet = flag.NewFlagSet("cistern", flag.ContinueOnError)
 	fs := cfg.FlagSet
 	fs.Usage = func() {
-		fmt.Fprintln(os.Stderr, usageline)
+		fmt.Fprintln(os.Stderr, "Usage of cistern:")
+		fs.PrintDefaults()
 	}
 	fs.Uint64Var(&cfg.ClusterID, "cluster-id", 0, "specifies the ID of TiDB cluster that cistern in charge of")
 	fs.StringVar(&cfg.ListenAddr, "addr", defaultListenAddr, "addr (i.e. 'host:port') to listen on for drainer connections")
@@ -79,7 +80,6 @@ func (cfg *Config) Parse(args []string) error {
 	switch perr {
 	case nil:
 	case flag.ErrHelp:
-		fmt.Fprintln(os.Stderr, flagsline)
 		os.Exit(1)
 	default:
 		os.Exit(2)

--- a/drainer/config.go
+++ b/drainer/config.go
@@ -3,6 +3,7 @@ package drainer
 import (
 	"flag"
 	"fmt"
+	"os"
 
 	"github.com/BurntSushi/toml"
 	"github.com/juju/errors"
@@ -13,6 +14,10 @@ func NewConfig() *Config {
 	cfg := &Config{}
 	cfg.FlagSet = flag.NewFlagSet("drainer", flag.ContinueOnError)
 	fs := cfg.FlagSet
+	fs.Usage = func() {
+		fmt.Fprintln(os.Stderr, "Usage of drainer:")
+		fs.PrintDefaults()
+	}
 
 	fs.StringVar(&cfg.configFile, "config", "", "Config file")
 	fs.IntVar(&cfg.TxnBatch, "txn-batch", 1, "number of binlog events in a transaction batch")

--- a/pump/config.go
+++ b/pump/config.go
@@ -50,7 +50,8 @@ func NewConfig() *Config {
 	cfg.FlagSet = flag.NewFlagSet("pump", flag.ContinueOnError)
 	fs := cfg.FlagSet
 	fs.Usage = func() {
-		fmt.Fprintln(os.Stderr, usageline)
+		fmt.Fprintln(os.Stderr, "Usage of pump:")
+		fs.PrintDefaults()
 	}
 
 	fs.StringVar(&cfg.ListenAddr, "addr", defaultListenAddr, "addr(i.e. 'host:port') to listen on for client traffic")


### PR DESCRIPTION
when `FlagSet.Parse` get -h or -help flag, if `FlagSet.Usage` function in not nil, it will be called.
`PrintDefaults` would print the available command line flag.
