### PR TITLE
Simplify and refine a little code

### DIFF
--- a/cmd/arbiter/main.go
+++ b/cmd/arbiter/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/pingcap/tidb-binlog/pkg/util"
 	"github.com/pingcap/tidb-binlog/pkg/version"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 func main() {
@@ -53,7 +54,7 @@ func main() {
 
 func startHTTPServer(addr string) {
 	prometheus.DefaultGatherer = arbiter.Registry
-	http.Handle("/metrics", prometheus.Handler())
+	http.Handle("/metrics", promhttp.Handler())
 
 	err := http.ListenAndServe(addr, nil)
 	if err != nil {

--- a/cmd/pump/main.go
+++ b/cmd/pump/main.go
@@ -37,7 +37,6 @@ func main() {
 
 	sc := make(chan os.Signal, 1)
 	signal.Notify(sc,
-		syscall.SIGKILL,
 		syscall.SIGHUP,
 		syscall.SIGINT,
 		syscall.SIGTERM,

--- a/drainer/server.go
+++ b/drainer/server.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pingcap/tidb/store/tikv/oracle"
 	"github.com/pingcap/tipb/go-binlog"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/soheilhy/cmux"
 	"github.com/unrolled/render"
 	"golang.org/x/net/context"
@@ -335,7 +336,7 @@ func (s *Server) Start() error {
 	router.HandleFunc("/state/{nodeID}/{action}", s.ApplyAction).Methods("PUT")
 	http.Handle("/", router)
 	prometheus.DefaultGatherer = registry
-	http.Handle("/metrics", prometheus.Handler())
+	http.Handle("/metrics", promhttp.Handler())
 
 	go http.Serve(httpL, nil)
 

--- a/drainer/syncer.go
+++ b/drainer/syncer.go
@@ -45,8 +45,7 @@ type Syncer struct {
 
 	executors []executor.Executor
 
-	positions    map[string]int64
-	initCommitTS int64
+	positions map[string]int64
 
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -66,7 +65,6 @@ func NewSyncer(ctx context.Context, cp checkpoint.CheckPoint, cfg *SyncerConfig)
 	syncer.input = make(chan *binlogItem, maxBinlogItemCount)
 	syncer.jobCh = newJobChans(cfg.WorkerCount)
 	syncer.ctx, syncer.cancel = context.WithCancel(ctx)
-	syncer.initCommitTS = cp.TS()
 	syncer.positions = make(map[string]int64)
 	syncer.causality = loader.NewCausality()
 	syncer.lastSyncTime = time.Now()

--- a/drainer/translator/flash.go
+++ b/drainer/translator/flash.go
@@ -196,22 +196,17 @@ func (f *flashTranslator) GenDDLSQL(sql string, schema string, commitTS int64) (
 		return "", errors.Trace(err)
 	}
 
-	switch stmt.(type) {
+	switch stmt := stmt.(type) {
 	case *ast.CreateDatabaseStmt:
-		createDatabaseStmt, _ := stmt.(*ast.CreateDatabaseStmt)
-		return extractCreateDatabase(createDatabaseStmt)
+		return extractCreateDatabase(stmt)
 	case *ast.DropDatabaseStmt:
-		dropDatabaseStmt, _ := stmt.(*ast.DropDatabaseStmt)
-		return extractDropDatabase(dropDatabaseStmt)
+		return extractDropDatabase(stmt)
 	case *ast.DropTableStmt:
-		dropTableStmt, _ := stmt.(*ast.DropTableStmt)
-		return extractDropTable(dropTableStmt, schema)
+		return extractDropTable(stmt, schema)
 	case *ast.CreateTableStmt:
-		createTableStmt, _ := stmt.(*ast.CreateTableStmt)
-		return extractCreateTable(createTableStmt, schema)
+		return extractCreateTable(stmt, schema)
 	case *ast.AlterTableStmt:
-		alterTableStmt, _ := stmt.(*ast.AlterTableStmt)
-		alterSQL, err := extractAlterTable(alterTableStmt, schema)
+		alterSQL, err := extractAlterTable(stmt, schema)
 		if err != nil {
 			return alterSQL, err
 		}
@@ -220,11 +215,9 @@ func (f *flashTranslator) GenDDLSQL(sql string, schema string, commitTS int64) (
 		}
 		return alterSQL, nil
 	case *ast.RenameTableStmt:
-		renameTableStmt, _ := stmt.(*ast.RenameTableStmt)
-		return extractRenameTable(renameTableStmt, schema)
+		return extractRenameTable(stmt, schema)
 	case *ast.TruncateTableStmt:
-		truncateTableStmt, _ := stmt.(*ast.TruncateTableStmt)
-		return extractTruncateTable(truncateTableStmt, schema), nil
+		return extractTruncateTable(stmt, schema), nil
 	default:
 		// TODO: hacking around empty sql, should bypass in upper level
 		return genEmptySQL(sql), nil

--- a/pump/server.go
+++ b/pump/server.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pingcap/tipb/go-binlog"
 	pb "github.com/pingcap/tipb/go-binlog"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/soheilhy/cmux"
 	"github.com/unrolled/render"
 	"golang.org/x/net/context"
@@ -394,7 +395,7 @@ func (s *Server) Start() error {
 	router.HandleFunc("/debug/binlog/{ts}", s.BinlogByTS).Methods("GET")
 	http.Handle("/", router)
 	prometheus.DefaultGatherer = registry
-	http.Handle("/metrics", prometheus.Handler())
+	http.Handle("/metrics", promhttp.Handler())
 
 	go http.Serve(httpL, nil)
 


### PR DESCRIPTION


<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Simplify and refine code

### What is changed and how it works?
- drainer/translator/flash.go:199:9: S1034: assigning the result of this
type assertion to a variable (switch stmt := stmt.(type)) could
eliminate the following type assertions:
- syscall.SIGKILL can't be captured
- prometheus.Handler is deprecated: Please note the issues described in
the doc comment of InstrumentHandler. You might want to consider using
promhttp.Handler instead (which is non instrumented)

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test


Code changes



Side effects

Related changes

