### PR TITLE
drainer/* config the schema name to save checkpoint table

### DIFF
--- a/cmd/drainer/drainer.toml
+++ b/cmd/drainer/drainer.toml
@@ -66,10 +66,11 @@ host = "127.0.0.1"
 user = "root"
 password = ""
 port = 3306
-# checkpoint-schema = "tidb_binlog"
 # Time and size limits for flash batch write
 # time-limit = "30s"
 # size-limit = "100000"
+[syncer.to.checkpoint]
+#schema = "tidb_binlog"
 
 # Uncomment this if you want to use pb or sql as db-type.
 # Compress compresses output file, like pb and sql file. Now it supports "gzip" algorithm only. 

--- a/drainer/executor/util.go
+++ b/drainer/executor/util.go
@@ -7,19 +7,24 @@ import (
 
 // DBConfig is the DB configuration.
 type DBConfig struct {
-	Host             string `toml:"host" json:"host"`
-	User             string `toml:"user" json:"user"`
-	Password         string `toml:"password" json:"password"`
-	Port             int    `toml:"port" json:"port"`
-	CheckpointSchema string `toml:"checkpoint-schema" json:"checkpoint-schema"`
-	BinlogFileDir    string `toml:"dir" json:"dir"`
-	Compression      string `toml:"compression" json:"compression"`
-	TimeLimit        string `toml:"time-limit" json:"time-limit"`
-	SizeLimit        string `toml:"size-limit" json:"size-limit"`
+	Host          string           `toml:"host" json:"host"`
+	User          string           `toml:"user" json:"user"`
+	Password      string           `toml:"password" json:"password"`
+	Port          int              `toml:"port" json:"port"`
+	Checkpoint    CheckpointConfig `toml:"checkpoint" json:"checkpoint"`
+	BinlogFileDir string           `toml:"dir" json:"dir"`
+	Compression   string           `toml:"compression" json:"compression"`
+	TimeLimit     string           `toml:"time-limit" json:"time-limit"`
+	SizeLimit     string           `toml:"size-limit" json:"size-limit"`
 
 	KafkaAddrs   string `toml:"kafka-addrs" json:"kafka-addrs"`
 	KafkaVersion string `toml:"kafka-version" json:"kafka-version"`
 	TopicName    string `toml:"topic-name" json:"topic-name"`
 	// get it from pd
 	ClusterID uint64 `toml:"-" json:"-"`
+}
+
+// CheckpointConfig is the Checkpoint configuration.
+type CheckpointConfig struct {
+	Schema string `toml:"schema" json:"schema"`
 }

--- a/drainer/util.go
+++ b/drainer/util.go
@@ -76,8 +76,8 @@ func GenCheckPointCfg(cfg *Config, id uint64) *checkpoint.Config {
 		CheckPointFile:  path.Join(cfg.DataDir, "savepoint"),
 	}
 
-	if cfg.SyncerCfg.To.CheckpointSchema != "" {
-		checkpointCfg.Schema = cfg.SyncerCfg.To.CheckpointSchema
+	if cfg.SyncerCfg.To.Checkpoint.Schema != "" {
+		checkpointCfg.Schema = cfg.SyncerCfg.To.Checkpoint.Schema
 	}
 
 	return checkpointCfg


### PR DESCRIPTION
for some user want to run multi drainer for different DB

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
https://internal.pingcap.net/jira/browse/TOOL-556

### What is changed and how it works?
can config checkpoint-schema name

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 <del>- Integration test
 - Manual test (add detailed scripts or steps below)

Code changes

Side effects


Related changes

