### PR TITLE
*: fix prothemus push bug

### DIFF
--- a/cistern/metrics.go
+++ b/cistern/metrics.go
@@ -91,7 +91,7 @@ func (mc *metricClient) Start(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-time.After(time.Duration(mc.interval) * time.Second):
-			err := push.FromGatherer(
+			err := push.AddFromGatherer(
 				"binlog",
 				push.HostnameGroupingKey(),
 				mc.addr,

--- a/drainer/metrics.go
+++ b/drainer/metrics.go
@@ -54,7 +54,7 @@ func (mc *metricClient) Start(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-time.After(time.Duration(mc.interval) * time.Second):
-			err := push.FromGatherer(
+			err := push.AddFromGatherer(
 				"binlog",
 				push.HostnameGroupingKey(),
 				mc.addr,

--- a/pump/metrics.go
+++ b/pump/metrics.go
@@ -46,7 +46,7 @@ func (mc *metricClient) Start(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-time.After(time.Duration(mc.interval) * time.Second):
-			err := push.FromGatherer(
+			err := push.AddFromGatherer(
 				"binlog",
 				push.HostnameGroupingKey(),
 				mc.addr,


### PR DESCRIPTION
FromGather `The metrics pushed must not contain a job label of their own nor any of the grouping labels.` 

AddFromFather  `AddFromGatherer works like FromGatherer, but only previously pushed metrics with the same name (and the same job and other grouping labels) will be replaced.`

FromGather  can cause pushGateWay do replace operation by job_name+instance(hostname), so we can't deploy the pump/cistern/drainer on one machine unless we change job label or use AddFromFather.