### PR TITLE
drainer: Consume pending binlogs from removed sources to avoid loss of data

### DIFF
--- a/drainer/collector.go
+++ b/drainer/collector.go
@@ -262,8 +262,8 @@ func (c *Collector) updatePumpStatus(ctx context.Context) error {
 			case node.Offline:
 				// before pump change status to offline, it needs to check all the binlog save in this pump had already been consumed in drainer.
 				// so when the pump is offline, we can remove this pump directly.
-				c.merger.RemoveSource(n.NodeID)
 				c.pumps[n.NodeID].Close()
+				c.merger.RemoveSource(n.NodeID)
 				delete(c.pumps, n.NodeID)
 				log.Infof("node(%s) of cluster(%d) has been removed and release the connection to it",
 					p.nodeID, p.clusterID)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Avoid the loss of pending binlogs of an removed source.

### What is changed and how it works?

When a source is removed, `RemoveSource` would exhaust the channel and push its pending binlogs with `strategy`.

Let `N` be the number of sources.
Before this change, the `strategy` may contain at most `N` items;
After this change, the `strategy` may contain `N` + `binlogChanSize` items.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

Side effects

Related changes
