### PR TITLE
pump exit with code 2 when meet error

### DIFF
--- a/cmd/pump/main.go
+++ b/cmd/pump/main.go
@@ -57,7 +57,7 @@ func main() {
 	if err := p.Start(); err != nil {
 		log.Errorf("pump server error, %v", err)
 		// exit when start fail
-		return
+		os.Exit(2)
 	}
 
 	wg.Wait()


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
jira issue: https://internal.pingcap.net/jira/browse/TOOL-413


### What is changed and how it works?
return exit code 2 when meet errors, and we can set `Restart=on-failure` for systemd, and pump/drainer will not be restart again when use binlogctl to pause/offline them.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Manual test