### PR TITLE
syncer.go: don't add row_id column to table info (#422)

### DIFF
--- a/drainer/syncer.go
+++ b/drainer/syncer.go
@@ -416,7 +416,7 @@ func (s *Syncer) run(jobs []*model.Job) error {
 			log.Debug("get ddl binlog job: ", string(data))
 		}
 	}
-	s.schema, err = NewSchema(jobs, s.cfg.DestDBType == "tidb")
+	s.schema, err = NewSchema(jobs, false)
 
 	s.executors, err = createExecutors(s.cfg.DestDBType, s.cfg.To, s.cfg.WorkerCount)
 	if err != nil {


### PR DESCRIPTION


<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
this make it don't use _tidb_rowid column when dest-type = tidb

### What is changed and how it works?
git cherry-pick

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test