### PR TITLE
syncer.go: fix bug save checkpoint which only partially synced to downstream

### DIFF
--- a/drainer/syncer.go
+++ b/drainer/syncer.go
@@ -537,7 +537,9 @@ func (s *Syncer) sync(executor executor.Executor, jobChan chan *job) {
 				tpCnt[job.mutationTp]++
 			}
 
-			if job.binlogTp == translator.FLUSH || (!s.cfg.DisableDispatch && idx >= count) || job.isCompleteBinlog {
+			if job.binlogTp == translator.FLUSH ||
+				!s.cfg.DisableDispatch && idx >= count ||
+				s.cfg.DisableDispatch && job.isCompleteBinlog {
 				err = execute(executor, sqls, args, commitTSs, false)
 				if err != nil {
 					log.Fatalf(errors.ErrorStack(err))


### PR DESCRIPTION
remove the magic DML type job which set isCompleteBinlog to true
set isCompleteBinlog to true when this job the the last job of a txn
simplify checkWait