### PR TITLE
TOOL-1123 fix the Makefile indentation problem

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ PROJECT=tidb-binlog
 
 # Ensure GOPATH is set before running build process.
 ifeq "$(GOPATH)" ""
-	$(error Please set the environment variable GOPATH before running `make`)
+  $(error Please set the environment variable GOPATH before running `make`)
 endif
 
 CURDIR := $(shell pwd)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Previously the Makefile has error when running the make command will get "$(error Please set the environment variable GOPATH before running `make`)"
Detailed info and steps pls check the issue link: https://internal.pingcap.net/jira/browse/TOOL-1123

### What is changed and how it works?
As i check the Makefile of TiDB, i find the indentation in the Binlog Makefile line 8 is incorrect which leads to the problem. 
