### PR TITLE
TOOL-638: Fix lost long-live connection to CH (cherry-picking to release-2.1)

### DIFF
--- a/drainer/checkpoint/flash.go
+++ b/drainer/checkpoint/flash.go
@@ -62,7 +62,7 @@ func newFlash(cfg *Config) (CheckPoint, error) {
 		return nil, errors.Trace(err)
 	}
 
-	db, err := pkgsql.OpenCH(hostAndPorts[0].Host, hostAndPorts[0].Port, cfg.Db.User, cfg.Db.Password, "")
+	db, err := pkgsql.OpenCH(hostAndPorts[0].Host, hostAndPorts[0].Port, cfg.Db.User, cfg.Db.Password, "", 0)
 	if err != nil {
 		log.Errorf("open database error %v", err)
 		return nil, errors.Trace(err)

--- a/pkg/sql/sql.go
+++ b/pkg/sql/sql.go
@@ -17,7 +17,6 @@ import (
 	"github.com/pingcap/tidb/infoschema"
 	tmysql "github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/terror"
-	"github.com/zanmato1984/clickhouse"
 )
 
 var (
@@ -246,7 +245,7 @@ func ParseCHAddr(addr string) ([]CHHostAndPort, error) {
 	return result, nil
 }
 
-func composeCHDSN(host string, port int, username string, password string, dbName string) string {
+func composeCHDSN(host string, port int, username string, password string, dbName string, blockSize int) string {
 	dbDSN := fmt.Sprintf("tcp://%s:%d?", host, port)
 	if len(username) > 0 {
 		dbDSN = fmt.Sprintf("%susername=%s&", dbDSN, username)
@@ -257,12 +256,15 @@ func composeCHDSN(host string, port int, username string, password string, dbNam
 	if len(dbName) > 0 {
 		dbDSN = fmt.Sprintf("%sdatabase=%s&", dbDSN, dbName)
 	}
+	if blockSize > 0 {
+		dbDSN = fmt.Sprintf("%sblock_size=%d&", dbDSN, blockSize)
+	}
 	return dbDSN
 }
 
 // OpenCH opens a connection to CH and returns the standard SQL driver's DB interface.
-func OpenCH(host string, port int, username string, password string, dbName string) (*sql.DB, error) {
-	dbDSN := composeCHDSN(host, port, username, password, dbName)
+func OpenCH(host string, port int, username string, password string, dbName string, blockSize int) (*sql.DB, error) {
+	dbDSN := composeCHDSN(host, port, username, password, dbName, blockSize)
 	log.Infof("Connecting to %s", dbDSN)
 	db, err := sql.Open("clickhouse", dbDSN)
 	if err != nil {
@@ -270,11 +272,4 @@ func OpenCH(host string, port int, username string, password string, dbName stri
 	}
 
 	return db, nil
-}
-
-// OpenCHDirect opens a connection to CH and returns the raw CH driver's connection interface.
-// It is mainly used for batch inserting which uses CH's block interface.
-func OpenCHDirect(host string, port int, username string, password string, dbName string) (clickhouse.Clickhouse, error) {
-	dbDSN := composeCHDSN(host, port, username, password, dbName)
-	return clickhouse.OpenDirect(dbDSN)
 }


### PR DESCRIPTION
…er) (#403)

* Use ch driver's own block

* Minor fix

* Fix fmt

* Use direct sql.DB instead of wrapping chDB

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->


### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note