### PR TITLE
drainer: support generated columns from INSERT statements

### DIFF
--- a/drainer/translator/translator_test.go
+++ b/drainer/translator/translator_test.go
@@ -307,7 +307,7 @@ func testGenDatum(c *C, col *model.ColumnInfo, base int) (types.Datum, interface
 // hasPK:  create table t(id int, name varchar(45), sex enum("male", "female"), PRIMARY KEY(id, name));
 // normal: create table t(id int, name varchar(45), sex enum("male", "female"));
 func testGenTable(tt string) *model.TableInfo {
-	t := &model.TableInfo{}
+	t := &model.TableInfo{State: model.StatePublic}
 	t.Name = model.NewCIStr("account")
 
 	// the hard values are from TiDB :-), so just ingore them
@@ -323,6 +323,7 @@ func testGenTable(tt string) *model.TableInfo {
 			Charset: "binary",
 			Collate: "binary",
 		},
+		State: model.StatePublic,
 	}
 
 	userNameCol := &model.ColumnInfo{
@@ -337,6 +338,7 @@ func testGenTable(tt string) *model.TableInfo {
 			Charset: "utf8",
 			Collate: "utf8_unicode_ci",
 		},
+		State: model.StatePublic,
 	}
 
 	sexCol := &model.ColumnInfo{
@@ -352,6 +354,7 @@ func testGenTable(tt string) *model.TableInfo {
 			Collate: "binary",
 			Elems:   []string{"male", "female"},
 		},
+		State: model.StatePublic,
 	}
 
 	t.Columns = []*model.ColumnInfo{userIDCol, userNameCol, sexCol}

--- a/tests/gencol/drainer.toml
+++ b/tests/gencol/drainer.toml
@@ -1,0 +1,18 @@
+detect-interval = 10
+data-dir = '/tmp/tidb_binlog_test/data.drainer'
+pd-urls = 'http://127.0.0.1:2379'
+
+[syncer]
+ignore-schemas = 'INFORMATION_SCHEMA,PERFORMANCE_SCHEMA,mysql'
+txn-batch = 1
+worker-count = 1
+disable-dispatch = false
+safe-mode = false
+db-type = 'mysql'
+replicate-do-db = ['gencol']
+
+[syncer.to]
+host = '127.0.0.1'
+user = 'root'
+password = ''
+port = 3306

--- a/tests/gencol/run.sh
+++ b/tests/gencol/run.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+
+set -e
+
+cd "$(dirname "$0")"
+
+run_drainer &
+
+run_sql 'DROP TABLE IF EXISTS gencol.gct;'
+run_sql 'DROP DATABASE IF EXISTS gencol;'
+run_sql 'CREATE DATABASE gencol;'
+run_sql 'CREATE TABLE gencol.gct(a INT PRIMARY KEY, b INT GENERATED ALWAYS AS (a*a) VIRTUAL, c INT);'
+
+# Verify INSERT statements works with generated columns...
+
+run_sql 'INSERT INTO gencol.gct (a, c) VALUES (1, 10), (2, 12), (3, 32);'
+
+sleep 3
+
+down_run_sql 'SELECT count(*), sum(a), sum(b), sum(c) FROM gencol.gct;'
+check_contains 'count(*): 3'
+check_contains 'sum(a): 6'
+check_contains 'sum(b): 14'
+check_contains 'sum(c): 54'
+
+# Verify UPDATE statements works with generated columns...
+
+run_sql 'UPDATE gencol.gct SET a = 7, c = 8 WHERE b = 1;'
+
+sleep 3
+
+down_run_sql 'SELECT count(*), sum(a), sum(b), sum(c) FROM gencol.gct;'
+check_contains 'count(*): 3'
+check_contains 'sum(a): 12'
+check_contains 'sum(b): 62'
+check_contains 'sum(c): 52'
+
+# Verify DELETE statements works with generated columns...
+
+run_sql 'DELETE FROM gencol.gct WHERE b = 9;'
+
+sleep 3
+
+down_run_sql 'SELECT count(*), sum(a), sum(b), sum(c) FROM gencol.gct;'
+check_contains 'count(*): 2'
+check_contains 'sum(a): 9'
+check_contains 'sum(b): 53'
+check_contains 'sum(c): 20'
+
+killall drainer


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

[TOOL-955](https://internal.pingcap.net/jira/browse/TOOL-955)

### What is changed and how it works?

In the `mysql` translator, when generating the INSERT statements, ignore columns which are generated. 

Note: other translators (`flash`, `pb`, `kafka`) are not changed. Please confirm if we need to change other translators too.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Code changes

Side effects

Related changes
