### PR TITLE
*: remove all the megacheck&ineffassign warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,7 @@ check:
 check-static:
 	gometalinter --disable-all --deadline 120s \
 		--enable megacheck \
+		--enable ineffassign \
 		$$($(PACKAGE_DIRECTORIES))
 
 update:

--- a/drainer/collector.go
+++ b/drainer/collector.go
@@ -114,10 +114,7 @@ func (c *Collector) publishBinlogs(ctx context.Context) {
 					err := util.RetryOnError(getDDLJobRetryTime, time.Second, fmt.Sprintf("get ddl job by id %d error", binlog.DdlJobId), func() error {
 						var err1 error
 						job, err1 = getDDLJob(c.tiStore, binlog.DdlJobId)
-						if err1 != nil {
-							return err1
-						}
-						return nil
+						return err1
 					})
 
 					if err != nil {

--- a/drainer/config.go
+++ b/drainer/config.go
@@ -279,10 +279,10 @@ func (cfg *Config) adjustConfig() error {
 	// get KafkaAddrs from zookeeper if ZkAddrs is setted
 	if cfg.SyncerCfg.To.ZKAddrs != "" {
 		zkClient, err := zk.NewFromConnectionString(cfg.SyncerCfg.To.ZKAddrs, time.Second*5, time.Second*60)
-		defer zkClient.Close()
 		if err != nil {
 			return errors.Trace(err)
 		}
+		defer zkClient.Close()
 
 		kafkaUrls, err := zkClient.KafkaUrls()
 		if err != nil {

--- a/drainer/executor/flash.go
+++ b/drainer/executor/flash.go
@@ -238,7 +238,7 @@ func (e *flashExecutor) Execute(sqls []string, args [][]interface{}, commitTSs [
 			sql := sqls[i]
 			args := row[1:]
 			if _, ok := e.rowBatches[sql]; !ok {
-				e.rowBatches[sql] = make([]*flashRowBatch, len(e.chDBs), len(e.chDBs))
+				e.rowBatches[sql] = make([]*flashRowBatch, len(e.chDBs))
 			}
 			if e.rowBatches[sql][hashKey] == nil {
 				e.rowBatches[sql][hashKey] = newFlashRowBatch(sql, e.sizeLimit)

--- a/drainer/filter.go
+++ b/drainer/filter.go
@@ -50,10 +50,7 @@ func (s *Syncer) whiteFilter(stbs []TableName) []TableName {
 func (s *Syncer) skipSchemaAndTable(schema string, table string) bool {
 	tbs := []TableName{{Schema: schema, Table: table}}
 	tbs = s.whiteFilter(tbs)
-	if len(tbs) == 0 {
-		return true
-	}
-	return false
+	return len(tbs) == 0
 }
 
 func (s *Syncer) matchString(pattern string, t string) bool {

--- a/drainer/schema_test.go
+++ b/drainer/schema_test.go
@@ -176,15 +176,15 @@ func (*testDrainerSuite) TestTable(c *C) {
 	jobs = append(jobs, &model.Job{ID: 9, SchemaID: 3, TableID: 2, Type: model.ActionTruncateTable, BinlogInfo: &model.HistoryInfo{123, nil, tblInfo1, 123}})
 	schema1, err := NewSchema(jobs, ignoreNames, false)
 	c.Assert(err, IsNil)
-	table, ok = schema1.TableByID(tblInfo1.ID)
+	_, ok = schema1.TableByID(tblInfo1.ID)
 	c.Assert(ok, IsTrue)
-	table, ok = schema1.TableByID(2)
+	_, ok = schema1.TableByID(2)
 	c.Assert(ok, IsFalse)
 	// check drop table
 	jobs = append(jobs, &model.Job{ID: 9, SchemaID: 3, TableID: 9, Type: model.ActionDropTable})
 	schema2, err := NewSchema(jobs, ignoreNames, false)
 	c.Assert(err, IsNil)
-	table, ok = schema2.TableByID(tblInfo.ID)
+	_, ok = schema2.TableByID(tblInfo.ID)
 	c.Assert(ok, IsFalse)
 	// test schemaAndTableName
 	_, _, ok = schema1.SchemaAndTableName(9)

--- a/drainer/server.go
+++ b/drainer/server.go
@@ -388,7 +388,6 @@ func (s *Server) ApplyAction(w http.ResponseWriter, r *http.Request) {
 
 	go s.Close()
 	rd.JSON(w, http.StatusOK, util.SuccessResponse(fmt.Sprintf("apply action %s success!", action), nil))
-	return
 }
 
 // GetLatestTS returns the last binlog's commit ts which synced to downstream.
@@ -398,7 +397,6 @@ func (s *Server) GetLatestTS(w http.ResponseWriter, r *http.Request) {
 	})
 	ts := s.syncer.GetLatestCommitTS()
 	rd.JSON(w, http.StatusOK, util.SuccessResponse("get drainer's latest ts success!", map[string]int64{"ts": ts}))
-	return
 }
 
 // commitStatus commit the node's last status to pd when close the server.
@@ -441,7 +439,7 @@ func (s *Server) updateStatus() error {
 func (s *Server) Close() {
 	log.Info("begin to close drainer server")
 
-	if atomic.CompareAndSwapInt32(&s.isClosed, 0, 1) == false {
+	if !atomic.CompareAndSwapInt32(&s.isClosed, 0, 1) {
 		log.Debug("server had closed")
 		return
 	}

--- a/drainer/syncer.go
+++ b/drainer/syncer.go
@@ -424,8 +424,6 @@ func (s *Syncer) addJob(job *job) {
 		eventCounter.WithLabelValues("flush").Add(1)
 		s.jobWg.Wait()
 		return
-	} else if job.binlogTp == translator.FAKE {
-		// do nothing
 	}
 
 	if job.binlogTp != translator.FAKE {

--- a/drainer/translator/flash.go
+++ b/drainer/translator/flash.go
@@ -402,8 +402,8 @@ func analyzeAlterSpec(alterSpec *ast.AlterTableSpec) (string, error) {
 	case ast.AlterTableOption:
 		return "", nil
 	case ast.AlterTableAddColumns:
-		var colDefStr = ""
-		var colPosStr = ""
+		var colDefStr string
+		var colPosStr string
 		var err error
 		// TODO: Support add multiple columns.
 		colDefStr, err = analyzeColumnDef(alterSpec.NewColumns[0], "")
@@ -448,8 +448,8 @@ func analyzeAlterSpec(alterSpec *ast.AlterTableSpec) (string, error) {
 }
 
 func analyzeModifyColumn(alterSpec *ast.AlterTableSpec) (string, error) {
-	var colDefStr = ""
-	var colPosStr = ""
+	var colDefStr string
+	var colPosStr string
 	var err error
 	colDefStr, err = analyzeColumnDef(alterSpec.NewColumns[0], "")
 	if err != nil {

--- a/drainer/translator/flash_util.go
+++ b/drainer/translator/flash_util.go
@@ -367,6 +367,9 @@ func convertValueType(data types.Datum, source *types.FieldType, target *types.F
 		case mysql.TypeFloat, mysql.TypeDouble, mysql.TypeNewDecimal:
 			mysqlTime, err = types.ParseTimeFromFloatString(&stmtctx.StatementContext{TimeZone: gotime.Local}, data.GetMysqlDecimal().String(), target.Tp, 0)
 		}
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
 		formatted, err := mysqlTime.DateFormat("%Y-%m-%d %H:%i:%S")
 		if err != nil {
 			return nil, errors.Trace(err)
@@ -395,7 +398,7 @@ func convertValueType(data types.Datum, source *types.FieldType, target *types.F
 		case mysql.TypeVarchar, mysql.TypeTinyBlob, mysql.TypeMediumBlob, mysql.TypeLongBlob, mysql.TypeBlob, mysql.TypeVarString, mysql.TypeString:
 			// As TiDB allows string literal like '1998.0' to be year value, and ParseYear() will error out for it, we need to cast to integer by ourselves.
 			var d float64
-			_, err := fmt.Sscanf(data.GetString(), "%f", &d)
+			_, err = fmt.Sscanf(data.GetString(), "%f", &d)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
@@ -403,7 +406,8 @@ func convertValueType(data types.Datum, source *types.FieldType, target *types.F
 		case mysql.TypeTiny, mysql.TypeShort, mysql.TypeLong, mysql.TypeLonglong, mysql.TypeInt24:
 			year, err = types.ParseYear(fmt.Sprintf("%v", data.GetInt64()))
 		case mysql.TypeFloat, mysql.TypeDouble, mysql.TypeNewDecimal:
-			d, err := data.GetMysqlDecimal().ToFloat64()
+			var d float64
+			d, err = data.GetMysqlDecimal().ToFloat64()
 			if err != nil {
 				return nil, errors.Trace(err)
 			}

--- a/pkg/assemble/assemble_test.go
+++ b/pkg/assemble/assemble_test.go
@@ -5,11 +5,12 @@ import (
 	"hash/crc32"
 	"time"
 
+	"testing"
+
 	"github.com/Shopify/sarama"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb-binlog/pkg/slicer"
 	"github.com/prometheus/client_golang/prometheus"
-	"testing"
 )
 
 func TestClient(t *testing.T) {
@@ -133,7 +134,6 @@ func (t *testAssemblerSuite) TestAssembleBinlog(c *C) {
 
 	// cache overflow
 	// [incomplete binlog,  binlog slices]
-	binlog = nil
 	messages = t.testGenerateConsumerMessage("t1", 4, nil)
 	asm.cacheSize = 3
 	for _, message := range messages {

--- a/pkg/etcd/etcd_test.go
+++ b/pkg/etcd/etcd_test.go
@@ -98,7 +98,7 @@ func (t *testEtcdSuite) TestUpdate(c *C) {
 	c.Assert(string(res), Equals, obj2)
 
 	time.Sleep(2 * time.Second)
-	res, err = etcdCli.Get(ctx, key)
+	_, err = etcdCli.Get(ctx, key)
 	c.Assert(errors.IsNotFound(err), IsTrue)
 }
 

--- a/pkg/flags/flag.go
+++ b/pkg/flags/flag.go
@@ -2,7 +2,6 @@ package flags
 
 import (
 	"flag"
-	"fmt"
 	"net/url"
 	"os"
 	"strings"
@@ -12,26 +11,6 @@ import (
 
 func flagToEnv(prefix, name string) string {
 	return prefix + "_" + strings.ToUpper(strings.Replace(name, "-", "_", -1))
-}
-
-func verifyEnv(prefix string, usedEnvKey, alreadySet map[string]bool) {
-	for _, env := range os.Environ() {
-		kv := strings.SplitN(env, "=", 2)
-		if len(kv) != 2 {
-			panic(fmt.Sprintf("found invalid env %s", env))
-		}
-		if usedEnvKey[kv[0]] {
-			continue
-		}
-		if alreadySet[kv[0]] {
-			// recognized environment variable, but unused: shadowed by corresponding flag
-			continue
-		}
-		if strings.HasPrefix(env, prefix) {
-			// unrecognized environment variable
-			continue
-		}
-	}
 }
 
 // SetFlagsFromEnv parses all registered flags in the given flagset,
@@ -49,8 +28,6 @@ func SetFlagsFromEnv(prefix string, fs *flag.FlagSet) error {
 	fs.VisitAll(func(f *flag.Flag) {
 		err = setFlagFromEnv(fs, prefix, f.Name, usedEnvKey, alreadySet)
 	})
-
-	verifyEnv(prefix, usedEnvKey, alreadySet)
 
 	return errors.Trace(err)
 }

--- a/pkg/offsets/offset_test.go
+++ b/pkg/offsets/offset_test.go
@@ -6,6 +6,9 @@ import (
 	"time"
 
 	"encoding/binary"
+	"hash/crc32"
+	"math/rand"
+
 	"github.com/Shopify/sarama"
 	"github.com/juju/errors"
 	. "github.com/pingcap/check"
@@ -14,8 +17,6 @@ import (
 	"github.com/pingcap/tipb/go-binlog"
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/net/context"
-	"hash/crc32"
-	"math/rand"
 )
 
 var (
@@ -142,7 +143,7 @@ func (to *testOffsetSuite) TestOffset(c *C) {
 	messages, err = sli.Generate(entity)
 	c.Assert(err, IsNil)
 	messages = messages[1:] // drop a slice
-	offset, err = to.produceMessageSlices(messages)
+	_, err = to.produceMessageSlices(messages)
 	c.Assert(err, IsNil)
 
 	message = []byte("eeeeeeeeeeeeeeeeeeee")

--- a/pkg/sql/sql.go
+++ b/pkg/sql/sql.go
@@ -144,19 +144,20 @@ func GetTidbPosition(db *sql.DB) (int64, error) {
 	}
 	defer rows.Close()
 
-	for rows.Next() {
-		fields, err1 := ScanRow(rows)
-		if err1 != nil {
-			return 0, errors.Trace(err1)
-		}
-
-		ts, err1 := strconv.ParseInt(string(fields["Position"]), 10, 64)
-		if err1 != nil {
-			return 0, errors.Trace(err1)
-		}
-		return ts, nil
+	if !rows.Next() {
+		return 0, errors.New("get slave cluster's ts failed")
 	}
-	return 0, errors.New("get slave cluster's ts failed")
+
+	fields, err1 := ScanRow(rows)
+	if err1 != nil {
+		return 0, errors.Trace(err1)
+	}
+
+	ts, err1 := strconv.ParseInt(string(fields["Position"]), 10, 64)
+	if err1 != nil {
+		return 0, errors.Trace(err1)
+	}
+	return ts, nil
 }
 
 // ScanRow scans rows into a map.

--- a/pump/binlogger.go
+++ b/pump/binlogger.go
@@ -332,7 +332,7 @@ func (b *binlogger) GC(days time.Duration, pos binlog.Pos) {
 				continue
 			}
 			log.Info("GC binlog file:", fileName)
-		} else if time.Now().Sub(fi.ModTime()) > days {
+		} else if time.Since(fi.ModTime()) > days {
 			log.Warningf("binlog file %s is already reach the gc time, but data is not send to kafka, position is %v", fileName, pos)
 		}
 	}

--- a/pump/binlogger_test.go
+++ b/pump/binlogger_test.go
@@ -68,13 +68,13 @@ func (s *testBinloggerSuite) TestOpenForWrite(c *C) {
 	latestPos := &binlog.Pos{Suffix: 1}
 	c.Assert(latestPos.Suffix, Equals, uint64(1))
 
-	curOffset, err := curFile.Seek(0, os.SEEK_CUR)
+	curOffset, err := curFile.Seek(0, io.SeekCurrent)
 	c.Assert(err, IsNil)
 
 	_, err = b.WriteTail(&binlog.Entity{Payload: []byte("binlogtest")})
 	c.Assert(err, IsNil)
 
-	nowOffset, err := curFile.Seek(0, os.SEEK_CUR)
+	nowOffset, err := curFile.Seek(0, io.SeekCurrent)
 	c.Assert(err, IsNil)
 	c.Assert(nowOffset, Equals, curOffset+26)
 

--- a/pump/node.go
+++ b/pump/node.go
@@ -266,10 +266,8 @@ func checkNodeID(nodeID string) bool {
 	}
 
 	_, err = strconv.Atoi(port)
-	if err != nil {
-		return false
-	}
-	return true
+
+	return err != nil
 }
 
 // FormatNodeID formats the nodeID, the nodeID should looks like "host:port"

--- a/pump/slicer.go
+++ b/pump/slicer.go
@@ -47,7 +47,7 @@ func (s *KafkaSlicer) Generate(entity *binlog.Entity) ([]*sarama.ProducerMessage
 		total     = (len(entity.Payload) + GlobalConfig.SlicesSize - 1) / GlobalConfig.SlicesSize
 		messages  = make([]*sarama.ProducerMessage, 0, total)
 		left      = 0
-		right     = 0
+		right     int
 		totalByte = make([]byte, 4)
 		messageID = []byte(BinlogSliceMessageID(entity.Pos))
 	)

--- a/pump/storage/log.go
+++ b/pump/storage/log.go
@@ -145,7 +145,7 @@ func newLogFile(fid uint32, name string) (lf *logFile, err error) {
 		}
 	}
 
-	if lf.end == false {
+	if !lf.end {
 		err = lf.recover()
 		if err != nil {
 			err = errors.Trace(err)
@@ -248,7 +248,7 @@ func (lf *logFile) readRecord(offset int64) (record *Record, err error) {
 		return
 	}
 
-	if record.isValid() == false {
+	if !record.isValid() {
 		err = errors.New("checksum mismatch")
 		return
 	}

--- a/pump/storage/sorter.go
+++ b/pump/storage/sorter.go
@@ -154,7 +154,7 @@ func (s *sorter) run() {
 		if item.tp == pb.BinlogType_Prewrite {
 			for {
 				_, ok := s.waitStartTS[item.start]
-				if ok == false {
+				if !ok {
 					break
 				}
 				if s.resolver != nil && s.resolver(item.start) {

--- a/pump/storage/sorter_test.go
+++ b/pump/storage/sorter_test.go
@@ -54,9 +54,7 @@ func testSorter(c *check.C, items []sortItem, expectMaxCommitTS []int64) {
 }
 
 func (s *SorterSuite) TestSorter(c *check.C) {
-	var items []sortItem
-
-	items = []sortItem{
+	var items = []sortItem{
 		{
 			start: 1,
 			tp:    pb.BinlogType_Prewrite,

--- a/pump/storage/vlog.go
+++ b/pump/storage/vlog.go
@@ -371,7 +371,7 @@ func (vlog *valueLog) scan(start valuePointer, fn func(vp valuePointer, record *
 		if fid < start.Fid {
 			continue
 		}
-		lf, _ := vlog.filesMap[fid]
+		lf := vlog.filesMap[fid]
 		var startOffset int64
 		if fid == start.Fid {
 			startOffset = start.Offset

--- a/pump/storage/vlog_test.go
+++ b/pump/storage/vlog_test.go
@@ -128,8 +128,7 @@ func (vs *VlogSuit) TestCloseAndOpen(c *check.C) {
 	var reqs []*request
 	for i := 0; i < n; i++ {
 		// close and open back every time
-		var err error
-		err = vlog.close()
+		var err = vlog.close()
 		c.Assert(err, check.IsNil)
 
 		vlog = new(valueLog)


### PR DESCRIPTION
 remove all the megacheck&ineffassign warning except prometheus.Handler is deprecated

check before this pr
```
➜  tidb-binlog git:(cleanup) ✗ make check-static
gometalinter --disable-all --deadline 120s \
		--enable megacheck \
		$(go list ./...| grep -vE 'vendor|cmd|test|proto|diff' | sed 's|github.com/pingcap/tidb-binlog/||')
drainer/config.go:282:3:warning: should check returned error before deferring zkClient.Close() (SA5001) (megacheck)
drainer/schema_test.go:179:2:warning: this value of table is never used (SA4006) (megacheck)
drainer/schema_test.go:181:2:warning: this value of table is never used (SA4006) (megacheck)
drainer/schema_test.go:187:2:warning: this value of table is never used (SA4006) (megacheck)
drainer/server.go:341:26:warning: prometheus.Handler is deprecated: Please note the issues described in the doc comment of InstrumentHandler. You might want to consider using promhttp.Handler instead (which is non instrumented).  (SA1019) (megacheck)
drainer/syncer.go:427:9:warning: empty branch (SA9003) (megacheck)
drainer/translator/flash_util.go:364:15:warning: this value of err is never used (SA4006) (megacheck)
drainer/translator/flash_util.go:366:15:warning: this value of err is never used (SA4006) (megacheck)
drainer/translator/flash_util.go:368:15:warning: this value of err is never used (SA4006) (megacheck)
drainer/translator/flash_util.go:402:10:warning: this value of err is never used (SA4006) (megacheck)
drainer/translator/flash_util.go:410:10:warning: this value of err is never used (SA4006) (megacheck)
pkg/etcd/etcd_test.go:101:2:warning: this value of res is never used (SA4006) (megacheck)
pkg/flags/flag.go:30:23:warning: HasPrefix is a pure function but its return value is ignored (SA4017) (megacheck)
pkg/offsets/offset_test.go:145:2:warning: this value of offset is never used (SA4006) (megacheck)
pkg/sql/sql.go:157:3:warning: the surrounding loop is unconditionally terminated (SA4004) (megacheck)
pump/binlogger_test.go:71:36:warning: os.SEEK_CUR is deprecated: Use io.SeekStart, io.SeekCurrent, and io.SeekEnd.  (SA1019) (megacheck)
pump/binlogger_test.go:77:36:warning: os.SEEK_CUR is deprecated: Use io.SeekStart, io.SeekCurrent, and io.SeekEnd.  (SA1019) (megacheck)
pump/server.go:116:34:warning: grpc.MaxMsgSize is deprecated: use MaxRecvMsgSize instead.  (SA1019) (megacheck)
pump/server.go:393:26:warning: prometheus.Handler is deprecated: Please note the issues described in the doc comment of InstrumentHandler. You might want to consider using promhttp.Handler instead (which is non instrumented).  (SA1019) (megacheck)
pump/server.go:488:19:warning: using time.Tick leaks the underlying ticker, consider using it only in endless functions, tests and the main package, and use time.NewTicker here (SA1015) (megacheck)
pump/server.go:691:20:warning: using time.Tick leaks the underlying ticker, consider using it only in endless functions, tests and the main package, and use time.NewTicker here (SA1015) (megacheck)
pump/storage/storage.go:285:27:warning: using time.Tick leaks the underlying ticker, consider using it only in endless functions, tests and the main package, and use time.NewTicker here (SA1015) (megacheck)
pump/storage/storage.go:288:25:warning: using time.Tick leaks the underlying ticker, consider using it only in endless functions, tests and the main package, and use time.NewTicker here (SA1015) (megacheck)
pump/storage/storage.go:371:10:warning: empty branch (SA9003) (megacheck)
drainer/collector.go:117:7:warning: 'if err1 != nil { return err1 }; return nil' can be simplified to 'return err1' (S1013) (megacheck)
drainer/executor/flash.go:241:48:warning: should use make([]*flashRowBatch, len(e.chDBs)) instead (S1019) (megacheck)
drainer/filter.go:53:2:warning: should use 'return <expr>' instead of 'if <expr> { return <bool> }; return <bool>' (S1008) (megacheck)
drainer/server.go:391:2:warning: redundant return statement (S1023) (megacheck)
drainer/server.go:401:2:warning: redundant return statement (S1023) (megacheck)
drainer/server.go:444:5:warning: should omit comparison to bool constant, can be simplified to !atomic.CompareAndSwapInt32(&s.isClosed, 0, 1) (S1002) (megacheck)
pump/binlogger.go:335:13:warning: should use time.Since instead of time.Now().Sub (S1012) (megacheck)
pump/node.go:269:2:warning: should use 'return <expr>' instead of 'if <expr> { return <bool> }; return <bool>' (S1008) (megacheck)
pump/server.go:635:2:warning: redundant return statement (S1023) (megacheck)
pump/server.go:753:5:warning: should omit comparison to bool constant, can be simplified to !atomic.CompareAndSwapInt32(&s.isClosed, 0, 1) (S1002) (megacheck)
pump/storage/log.go:148:5:warning: should omit comparison to bool constant, can be simplified to !lf.end (S1002) (megacheck)
pump/storage/log.go:251:5:warning: should omit comparison to bool constant, can be simplified to !record.isValid() (S1002) (megacheck)
pump/storage/sorter.go:157:8:warning: should omit comparison to bool constant, can be simplified to !ok (S1002) (megacheck)
pump/storage/sorter_test.go:57:2:warning: should merge variable declaration with assignment on next line (S1021) (megacheck)
pump/storage/storage.go:738:5:warning: should use a simple channel send/receive instead of select with a single case (S1000) (megacheck)
pump/storage/vlog.go:374:3:warning: should write lf := vlog.filesMap[fid] instead of lf, _ := vlog.filesMap[fid] (S1005) (megacheck)
pump/storage/vlog_test.go:131:3:warning: should merge variable declaration with assignment on next line (S1021) (megacheck)
make: *** [check-static] Error 1
```