### PR TITLE
*: Add sql-mode config for drainer (#511)

### DIFF
--- a/cmd/drainer/drainer.toml
+++ b/cmd/drainer/drainer.toml
@@ -24,6 +24,11 @@ pd-urls = "http://127.0.0.1:2379"
 # syncer Configuration.
 [syncer]
 
+# Assume the upstream sql-mode.
+# If this is setted , will use the same sql-mode to parse DDL statment, and set the same sql-mode at downstream when db-type is mysql.
+# If this is not setted, it will not set any sql-mode.
+# sql-mode = "STRICT_TRANS_TABLES,NO_ENGINE_SUBSTITUTION"
+
 # disable sync these schema
 ignore-schemas = "INFORMATION_SCHEMA,PERFORMANCE_SCHEMA,mysql"
 

--- a/drainer/config.go
+++ b/drainer/config.go
@@ -15,6 +15,8 @@ import (
 	"github.com/BurntSushi/toml"
 	"github.com/ngaut/log"
 	"github.com/pingcap/errors"
+	"github.com/pingcap/parser/mysql"
+
 	"github.com/pingcap/tidb-binlog/drainer/executor"
 	"github.com/pingcap/tidb-binlog/pkg/filter"
 	"github.com/pingcap/tidb-binlog/pkg/flags"
@@ -42,6 +44,8 @@ var (
 
 // SyncerConfig is the Syncer's configuration.
 type SyncerConfig struct {
+	StrSQLMode       *string            `toml:"sql-mode" json:"sql-mode"`
+	SQLMode          mysql.SQLMode      `toml:"-" json:"-"`
 	IgnoreSchemas    string             `toml:"ignore-schemas" json:"ignore-schemas"`
 	TxnBatch         int                `toml:"txn-batch" json:"txn-batch"`
 	WorkerCount      int                `toml:"worker-count" json:"worker-count"`
@@ -81,7 +85,7 @@ func NewConfig() *Config {
 
 	cfg := &Config{
 		EtcdTimeout: defaultEtcdTimeout,
-		SyncerCfg:   new(SyncerConfig),
+		SyncerCfg:   &SyncerConfig{},
 	}
 	cfg.FlagSet = flag.NewFlagSet("drainer", flag.ContinueOnError)
 	fs := cfg.FlagSet
@@ -154,6 +158,13 @@ func (cfg *Config) Parse(args []string) error {
 	err := flags.SetFlagsFromEnv("BINLOG_SERVER", cfg.FlagSet)
 	if err != nil {
 		return errors.Trace(err)
+	}
+
+	if cfg.SyncerCfg.StrSQLMode != nil {
+		cfg.SyncerCfg.SQLMode, err = mysql.GetSQLMode(*cfg.SyncerCfg.StrSQLMode)
+		if err != nil {
+			return errors.Annotate(err, "invalid config: `sql-mode` must be a valid SQL_MODE")
+		}
 	}
 
 	cfg.tls, err = cfg.Security.ToTLSConfig()

--- a/drainer/executor/executor.go
+++ b/drainer/executor/executor.go
@@ -15,10 +15,10 @@ type Executor interface {
 }
 
 // New returns the an Executor instance by given name
-func New(name string, cfg *DBConfig) (Executor, error) {
+func New(name string, cfg *DBConfig, sqlMode *string) (Executor, error) {
 	switch name {
 	case "mysql", "tidb":
-		return newMysql(cfg)
+		return newMysql(cfg, sqlMode)
 	case "pb":
 		return newPB(cfg)
 	case "flash":

--- a/drainer/executor/mysql.go
+++ b/drainer/executor/mysql.go
@@ -17,8 +17,8 @@ type mysqlExecutor struct {
 	*baseError
 }
 
-func newMysql(cfg *DBConfig) (Executor, error) {
-	db, err := pkgsql.OpenDB("mysql", cfg.Host, cfg.Port, cfg.User, cfg.Password)
+func newMysql(cfg *DBConfig, sqlMode *string) (Executor, error) {
+	db, err := pkgsql.OpenDBWithSQLMode("mysql", cfg.Host, cfg.Port, cfg.User, cfg.Password, sqlMode)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/drainer/translator/kafka.go
+++ b/drainer/translator/kafka.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ngaut/log"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"
+	parsermysql "github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb-binlog/pkg/util"
 	obinlog "github.com/pingcap/tidb-tools/tidb-binlog/slave_binlog_proto/go-binlog"
 	"github.com/pingcap/tidb/mysql"
@@ -24,7 +25,7 @@ func init() {
 	Register("kafka", &kafkaTranslator{})
 }
 
-func (p *kafkaTranslator) SetConfig(bool) {
+func (p *kafkaTranslator) SetConfig(bool, parsermysql.SQLMode) {
 	// do nothing
 }
 

--- a/drainer/translator/pb.go
+++ b/drainer/translator/pb.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pingcap/parser"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/model"
+	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb-binlog/pkg/util"
 	pb "github.com/pingcap/tidb-binlog/proto/binlog"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
@@ -19,14 +20,15 @@ import (
 
 // pbTranslator translates TiDB binlog to self-description protobuf
 type pbTranslator struct {
+	sqlMode mysql.SQLMode
 }
 
 func init() {
 	Register("pb", &pbTranslator{})
 }
 
-func (p *pbTranslator) SetConfig(bool) {
-	// do nothing
+func (p *pbTranslator) SetConfig(_ bool, sqlMode mysql.SQLMode) {
+	p.sqlMode = sqlMode
 }
 
 func (p *pbTranslator) GenInsertSQLs(schema string, table *model.TableInfo, rows [][]byte, commitTS int64) ([]string, [][]string, [][]interface{}, error) {
@@ -182,7 +184,9 @@ func (p *pbTranslator) GenDeleteSQLs(schema string, table *model.TableInfo, rows
 }
 
 func (p *pbTranslator) GenDDLSQL(sql string, schema string, commitTS int64) (string, error) {
-	stmt, err := parser.New().ParseOneStmt(sql, "", "")
+	ddlParser := parser.New()
+	ddlParser.SetSQLMode(p.sqlMode)
+	stmt, err := ddlParser.ParseOneStmt(sql, "", "")
 	if err != nil {
 		return "", errors.Trace(err)
 	}

--- a/drainer/translator/translator.go
+++ b/drainer/translator/translator.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ngaut/log"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"
+	parsermysql "github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb-binlog/pkg/util"
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/table"
@@ -35,7 +36,7 @@ var providers = make(map[string]SQLTranslator)
 // SQLTranslator is the interface for translating TiDB binlog to target sqls
 type SQLTranslator interface {
 	// Config set the configuration
-	SetConfig(safeMode bool)
+	SetConfig(safeMode bool, sqlMode parsermysql.SQLMode)
 
 	// GenInsertSQLs generates the insert sqls
 	GenInsertSQLs(schema string, table *model.TableInfo, rows [][]byte, commitTS int64) ([]string, [][]string, [][]interface{}, error)

--- a/drainer/translator/translator_test.go
+++ b/drainer/translator/translator_test.go
@@ -9,6 +9,7 @@ import (
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/model"
+	parsermysql "github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/tablecodec"
@@ -57,7 +58,7 @@ func (t *testTranslatorSuite) TestTranslater(c *C) {
 }
 
 func testGenInsertSQLs(c *C, s SQLTranslator, safeMode bool) {
-	s.SetConfig(safeMode)
+	s.SetConfig(safeMode, parsermysql.ModeStrictTransTables|parsermysql.ModeNoEngineSubstitution)
 	schema := "t"
 	tables := []*model.TableInfo{testGenTable("normal"), testGenTable("hasPK"), testGenTable("hasID")}
 	exceptedKeys := []int{3, 2, 1}

--- a/drainer/util.go
+++ b/drainer/util.go
@@ -133,10 +133,10 @@ func closeExecutors(executors ...executor.Executor) {
 	}
 }
 
-func createExecutors(destDBType string, cfg *executor.DBConfig, count int) ([]executor.Executor, error) {
+func createExecutors(destDBType string, cfg *executor.DBConfig, count int, sqlMODE *string) ([]executor.Executor, error) {
 	executors := make([]executor.Executor, 0, count)
 	for i := 0; i < count; i++ {
-		executor, err := executor.New(destDBType, cfg)
+		executor, err := executor.New(destDBType, cfg, sqlMODE)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/pkg/sql/sql.go
+++ b/pkg/sql/sql.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"net"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -116,15 +117,24 @@ func ExecuteTxnWithHistogram(db *sql.DB, sqls []string, args [][]interface{}, hi
 	return nil
 }
 
-// OpenDB creates an instance of sql.DB.
-func OpenDB(proto string, host string, port int, username string, password string) (*sql.DB, error) {
+// OpenDBWithSQLMode creates an instance of sql.DB.
+func OpenDBWithSQLMode(proto string, host string, port int, username string, password string, sqlMode *string) (*sql.DB, error) {
 	dbDSN := fmt.Sprintf("%s:%s@tcp(%s:%d)/?charset=utf8mb4,utf8&multiStatements=true", username, password, host, port)
+	if sqlMode != nil {
+		// same as "set sql_mode = '<sqlMode>'"
+		dbDSN += "&sql_mode='" + url.QueryEscape(*sqlMode) + "'"
+	}
 	db, err := sql.Open(proto, dbDSN)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Annotatef(err, "dsn: %s", dbDSN)
 	}
 
 	return db, nil
+}
+
+// OpenDB creates an instance of sql.DB.
+func OpenDB(proto string, host string, port int, username string, password string) (*sql.DB, error) {
+	return OpenDBWithSQLMode(proto, host, port, username, password, nil)
 }
 
 // IgnoreDDLError checks the error can be ignored or not.


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

cherry-pick: #511 

### What is changed and how it works?

If this is setted , will use the same sql-mode to parse DDL statment, and set the same sql-mode at downstream when db-type is mysql.
If this is not setted, it will not set any sql-mode.

(cherry picked from commit 06e378fb258891dc377f74dc94e508eea74b0c28)

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - Has exported function/method change

Side effects

N/A

Related changes

N/A