### PR TITLE
pkg/loader: Optimize by setting known capacity

### DIFF
--- a/pkg/loader/executor.go
+++ b/pkg/loader/executor.go
@@ -162,14 +162,13 @@ func (e *executor) bulkReplace(inserts []*DML) error {
 		builder.WriteString(holder)
 	}
 
-	var args []interface{}
+	args := make([]interface{}, 0, len(inserts)*len(info.columns))
 	for _, insert := range inserts {
 		for _, name := range info.columns {
 			v := insert.Values[name]
 			args = append(args, v)
 		}
 	}
-
 	tx, err := e.begin()
 	if err != nil {
 		return errors.Trace(err)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

The capacity of the `args` slice is known, so we can set it before appending to reduce memory allocations.

### What is changed and how it works?

Change the way the `args` slice is initialized.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->


Code changes


Side effects


Related changes