### PR TITLE
pump: skip magic code of current corruption binlog

### DIFF
--- a/pump/binlogger.go
+++ b/pump/binlogger.go
@@ -206,7 +206,8 @@ func (b *binlogger) ReadFrom(from binlog.Pos, nums int32) ([]binlog.Entity, erro
 				if err == ErrCRCMismatch || err == ErrMagicMismatch {
 					corruptionBinlogCounter.Add(1)
 					log.Errorf("decode %+v binlog error %v", from, err)
-					offset, err1 := seekNextBinlog(f, from.Offset)
+					// offset + 1 to skip magic code of current binlog
+					offset, err1 := seekBinlog(f, from.Offset+1)
 					if err1 == nil {
 						from.Offset = offset
 						decoder = NewDecoder(from, io.Reader(f))
@@ -315,7 +316,8 @@ func (b *binlogger) Walk(ctx context.Context, from binlog.Pos, sendBinlog func(e
 				if err == ErrCRCMismatch || err == ErrMagicMismatch {
 					corruptionBinlogCounter.Add(1)
 					log.Errorf("decode %+v binlog error %v", from, err)
-					offset, err1 := seekNextBinlog(f, from.Offset)
+					// offset + 1 to skip magic code of current binlog
+					offset, err1 := seekBinlog(f, from.Offset+1)
 					if err1 == nil {
 						from.Offset = offset
 						decoder = NewDecoder(from, io.Reader(f))

--- a/pump/util.go
+++ b/pump/util.go
@@ -159,7 +159,8 @@ func posToFloat(pos *binlog.Pos) float64 {
 }
 
 // use magic code to find next binlog and skips corruption data
-func seekNextBinlog(f *os.File, offset int64) (int64, error) {
+// seekBinlog seeks one binlog from current offset
+func seekBinlog(f *os.File, offset int64) (int64, error) {
 	var (
 		batchSize    = 1024
 		headerLength = 3 // length of magic code - 1
@@ -168,9 +169,6 @@ func seekNextBinlog(f *os.File, offset int64) (int64, error) {
 		header       = buff[0:headerLength]
 		tail         = buff[headerLength:]
 	)
-
-	// skip magic code of current corruption binlog
-	offset++
 
 	_, err := f.Seek(offset, io.SeekStart)
 	if err != nil {


### PR DESCRIPTION
`seekNextBinlog ` would forward offset one step to seek next binlog, not itself