### PR TITLE
syncer.go: avoid too long log which is unreadable

### DIFF
--- a/drainer/syncer.go
+++ b/drainer/syncer.go
@@ -1,7 +1,9 @@
 package drainer
 
 import (
+	"fmt"
 	"regexp"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -400,6 +402,27 @@ type job struct {
 	isCompleteBinlog bool
 }
 
+func (j *job) String() string {
+	// build args String, avoid to print too big value arg
+	builder := new(strings.Builder)
+	builder.WriteString("[")
+
+	for i := 0; i < len(j.args); i++ {
+		if i > 0 {
+			builder.WriteString(", ")
+		}
+
+		tmp := fmt.Sprintf("%v", j.args[i])
+		if len(tmp) > 30 {
+			tmp = tmp[0:30] + "..."
+		}
+		builder.WriteString(tmp)
+	}
+	builder.WriteString("]")
+
+	return fmt.Sprintf("{binlogTp: %v, mutationTp: %v, sql: %v, args: %v, key: %v, commitTS: %v, nodeID: %v, isCompleteBinlog: %v}", j.binlogTp, j.mutationTp, j.sql, builder.String(), j.key, j.commitTS, j.nodeID, j.isCompleteBinlog)
+}
+
 func newDMLJob(tp pb.MutationType, sql string, args []interface{}, key string, commitTS int64, nodeID string, isCompleteBinlog bool) *job {
 	return &job{binlogTp: translator.DML, mutationTp: tp, sql: sql, args: args, key: key, commitTS: commitTS, nodeID: nodeID, isCompleteBinlog: isCompleteBinlog}
 }
@@ -413,6 +436,8 @@ func newFakeJob(commitTS int64, nodeID string) *job {
 }
 
 func (s *Syncer) addJob(job *job) {
+	log.Debugf("add job: %s", job)
+
 	// make all DMLs be executed before DDL
 	if job.binlogTp == translator.DDL {
 		s.jobWg.Wait()
@@ -430,7 +455,6 @@ func (s *Syncer) addJob(job *job) {
 		s.jobWg.Add(1)
 		idx := int(genHashKey(job.key)) % s.cfg.WorkerCount
 		s.jobCh[idx] <- job
-		log.Debugf("job commit TS %d sql %s args %v key %s", job.commitTS, job.sql, job.args, job.key)
 	}
 
 	if pos, ok := s.positions[job.nodeID]; !ok || job.commitTS > pos {

--- a/pump/server.go
+++ b/pump/server.go
@@ -291,7 +291,6 @@ func (s *Server) PullBinlogs(in *binlog.PullBinlogReq, stream binlog.Pump_PullBi
 			return nil
 		}
 	}
-	return nil
 }
 
 // Start runs Pump Server to serve the listening addr, and maintains heartbeat to Etcd


### PR DESCRIPTION
also remove unreachable return nil