### PR TITLE
flush: fix checkpoint saveTime

### DIFF
--- a/drainer/checkpoint/flash.go
+++ b/drainer/checkpoint/flash.go
@@ -141,6 +141,8 @@ func (sp *FlashCheckPoint) Save(ts int64, poss map[string]pb.Pos) error {
 	sp.Lock()
 	defer sp.Unlock()
 
+	sp.saveTime = time.Now()
+
 	// Init CP using metaCP's safe CP.
 	forceSave, ok, safeTS, safePoss := sp.metaCP.PopSafeCP()
 	if forceSave {
@@ -160,7 +162,6 @@ func (sp *FlashCheckPoint) Save(ts int64, poss map[string]pb.Pos) error {
 	}
 
 	sp.CommitTS = safeTS
-	sp.saveTime = time.Now()
 
 	b, err := json.Marshal(sp)
 	if err != nil {


### PR DESCRIPTION
flush updates checkpoint every `timeLimit`. 
In order to avoid returning true every time we call `checkpoint.Check()`( thus performance of drainer would be affected), we should update `saveTime` firstly in `checkpoint.Save`