### PR TITLE
drainer/* Fix not skip rollback state ddl job

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,7 @@ integration_test: build
 	@which bin/pd-server
 	@which bin/drainer
 	@which bin/pump
+	@which bin/binlogctl
 	@which bin/reparo
 	tests/run.sh
 

--- a/reparo/translator/mysql_test.go
+++ b/reparo/translator/mysql_test.go
@@ -22,11 +22,12 @@ func (s *testTranslatorSuite) TestGenWhere(c *C) {
 	}{
 		{[]string{"a"}, []interface{}{""}, "`a` = ?"},
 		{[]string{"a", "b"}, []interface{}{"", ""}, "`a` = ? AND `b` = ?"},
-		{[]string{"a", "b"}, []interface{}{nil, ""}, "`a` IS ? AND `b` = ?"},
+		{[]string{"a", "b"}, []interface{}{nil, ""}, "`a` IS NULL AND `b` = ?"},
 	}
 
 	for _, t := range cases {
-		where := genWhere(t.cols, t.args)
+		where, args := genWhere(t.cols, t.args)
+		t.args = args
 		c.Assert(where, Equals, t.where)
 	}
 }

--- a/tests/README.md
+++ b/tests/README.md
@@ -9,6 +9,7 @@ This folder contains all tests which relies on external service such as TiDB.
    - `bin/pd-server`
    - `bin/tikv-server`
    - `bin/tidb-server`
+   - `bin/binlogctl`
 
 2. The following programs must be installed:
 

--- a/tests/reparo/reparo.toml
+++ b/tests/reparo/reparo.toml
@@ -1,5 +1,5 @@
 # drainer 输出的 protobuf 格式 binlog 文件的存储路径
-data-dir = "data.drainer"
+data-dir = "/tmp/tidb_binlog_test/data.drainer"
 
 # log-file = ""
 # log-rotate = "hour"

--- a/tests/status/drainer.toml
+++ b/tests/status/drainer.toml
@@ -8,7 +8,7 @@
 detect-interval = 10
 
 # drainer meta data directory path
-data-dir = "/tmp/tidb_binlog_test/data.drainer"
+data-dir = "data.drainer"
 
 # a comma separated list of PD endpoints
 pd-urls = "http://127.0.0.1:2379"
@@ -37,5 +37,3 @@ db-type = "pb"
 #[syncer.to]
 #dir = "/data/data.drainer"
 #compression = "gzip"
-
-

--- a/tests/status/run.sh
+++ b/tests/status/run.sh
@@ -1,0 +1,95 @@
+#!/bin/sh
+
+ set -e
+
+ cd "$(dirname "$0")"
+
+statusLog="status.log"
+
+# run drainer, and drainer's status should be online
+run_drainer &
+sleep 3
+binlogctl -pd-urls 127.0.0.1:2379 -cmd drainers > $statusLog 2>&1
+cat $statusLog
+count=`grep -c "online" $statusLog`
+if [ $count -ne 1 ]; then
+     echo "drainer is not online"
+    exit 2
+fi
+
+drainerNodeID=`cat $statusLog | sed 's/.*NodeID:\([a-zA-Z0-9\-]*:[0-9]*\) .*/\1/g'`
+
+# pump's state should be online
+binlogctl -pd-urls 127.0.0.1:2379 -cmd pumps > $statusLog 2>&1
+cat $statusLog
+count=`grep -c "online" $statusLog`
+if [ $count -ne 1 ]; then
+     echo "pump is not online"
+    exit 2
+fi
+
+# stop pump, and pump's state should be paused
+binlogctl -pd-urls 127.0.0.1:2379 -cmd pause-pump -node-id pump1:8215
+sleep 3
+binlogctl -pd-urls 127.0.0.1:2379 -cmd pumps > $statusLog 2>&1
+cat $statusLog
+count=`grep -c "paused" $statusLog`
+if [ $count -ne 1 ]; then
+    echo "pump is not paused"
+    exit 2
+fi
+
+# offline pump, and pump's status should be offline
+run_pump &
+sleep 3
+binlogctl -pd-urls 127.0.0.1:2379 -cmd offline-pump -node-id pump1:8215
+sleep 10
+binlogctl -pd-urls 127.0.0.1:2379 -cmd pumps > $statusLog 2>&1
+cat $statusLog
+count=`grep -c "offline" $statusLog`
+if [ $count -ne 1 ]; then
+    echo "pump is not offline"
+    exit 2
+fi
+
+# stop drainer, and drainer's state should be paused
+binlogctl -pd-urls 127.0.0.1:2379 -cmd pause-drainer -node-id $drainerNodeID
+sleep 3
+binlogctl -pd-urls 127.0.0.1:2379 -cmd drainers > $statusLog 2>&1
+cat $statusLog
+count=`grep -c "paused" $statusLog`
+if [ $count -ne 1 ]; then
+    echo "drainer is not paused"
+    exit 2
+fi
+
+# offline drainer, and drainer's state should be offline
+run_drainer &
+sleep 3
+binlogctl -pd-urls 127.0.0.1:2379 -cmd offline-drainer -node-id $drainerNodeID
+sleep 10
+binlogctl -pd-urls 127.0.0.1:2379 -cmd drainers > $statusLog 2>&1
+cat $statusLog
+count=`grep -c "offline" $statusLog`
+if [ $count -ne 1 ]; then
+    echo "drainer is not offline"
+    exit 2
+fi
+
+# update drainer's state to online, and then run pump, pump will notify drainer failed, pump's sttaus will be paused
+binlogctl -pd-urls 127.0.0.1:2379 -cmd update-drainer -node-id $drainerNodeID -state online
+run_pump &
+sleep 3
+
+binlogctl -pd-urls 127.0.0.1:2379 -cmd pumps > $statusLog 2>&1
+cat $statusLog
+count=`grep -c "paused" $statusLog`
+if [ $count -ne 1 ]; then
+    echo "pump is not paused"
+    exit 2
+fi
+
+# clean up
+binlogctl -pd-urls 127.0.0.1:2379 -cmd update-drainer -node-id $drainerNodeID -state paused
+run_pump &
+rm $statusLog || true


### PR DESCRIPTION
Only when reach this two state will write binlog: model.JobStateSynced model.JobStateRollbackDone
but we only skip job when job.State is model.JobStateCancelled

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
see https://internal.pingcap.net/jira/browse/TOOL-763

### What is changed and how it works?
skip when job.State != model.JobStateSynced
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test
Code changes

Side effects

Related changes

 - Need to cherry-pick to kafka branch