### PR TITLE
drainer,pump: Add support for enabling gzip grpc compression

### DIFF
--- a/cmd/drainer/drainer.toml
+++ b/cmd/drainer/drainer.toml
@@ -13,6 +13,9 @@ data-dir = "data.drainer"
 # a comma separated list of PD endpoints
 pd-urls = "http://127.0.0.1:2379"
 
+# Use the specified compressor to compress payload between pump and drainer
+compressor = ""
+
 #[security]
 # Path of file that contains list of trusted SSL CAs for connection with cluster components.
 # ssl-ca = "/path/to/ca.pem"

--- a/drainer/config.go
+++ b/drainer/config.go
@@ -38,6 +38,7 @@ const (
 var (
 	maxBinlogItemCount     int
 	defaultBinlogItemCount = 16 << 12
+	supportedCompressors   = [...]string{"gzip"}
 )
 
 // SyncerConfig is the Syncer's configuration.
@@ -68,6 +69,7 @@ type Config struct {
 	SyncerCfg       *SyncerConfig   `toml:"syncer" json:"sycner"`
 	Security        security.Config `toml:"security" json:"security"`
 	SyncedCheckTime int             `toml:"synced-check-time" json:"synced-check-time"`
+	Compressor      string          `toml:"compressor" json:"compressor"`
 	EtcdTimeout     time.Duration
 	MetricsAddr     string
 	MetricsInterval int
@@ -101,6 +103,7 @@ func NewConfig() *Config {
 	fs.StringVar(&cfg.LogFile, "log-file", "", "log file path")
 	fs.StringVar(&cfg.LogRotate, "log-rotate", "", "log file rotate type, hour/day")
 	fs.Int64Var(&cfg.InitialCommitTS, "initial-commit-ts", 0, "if drainer donesn't have checkpoint, use initial commitTS to initial checkpoint")
+	fs.StringVar(&cfg.Compressor, "compressor", "", "use the specified compressor to compress payload between pump and drainer, only 'gzip' is supported now (default \"\", ie. compression disabled.)")
 	fs.IntVar(&cfg.SyncerCfg.TxnBatch, "txn-batch", 20, "number of binlog events in a transaction batch")
 	fs.StringVar(&cfg.SyncerCfg.IgnoreSchemas, "ignore-schemas", "INFORMATION_SCHEMA,PERFORMANCE_SCHEMA,mysql", "disable sync those schemas")
 	fs.IntVar(&cfg.SyncerCfg.WorkerCount, "c", 16, "parallel worker count")
@@ -230,6 +233,20 @@ func (cfg *Config) validate() error {
 	for _, u := range urlv.URLSlice() {
 		if _, _, err := net.SplitHostPort(u.Host); err != nil {
 			return errors.Errorf("bad EtcdURL host format: %s, %v", u.Host, err)
+		}
+	}
+
+	if cfg.Compressor != "" {
+		found := false
+		for _, c := range supportedCompressors {
+			if cfg.Compressor == c {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return errors.Errorf(
+				"Invalid compressor: %v, must be one of these: %v", cfg.Compressor, supportedCompressors)
 		}
 	}
 

--- a/drainer/server.go
+++ b/drainer/server.go
@@ -35,6 +35,8 @@ var (
 	clusterID         uint64
 )
 
+type drainerKeyType string
+
 // Server implements the gRPC interface,
 // and maintains the runtime status
 type Server struct {
@@ -83,6 +85,8 @@ func NewServer(cfg *Config) (*Server, error) {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
+	ctx = context.WithValue(ctx, drainerKeyType("compressor"), cfg.Compressor)
+
 	clusterID = pdCli.GetClusterID(ctx)
 	// update latestTS and latestTime
 	latestTS, err := util.GetTSO(pdCli)

--- a/pump/server.go
+++ b/pump/server.go
@@ -16,7 +16,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/ngaut/log"
 	"github.com/pingcap/errors"
-	"github.com/pingcap/pd/client"
+	pd "github.com/pingcap/pd/client"
 	"github.com/pingcap/tidb-binlog/pkg/flags"
 	"github.com/pingcap/tidb-binlog/pkg/node"
 	"github.com/pingcap/tidb-binlog/pkg/util"
@@ -33,6 +33,7 @@ import (
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	_ "google.golang.org/grpc/encoding/gzip"
 )
 
 var notifyDrainerTimeout = time.Second * 10


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Add support for enabling gzip compression of payloads between Pump and Drainer [Issue](https://internal.pingcap.net/jira/browse/TOOL-1004)


### What is changed and how it works?

A new flag `compressor` is added, which can be `"gzip"` or `""` (compressor disabled).
The value is `""` by default, so original users won't get compression turned on by accident after upgrading to a version that include this change.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test
 - Manual test
    1. `stats.Handler` is used to verify that the payload is indeed compressed
    1. When compressor is used and the register of gzip is commented out on the server side, the requests are observed to be rejected.

Code changes

Side effects

Related changes