### PR TITLE
Fix NPE for non-created row batch for flash

### DIFF
--- a/drainer/executor/flash.go
+++ b/drainer/executor/flash.go
@@ -333,6 +333,9 @@ func (e *flashExecutor) flushAll(forceSaveCP bool) {
 	maxCommitTS := int64(0)
 	for _, rbs := range e.rowBatches {
 		for i, rb := range rbs {
+			if rb == nil {
+				continue
+			}
 			lastestCommitTS, err := rb.Flush(e.chDBs[i].Conn)
 			if err != nil {
 				e.err = errors.Trace(err)


### PR DESCRIPTION
Fix a bug in row batch flushing in flash executor. The bug is caused by:
* Row batch is per-query * per-flash-node
* As some point the row batch of a query may have not been created for a specific flash node (no row falls in that flash node), thus it could be null
* When flushing all row batches, it walks through all row batches for all queries * all flash nodes

Fix it by adding a null check.