### PR TITLE
binlogctl: refine log output when use help command

### DIFF
--- a/binlogctl/config.go
+++ b/binlogctl/config.go
@@ -81,11 +81,6 @@ type Config struct {
 func NewConfig() *Config {
 	cfg := &Config{}
 	cfg.FlagSet = flag.NewFlagSet("binlogctl", flag.ContinueOnError)
-	fs := cfg.FlagSet
-	fs.Usage = func() {
-		fmt.Fprintln(os.Stderr, "Usage of binlogctl:")
-		fs.PrintDefaults()
-	}
 
 	cfg.FlagSet.StringVar(&cfg.Command, "cmd", "pumps", "operator: \"generate_meta\", \"pumps\", \"drainers\", \"update-pump\", \"update-drainer\", \"pause-pump\", \"pause-drainer\", \"offline-pump\", \"offline-drainer\"")
 	cfg.FlagSet.StringVar(&cfg.NodeID, "node-id", "", "id of node, use to update some node with operation update-pump, update-drainer, pause-pump, pause-drainer, offline-pump and offline-drainer")


### PR DESCRIPTION


### What problem does this PR solve? <!--add issue link with summary if exists-->
old code will print error log when use --help or other unexpected cmd

### What is changed and how it works?
just print usage help

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (binlogctl --help and check output)

