### PR TITLE
drainer: Make sure only writable columns are included

### DIFF
--- a/drainer/translator/flash.go
+++ b/drainer/translator/flash.go
@@ -147,8 +147,7 @@ func GenFlashUpdateSQL(schema string, table *model.TableInfo, row []byte, commit
 	}
 	pkID := pkColumn.ID
 
-	columns := writableColumns(table)
-	colsTypeMap := util.ToColumnTypeMap(columns)
+	updtDecoder := newUpdateDecoder(table)
 	version := makeInternalVersionValue(uint64(commitTS))
 	delFlag := makeInternalDelmarkValue(false)
 
@@ -156,7 +155,7 @@ func GenFlashUpdateSQL(schema string, table *model.TableInfo, row []byte, commit
 	var newValues []interface{}
 
 	// TODO: Make updating pk working
-	_, newColumnValues, err := DecodeOldAndNewRow(row, colsTypeMap, gotime.Local)
+	_, newColumnValues, err := updtDecoder.decode(row, gotime.Local)
 	newPkValue := newColumnValues[pkID]
 
 	if err != nil {

--- a/drainer/translator/kafka.go
+++ b/drainer/translator/kafka.go
@@ -174,9 +174,8 @@ func deleteRowToRow(tableInfo *model.TableInfo, raw []byte) (row *obinlog.Row, e
 }
 
 func updateRowToRow(tableInfo *model.TableInfo, raw []byte) (row *obinlog.Row, changedRow *obinlog.Row, err error) {
-	columns := writableColumns(tableInfo)
-	colsTypeMap := util.ToColumnTypeMap(columns)
-	oldDatums, newDatums, err := DecodeOldAndNewRow(raw, colsTypeMap, time.Local)
+	updtDecoder := newUpdateDecoder(tableInfo)
+	oldDatums, newDatums, err := updtDecoder.decode(raw, time.Local)
 	if err != nil {
 		return
 	}

--- a/drainer/translator/mysql.go
+++ b/drainer/translator/mysql.go
@@ -58,11 +58,11 @@ func genMysqlInsert(schema string, table *model.TableInfo, row []byte) (names []
 
 func genMysqlUpdate(schema string, table *model.TableInfo, row []byte) (names []string, values []interface{}, oldValues []interface{}, err error) {
 	columns := writableColumns(table)
-	colsTypeMap := util.ToColumnTypeMap(columns)
+	updtDecoder := newUpdateDecoder(table)
 
 	var updateColumns []*model.ColumnInfo
 
-	oldColumnValues, newColumnValues, err := DecodeOldAndNewRow(row, colsTypeMap, time.Local)
+	oldColumnValues, newColumnValues, err := updtDecoder.decode(row, time.Local)
 	if err != nil {
 		return nil, nil, nil, errors.Annotatef(err, "table `%s`.`%s`", schema, table.Name)
 	}

--- a/drainer/translator/translator.go
+++ b/drainer/translator/translator.go
@@ -151,3 +151,21 @@ func DecodeOldAndNewRow(b []byte, cols map[int64]*types.FieldType, loc *time.Loc
 
 	return oldRow, newRow, nil
 }
+
+
+type updateDecoder struct {
+	colsTypes map[int64]*types.FieldType
+}
+
+func newUpdateDecoder(table *model.TableInfo) updateDecoder {
+	columns := writableColumns(table)
+	return updateDecoder{
+		colsTypes: util.ToColumnTypeMap(columns),
+	}
+}
+
+// decode decodes a byte slice into datums with a existing row map.
+// Row layout: colID1, value1, colID2, value2, .....
+func (ud updateDecoder) decode(b []byte, loc *time.Location) (map[int64]types.Datum, map[int64]types.Datum, error) {
+	return DecodeOldAndNewRow(b, ud.colsTypes, loc)
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

`DecodeOldAndNew` reports "corruption" when `generated columns` are
included.
The function recieves a `map[int64]*types.FieldType` instead of columns
or table to avoid recreating the `map`.
So we can't change the parameters of the function.

### What is changed and how it works?

Replace `DecodeOldAndNew` with `updateDecoder.decode`.
Calls of `decode` must be done by first creating a decoder with `newUpdateDecoder`,
 in which we create the map with only writable columns.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test
 - Manual test (add detailed scripts or steps below)

Code changes

Side effects

Related changes