### PR TITLE
metircs.go: use custom registry to avoid metircs from pump/

### DIFF
--- a/drainer/metrics.go
+++ b/drainer/metrics.go
@@ -120,22 +120,22 @@ var (
 		}, []string{"nodeID"})
 )
 
-var registerer = prometheus.NewRegistry()
+var registry = prometheus.NewRegistry()
 
 func init() {
-	registerer.MustRegister(windowGauge)
-	registerer.MustRegister(offsetGauge)
-	registerer.MustRegister(publishBinlogCounter)
-	registerer.MustRegister(ddlJobsCounter)
-	registerer.MustRegister(tikvQueryCount)
-	registerer.MustRegister(errorBinlogCount)
-	registerer.MustRegister(positionGauge)
-	registerer.MustRegister(eventCounter)
-	registerer.MustRegister(txnHistogram)
-	registerer.MustRegister(readBinlogHistogram)
-	registerer.MustRegister(readBinlogSizeHistogram)
-	registerer.MustRegister(publishBinlogHistogram)
-	registerer.MustRegister(findMatchedBinlogHistogram)
+	registry.MustRegister(windowGauge)
+	registry.MustRegister(offsetGauge)
+	registry.MustRegister(publishBinlogCounter)
+	registry.MustRegister(ddlJobsCounter)
+	registry.MustRegister(tikvQueryCount)
+	registry.MustRegister(errorBinlogCount)
+	registry.MustRegister(positionGauge)
+	registry.MustRegister(eventCounter)
+	registry.MustRegister(txnHistogram)
+	registry.MustRegister(readBinlogHistogram)
+	registry.MustRegister(readBinlogSizeHistogram)
+	registry.MustRegister(publishBinlogHistogram)
+	registry.MustRegister(findMatchedBinlogHistogram)
 }
 
 type metricClient struct {
@@ -155,7 +155,7 @@ func (mc *metricClient) Start(ctx context.Context, drainerID string) {
 				"binlog",
 				map[string]string{"instance": drainerID},
 				mc.addr,
-				registerer,
+				registry,
 			)
 			if err != nil {
 				log.Errorf("could not push metrics to Prometheus Pushgateway: %v", err)

--- a/pump/metrics.go
+++ b/pump/metrics.go
@@ -87,16 +87,18 @@ var (
 		}, []string{"label"})
 )
 
+var registry = prometheus.NewRegistry()
+
 func init() {
-	prometheus.MustRegister(rpcHistogram)
-	prometheus.MustRegister(writeBinlogSizeHistogram)
-	prometheus.MustRegister(readBinlogHistogram)
-	prometheus.MustRegister(lossBinlogCacheCounter)
-	prometheus.MustRegister(writeBinlogHistogram)
-	prometheus.MustRegister(readErrorCounter)
-	prometheus.MustRegister(writeErrorCounter)
-	prometheus.MustRegister(checkpointGauge)
-	prometheus.MustRegister(corruptionBinlogCounter)
+	registry.MustRegister(rpcHistogram)
+	registry.MustRegister(writeBinlogSizeHistogram)
+	registry.MustRegister(readBinlogHistogram)
+	registry.MustRegister(lossBinlogCacheCounter)
+	registry.MustRegister(writeBinlogHistogram)
+	registry.MustRegister(readErrorCounter)
+	registry.MustRegister(writeErrorCounter)
+	registry.MustRegister(checkpointGauge)
+	registry.MustRegister(corruptionBinlogCounter)
 }
 
 type metricClient struct {
@@ -118,7 +120,7 @@ func (mc *metricClient) Start(ctx context.Context, pumpID string) {
 				"binlog",
 				map[string]string{"instance": pumpID},
 				mc.addr,
-				prometheus.DefaultGatherer,
+				registry,
 			)
 			if err != nil {
 				log.Errorf("could not push metrics to Prometheus Pushgateway: %v", err)


### PR DESCRIPTION
 drainer import
the /pump dir, so drainer proccess use default register of prometheus
will contains the metrics in pump/metircs.go