### PR TITLE
cistern: store savepoint in local, add cluster ID into namespace

### DIFF
--- a/cistern/server.go
+++ b/cistern/server.go
@@ -42,15 +42,15 @@ type Server struct {
 
 // NewServer return a instance of binlog-server
 func NewServer(cfg *Config) (*Server, error) {
-	MetaNamespace = append(MetaNamespace, []byte(fmt.Sprintf("meta_%d", cfg.ClusterID))...)
-	BinlogNamespace = append(BinlogNamespace, []byte(fmt.Sprintf("binlog_%d", cfg.ClusterID))...)
-	SavePointNamespace = append(SavePointNamespace, []byte(fmt.Sprintf("savepoint_%d", cfg.ClusterID))...)
+	WindowNamespace = []byte(fmt.Sprintf("meta_%d", cfg.ClusterID))
+	BinlogNamespace = []byte(fmt.Sprintf("binlog_%d", cfg.ClusterID))
+	SavePointNamespace = []byte(fmt.Sprintf("savepoint_%d", cfg.ClusterID))
 
 	if err := os.MkdirAll(cfg.DataDir, 0700); err != nil {
 		return nil, err
 	}
 
-	s, err := store.NewBoltStore(path.Join(cfg.DataDir, "data.bolt"), [][]byte{MetaNamespace, BinlogNamespace})
+	s, err := store.NewBoltStore(path.Join(cfg.DataDir, "data.bolt"), [][]byte{WindowNamespace, BinlogNamespace, SavePointNamespace})
 	if err != nil {
 		return nil, errors.Annotatef(err, "failed to open BoltDB store in dir(%s)", cfg.DataDir)
 	}

--- a/cistern/window.go
+++ b/cistern/window.go
@@ -55,7 +55,7 @@ func (d *DepositWindow) SaveUpper(val int64) {
 // PersistLower updates the lower boundary of window, and write it into storage.
 func (d *DepositWindow) PersistLower(val int64) error {
 	data := codec.EncodeInt([]byte{}, val)
-	err := d.bolt.Put(MetaNamespace, windowKeyName, data)
+	err := d.bolt.Put(WindowNamespace, windowKeyName, data)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -65,7 +65,7 @@ func (d *DepositWindow) PersistLower(val int64) error {
 
 func loadMark(s store.Store) (int64, error) {
 	var l int64
-	data, err := s.Get(MetaNamespace, windowKeyName)
+	data, err := s.Get(WindowNamespace, windowKeyName)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return 0, nil


### PR DESCRIPTION
- store savepoint in local to allow two cistern alive for Availability
- add cluster ID into namespace to prevent be covered by different cluster ID

fix #27 , fix #28 
