### PR TITLE
drainer: Ignore generated columns when updating

### DIFF
--- a/drainer/translator/mysql.go
+++ b/drainer/translator/mysql.go
@@ -103,7 +103,7 @@ func (m *mysqlTranslator) GenUpdateSQLs(schema string, table *model.TableInfo, r
 		return sqls, keys, values, safeMode, err
 	}
 
-	columns := table.Columns
+	columns := writableColumns(table)
 	sqls := make([]string, 0, len(rows))
 	keys := make([][]string, 0, len(rows))
 	values := make([][]interface{}, 0, len(rows))
@@ -167,7 +167,7 @@ func (m *mysqlTranslator) GenUpdateSQLs(schema string, table *model.TableInfo, r
 }
 
 func (m *mysqlTranslator) genUpdateSQLsSafeMode(schema string, table *model.TableInfo, rows [][]byte, commitTS int64) ([]string, [][]string, [][]interface{}, error) {
-	columns := table.Columns
+	columns := writableColumns(table)
 	sqls := make([]string, 0, len(rows))
 	keys := make([][]string, 0, len(rows))
 	values := make([][]interface{}, 0, len(rows))

--- a/drainer/translator/pb.go
+++ b/drainer/translator/pb.go
@@ -79,7 +79,7 @@ func (p *pbTranslator) GenInsertSQLs(schema string, table *model.TableInfo, rows
 }
 
 func (p *pbTranslator) GenUpdateSQLs(schema string, table *model.TableInfo, rows [][]byte, commitTS int64) ([]string, [][]string, [][]interface{}, bool, error) {
-	columns := table.Columns
+	columns := writableColumns(table)
 	sqls := make([]string, 0, len(rows))
 	keys := make([][]string, 0, len(rows))
 	values := make([][]interface{}, 0, len(rows))

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -104,7 +104,7 @@ func (l *StdLogger) Println(v ...interface{}) {
 
 // ToColumnTypeMap return a map index by column id
 func ToColumnTypeMap(columns []*model.ColumnInfo) map[int64]*types.FieldType {
-	colTypeMap := make(map[int64]*types.FieldType)
+	colTypeMap := make(map[int64]*types.FieldType, len(columns))
 	for _, col := range columns {
 		colTypeMap[col.ID] = &col.FieldType
 	}

--- a/tests/gencol/run.sh
+++ b/tests/gencol/run.sh
@@ -35,6 +35,16 @@ check_contains 'sum(a): 12'
 check_contains 'sum(b): 62'
 check_contains 'sum(c): 52'
 
+run_sql 'UPDATE gencol.gct SET c = b WHERE a = 7;'
+
+sleep 3
+
+down_run_sql 'SELECT count(*), sum(a), sum(b), sum(c) FROM gencol.gct;'
+check_contains 'count(*): 3'
+check_contains 'sum(a): 12'
+check_contains 'sum(b): 62'
+check_contains 'sum(c): 93'
+
 # Verify DELETE statements works with generated columns...
 
 run_sql 'DELETE FROM gencol.gct WHERE b = 9;'
@@ -45,6 +55,6 @@ down_run_sql 'SELECT count(*), sum(a), sum(b), sum(c) FROM gencol.gct;'
 check_contains 'count(*): 2'
 check_contains 'sum(a): 9'
 check_contains 'sum(b): 53'
-check_contains 'sum(c): 20'
+check_contains 'sum(c): 61'
 
 killall drainer


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

It seems that we can't handle `UPDATE`s like the following:

```sql
	UPDATE gencol.gct SET c = b WHERE a = 7;
```

correctly (in which `b` is a generated column).

`drainer` exit with the following error:

```log
 323   │ 2019/04/02 17:14:55 server.go:225: [error] syncer exited, error gen update sqls failed: tab
       │ le `gencol`.`gct`:  row data is corruption [], schema: gencol, table: gct
 324   │ github.com/pingcap/tidb-binlog/drainer.(*Syncer).translateSqls
 325   │     /Users/satoru/go/src/github.com/pingcap/tidb-binlog/drainer/syncer.go:581
 326   │ github.com/pingcap/tidb-binlog/drainer.(*Syncer).run
 327   │     /Users/satoru/go/src/github.com/pingcap/tidb-binlog/drainer/syncer.go:482
 328   │ github.com/pingcap/tidb-binlog/drainer.(*Syncer).Start
 329   │     /Users/satoru/go/src/github.com/pingcap/tidb-binlog/drainer/syncer.go:96
 330   │ github.com/pingcap/tidb-binlog/drainer.(*Server).StartSyncer.func1
 331   │     /Users/satoru/go/src/github.com/pingcap/tidb-binlog/drainer/server.go:223
 332   │ runtime.goexit
 333   │     /usr/local/Cellar/go/1.12.1/libexec/src/runtime/asm_amd64.s:1337
```

This new test aims to expose this issue and fix the bug.


### What is changed and how it works?

1. A test case is added.
1. Generated columns are ignored before processing UPDATEs

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test