### PR TITLE
pump: remove enable tolerant config

### DIFF
--- a/cmd/pump/README.md
+++ b/cmd/pump/README.md
@@ -17,8 +17,6 @@ pump is a daemon that receives realtime binlog from tidb-server and writes in se
       path to the pump configuration file
   -data-dir string
       the path to store binlog data
-  -enable-tolerant
-      after enable tolerant, pump wouldn't return error if it fails to write binlog (default true)
   -gc int
       recycle binlog files older than gc days, zero means never recycle (default 7)
   -heartbeat-interval int

--- a/pump/config.go
+++ b/pump/config.go
@@ -68,7 +68,6 @@ type Config struct {
 	LogFile           string          `toml:"log-file" json:"log-file"`
 	LogRotate         string          `toml:"log-rotate" json:"log-rotate"`
 	Security          security.Config `toml:"security" json:"security"`
-	EnableTolerant    bool            `toml:"enable-tolerant" json:"enable-tolerant"`
 
 	GenFakeBinlogInterval int `toml:"gen-binlog-interval" json:"gen-binlog-interval"`
 
@@ -105,7 +104,6 @@ func NewConfig() *Config {
 	fs.IntVar(&cfg.MetricsInterval, "metrics-interval", 15, "prometheus client push interval in second, set \"0\" to disable prometheus push")
 	fs.StringVar(&cfg.configFile, "config", "", "path to the pump configuration file")
 	fs.BoolVar(&cfg.printVersion, "V", false, "print pump version info")
-	fs.BoolVar(&cfg.EnableTolerant, "enable-tolerant", true, "after enable tolerant, pump wouldn't return error if it fails to write binlog")
 	fs.StringVar(&cfg.LogFile, "log-file", "", "log file path")
 	fs.StringVar(&cfg.LogRotate, "log-rotate", "", "log file rotate type, hour/day")
 	fs.IntVar(&cfg.GenFakeBinlogInterval, "fake-binlog-interval", defaultGenFakeBinlogInterval, "interval time to generate fake binlog, the unit is second")

--- a/pump/server.go
+++ b/pump/server.go
@@ -234,12 +234,8 @@ func (s *Server) writeBinlog(ctx context.Context, in *binlog.WriteBinlogReq, isF
 errHandle:
 	lossBinlogCacheCounter.Add(1)
 	log.Errorf("write binlog error %v", err)
-	if !s.cfg.EnableTolerant {
-		ret.Errmsg = err.Error()
-		return ret, err
-	}
-
-	return ret, nil
+	ret.Errmsg = err.Error()
+	return ret, err
 }
 
 // PullBinlogs sends binlogs in the streaming way


### PR DESCRIPTION
pump should not keep this config in new version. pump need return error to pump client, and pump client will try use another pump. Enable tolerant should be do in tidb/pump client.