### PR TITLE
pump: Inline checkFileExist to differentiate NotFound and other error

### DIFF
--- a/pump/node.go
+++ b/pump/node.go
@@ -209,8 +209,13 @@ func (p *pumpNode) Quit() error {
 // in this case, the caller should invoke generateLocalNodeID()
 func readLocalNodeID(dataDir string) (string, error) {
 	nodeIDPath := filepath.Join(dataDir, nodeIDFile)
-	if _, err := CheckFileExist(nodeIDPath); err != nil {
-		return "", errors.NotFoundf("local nodeID file not exist: %v", err)
+	if fi, err := os.Stat(nodeIDPath); err != nil {
+		if os.IsNotExist(err) {
+			return "", errors.NotFoundf("Local nodeID file not exist: %v", err)
+		}
+		return "", err
+	} else if fi.IsDir() {
+		return "", errors.Errorf("Local nodeID path is a directory: %s", dataDir)
 	}
 	data, err := ioutil.ReadFile(nodeIDPath)
 	if err != nil {

--- a/pump/util.go
+++ b/pump/util.go
@@ -3,11 +3,9 @@ package pump
 import (
 	"fmt"
 	"math/rand"
-	"os"
 	"strings"
 	"sync/atomic"
 
-	"github.com/pingcap/errors"
 	bf "github.com/pingcap/tidb-binlog/pkg/binlogfile"
 )
 
@@ -42,18 +40,6 @@ func KRand(size int, kind int) []byte {
 	return result
 }
 
-// CheckFileExist chekcs the file exist status and wether it is a file
-func CheckFileExist(filepath string) (string, error) {
-	fi, err := os.Stat(filepath)
-	if err != nil {
-		return "", errors.Trace(err)
-	}
-	if fi.IsDir() {
-		return "", errors.Errorf("filepath: %s, is a directory, not a file", filepath)
-	}
-	return filepath, nil
-}
-
 // Exist checks the dir exist, that it should have some file
 func Exist(dirpath string) bool {
 	names, err := bf.ReadDir(dirpath)
@@ -66,7 +52,7 @@ func Exist(dirpath string) bool {
 
 // TopicName returns topic name
 func TopicName(clusterID string, nodeID string) string {
-	// ":" is not valide in kafka topic name
+	// ":" is not a valid kafka topic name
 	topicName := fmt.Sprintf("%s_%s", clusterID, strings.Replace(nodeID, ":", "_", -1))
 	return topicName
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

When `os.Stat` returns an error, it may not be `IsNotExist`, in that case we don't log `"Local nodeID file not exist"` because it would be misleading.

### What is changed and how it works?

Check for existence of the file directly in `readLocalNodeID`, which is the only place calling `checkFileExist`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

Side effects

Related changes
