### PR TITLE
drainer/* Improve  performance of dest-type=kafka (#423)

### DIFF
--- a/drainer/executor/bench_kafka_test.go
+++ b/drainer/executor/bench_kafka_test.go
@@ -8,6 +8,48 @@ import (
 	obinlog "github.com/pingcap/tidb-tools/tidb-binlog/slave_binlog_proto/go-binlog"
 )
 
+var bytes = make([]byte, 5*(1<<10))
+var table = &obinlog.Table{
+	SchemaName: proto.String("test"),
+	TableName:  proto.String("test"),
+	ColumnInfo: []*obinlog.ColumnInfo{
+		&obinlog.ColumnInfo{Name: "id", MysqlType: "int"},
+		&obinlog.ColumnInfo{Name: "a1", MysqlType: "blob"},
+	},
+	Mutations: []*obinlog.TableMutation{
+		&obinlog.TableMutation{
+			Type: obinlog.MutationType_Insert.Enum(),
+			Row: &obinlog.Row{
+				Columns: []*obinlog.Column{
+					&obinlog.Column{
+						Int64Value: proto.Int64(1),
+					},
+					&obinlog.Column{
+						BytesValue: bytes,
+					},
+				},
+			},
+		},
+	},
+}
+
+// with bytes = 5KB
+// BenchmarkBinlogMarshal-4          100000            573941 ns/op
+// means only 1742 op/second
+func BenchmarkBinlogMarshal(b *testing.B) {
+	binlog := &obinlog.Binlog{
+		DmlData: &obinlog.DMLData{
+			Tables: []*obinlog.Table{table},
+		},
+	}
+	for i := 0; i < b.N; i++ {
+		binlog.String()
+	}
+}
+
+// with bytes = 5KB
+// BenchmarkKafka-4         1000000             42384 ns/op
+// means 23593 op/second
 func BenchmarkKafka(b *testing.B) {
 	log.SetLevelByString("error")
 
@@ -20,31 +62,6 @@ func BenchmarkKafka(b *testing.B) {
 	executor, err := newKafka(cfg)
 	if err != nil {
 		b.Fatal(err)
-	}
-
-	bytes := make([]byte, 128)
-	table := &obinlog.Table{
-		SchemaName: proto.String("test"),
-		TableName:  proto.String("test"),
-		ColumnInfo: []*obinlog.ColumnInfo{
-			{Name: "id", MysqlType: "int"},
-			{Name: "a1", MysqlType: "blob"},
-		},
-		Mutations: []*obinlog.TableMutation{
-			{
-				Type: obinlog.MutationType_Insert.Enum(),
-				Row: &obinlog.Row{
-					Columns: []*obinlog.Column{
-						{
-							Int64Value: proto.Int64(1),
-						},
-						{
-							BytesValue: bytes,
-						},
-					},
-				},
-			},
-		},
 	}
 
 	b.ResetTimer()

--- a/drainer/executor/kafka.go
+++ b/drainer/executor/kafka.go
@@ -139,7 +139,7 @@ func (p *kafkaExecutor) Close() error {
 }
 
 func (p *kafkaExecutor) saveBinlog(binlog *obinlog.Binlog) error {
-	log.Debug("save binlog: ", binlog.String())
+	// log.Debug("save binlog: ", binlog.String())
 	data, err := binlog.Marshal()
 	if err != nil {
 		return errors.Trace(err)

--- a/drainer/translator/kafka.go
+++ b/drainer/translator/kafka.go
@@ -148,7 +148,7 @@ func insertRowToRow(tableInfo *model.TableInfo, raw []byte) (row *obinlog.Row, e
 		return
 	}
 
-	log.Debugf("decodeRow: %+v\n", columnValues)
+	// log.Debugf("decodeRow: %+v\n", columnValues)
 	// maybe only the pk column value
 	if columnValues == nil {
 		columnValues = make(map[int64]types.Datum)


### PR DESCRIPTION


<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
note binlog.String() may be pretty slow
only 1k+ op/second of the benchmark

### What is changed and how it works?
git cherry-pick

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Integration test
 