### PR TITLE
syncer: add use-insert config && enable safe-mode first 5 minutes

### DIFF
--- a/cmd/drainer/drainer.toml
+++ b/cmd/drainer/drainer.toml
@@ -38,9 +38,6 @@ disable-dispatch = false
 # safe mode will split update to delete and insert
 safe-mode = false
 
-# if set false, will generate SQL like 'replace into ...' for insert
-use-insert = true
-
 # downstream storage, equal to --dest-db-type
 # valid values are "mysql", "pb", "tidb", "flash", "kafka"
 db-type = "mysql"

--- a/drainer/config.go
+++ b/drainer/config.go
@@ -51,7 +51,6 @@ type SyncerConfig struct {
 	DisableDispatch  bool               `toml:"disable-dispatch" json:"disable-dispatch"`
 	SafeMode         bool               `toml:"safe-mode" json:"safe-mode"`
 	DisableCausality bool               `toml:"disable-detect" json:"disable-detect"`
-	UseInsert        bool               `toml:"use-insert" json:"use-insert"`
 }
 
 // Config holds the configuration of drainer
@@ -108,7 +107,6 @@ func NewConfig() *Config {
 	fs.BoolVar(&cfg.SyncerCfg.DisableDispatch, "disable-dispatch", false, "disable dispatching sqls that in one same binlog; if set true, work-count and txn-batch would be useless")
 	fs.BoolVar(&cfg.SyncerCfg.SafeMode, "safe-mode", false, "enable safe mode to make syncer reentrant")
 	fs.BoolVar(&cfg.SyncerCfg.DisableCausality, "disable-detect", false, "disbale detect causality")
-	fs.BoolVar(&cfg.SyncerCfg.UseInsert, "use-insert", true, "if set false, will generate SQL like 'replace into ...' for insert")
 	fs.IntVar(&maxBinlogItemCount, "cache-binlog-count", defaultBinlogItemCount, "blurry count of binlogs in cache, limit cache size")
 	fs.IntVar(&cfg.SyncedCheckTime, "synced-check-time", defaultSyncedCheckTime, "if we can't dectect new binlog after many minute, we think the all binlog is all synced")
 

--- a/drainer/syncer.go
+++ b/drainer/syncer.go
@@ -131,13 +131,13 @@ func (s *Syncer) checkWait(job *job) bool {
 
 func (s *Syncer) enableSafeModeInitializationPhase() {
 	// set safeMode to true and useInsert to flase at the first, and will use the config after 5 minutes.
-	s.translator.SetConfig(true, false)
+	s.translator.SetConfig(true)
 
 	go func() {
 		ctx, cancel := context.WithCancel(s.ctx)
 		defer func() {
 			cancel()
-			s.translator.SetConfig(s.cfg.SafeMode, s.cfg.UseInsert)
+			s.translator.SetConfig(s.cfg.SafeMode)
 		}()
 
 		select {
@@ -394,7 +394,7 @@ func (s *Syncer) run(jobs []*model.Job) error {
 		return errors.Trace(err)
 	}
 
-	s.translator.SetConfig(s.cfg.SafeMode, s.cfg.UseInsert)
+	s.translator.SetConfig(s.cfg.SafeMode)
 	go s.enableSafeModeInitializationPhase()
 
 	for i := 0; i < s.cfg.WorkerCount; i++ {

--- a/drainer/translator/flash.go
+++ b/drainer/translator/flash.go
@@ -27,7 +27,7 @@ func init() {
 }
 
 // Config set the configuration
-func (f *flashTranslator) SetConfig(bool, bool) {
+func (f *flashTranslator) SetConfig(bool) {
 }
 
 func (f *flashTranslator) GenInsertSQLs(schema string, table *model.TableInfo, rows [][]byte, commitTS int64) ([]string, [][]string, [][]interface{}, error) {

--- a/drainer/translator/kafka.go
+++ b/drainer/translator/kafka.go
@@ -25,7 +25,7 @@ func init() {
 	Register("kafka", &kafkaTranslator{})
 }
 
-func (p *kafkaTranslator) SetConfig(bool, bool) {
+func (p *kafkaTranslator) SetConfig(bool) {
 	// do nothing
 }
 

--- a/drainer/translator/pb.go
+++ b/drainer/translator/pb.go
@@ -26,7 +26,7 @@ func init() {
 	Register("pb", &pbTranslator{})
 }
 
-func (p *pbTranslator) SetConfig(bool, bool) {
+func (p *pbTranslator) SetConfig(bool) {
 	// do nothing
 }
 

--- a/drainer/translator/translator.go
+++ b/drainer/translator/translator.go
@@ -25,7 +25,7 @@ var providers = make(map[string]SQLTranslator)
 // SQLTranslator is the interface for translating TiDB binlog to target sqls
 type SQLTranslator interface {
 	// Config set the configuration
-	SetConfig(safeMode, useInsert bool)
+	SetConfig(safeMode bool)
 
 	// GenInsertSQLs generates the insert sqls
 	GenInsertSQLs(schema string, table *model.TableInfo, rows [][]byte, commitTS int64) ([]string, [][]string, [][]interface{}, error)

--- a/drainer/translator/translator_test.go
+++ b/drainer/translator/translator_test.go
@@ -55,8 +55,8 @@ func (t *testTranslatorSuite) TestTranslater(c *C) {
 	testGenDDLSQL(c, s)
 }
 
-func testGenInsertSQLs(c *C, s SQLTranslator, useInsert bool) {
-	s.SetConfig(false, useInsert)
+func testGenInsertSQLs(c *C, s SQLTranslator, safeMode bool) {
+	s.SetConfig(safeMode)
 	schema := "t"
 	tables := []*model.TableInfo{testGenTable("normal"), testGenTable("hasPK"), testGenTable("hasID")}
 	exceptedKeys := []int{0, 2, 1}
@@ -67,10 +67,10 @@ func testGenInsertSQLs(c *C, s SQLTranslator, useInsert bool) {
 		c.Assert(fmt.Sprintf("%v", keys[0]), Equals, fmt.Sprintf("%v", expectedKeys[:exceptedKeys[i]]))
 		c.Assert(err, IsNil)
 		c.Assert(len(vals[0]), Equals, 3)
-		if useInsert {
-			c.Assert(sqls[0], Equals, "insert into `t`.`account` (`ID`,`NAME`,`SEX`) values (?,?,?);")
-		} else {
+		if safeMode {
 			c.Assert(sqls[0], Equals, "replace into `t`.`account` (`ID`,`NAME`,`SEX`) values (?,?,?);")
+		} else {
+			c.Assert(sqls[0], Equals, "insert into `t`.`account` (`ID`,`NAME`,`SEX`) values (?,?,?);")
 		}
 		for index := range vals[0] {
 			c.Assert(vals[0][index], DeepEquals, expected[index])


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
1. some table don't have pk/uk, execute replace sql will be slow, we need add a config to set use `insert` or `replace`
issue: 
https://internal.pingcap.net/jira/browse/TOOL-574
https://internal.pingcap.net/jira/browse/TOOL-555

2. enable safe mode the first 5 minutes
issue: https://internal.pingcap.net/jira/browse/TOOL-558

 
### What is changed and how it works?
1. add a config `use-insert`, if set true, will generate sql like `insert into ...` for insert.
2. enable safe mode the first 5 minutes, just like syncer.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test
 set use-insert to true

Related changes

 - Need to update the documentation
 - Need to be included in the release note