### PR TITLE
pkg/loader: Ignore generated columns to avoid inserting them

### DIFF
--- a/drainer/translator/kafka.go
+++ b/drainer/translator/kafka.go
@@ -176,7 +176,8 @@ func deleteRowToRow(tableInfo *model.TableInfo, raw []byte) (row *obinlog.Row, e
 }
 
 func updateRowToRow(tableInfo *model.TableInfo, raw []byte) (row *obinlog.Row, changedRow *obinlog.Row, err error) {
-	colsTypeMap := util.ToColumnTypeMap(tableInfo.Columns)
+	columns := writableColumns(tableInfo)
+	colsTypeMap := util.ToColumnTypeMap(columns)
 	oldDatums, newDatums, err := DecodeOldAndNewRow(raw, colsTypeMap, time.Local)
 	if err != nil {
 		return

--- a/pkg/loader/load.go
+++ b/pkg/loader/load.go
@@ -330,6 +330,14 @@ func (s *Loader) execDMLs(dmls []*DML) error {
 		if err != nil {
 			return errors.Trace(err)
 		}
+		if len(dml.Values) > len(dml.info.columns) {
+			// Remove values of generated columns
+			vals := make(map[string]interface{}, len(dml.info.columns))
+			for _, col := range dml.info.columns {
+				vals[col] = dml.Values[col]
+			}
+			dml.Values = vals
+		}
 	}
 
 	tables := groupByTable(dmls)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Bugfix: Ignore generated columns to avoid inserting them, which would cause error

### What is changed and how it works?

1. Generated columns are ignored in `getTableInfo`
1. Select from the table `information_schema.columns` instead of `show columns` to simplify the query

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

Side effects

Related changes