### PR TITLE
drainer: Add a metric to track the delay of the downstream

### DIFF
--- a/drainer/metrics.go
+++ b/drainer/metrics.go
@@ -69,12 +69,13 @@ var (
 			Help:      "save checkpoint tso of drainer.",
 		})
 
-	checkpointDelayGauge = prometheus.NewGauge(
-		prometheus.GaugeOpts{
+	checkpointDelayHistogram = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
 			Namespace: "binlog",
 			Subsystem: "drainer",
 			Name:      "checkpoint_delay_seconds",
 			Help:      "How much the downstream checkpoint lag behind",
+			Buckets:   prometheus.ExponentialBuckets(0.00005, 2, 18),
 		})
 
 	executeHistogram = prometheus.NewHistogram(
@@ -131,7 +132,7 @@ func init() {
 	registry.MustRegister(ddlJobsCounter)
 	registry.MustRegister(errorCount)
 	registry.MustRegister(checkpointTSOGauge)
-	registry.MustRegister(checkpointDelayGauge)
+	registry.MustRegister(checkpointDelayHistogram)
 	registry.MustRegister(eventCounter)
 	registry.MustRegister(executeHistogram)
 	registry.MustRegister(binlogReachDurationHistogram)

--- a/drainer/metrics.go
+++ b/drainer/metrics.go
@@ -69,6 +69,14 @@ var (
 			Help:      "save checkpoint tso of drainer.",
 		})
 
+	checkpointDelayGauge = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "binlog",
+			Subsystem: "drainer",
+			Name:      "checkpoint_delay_seconds",
+			Help:      "How much the downstream checkpoint lag behind",
+		})
+
 	executeHistogram = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
 			Namespace: "binlog",
@@ -123,6 +131,7 @@ func init() {
 	registry.MustRegister(ddlJobsCounter)
 	registry.MustRegister(errorCount)
 	registry.MustRegister(checkpointTSOGauge)
+	registry.MustRegister(checkpointDelayGauge)
 	registry.MustRegister(eventCounter)
 	registry.MustRegister(executeHistogram)
 	registry.MustRegister(binlogReachDurationHistogram)

--- a/drainer/metrics.go
+++ b/drainer/metrics.go
@@ -75,7 +75,7 @@ var (
 			Subsystem: "drainer",
 			Name:      "checkpoint_delay_seconds",
 			Help:      "How much the downstream checkpoint lag behind",
-			Buckets:   prometheus.ExponentialBuckets(0.00005, 2, 18),
+			Buckets:   prometheus.ExponentialBuckets(0.001, 2, 22),
 		})
 
 	executeHistogram = prometheus.NewHistogram(

--- a/drainer/syncer.go
+++ b/drainer/syncer.go
@@ -221,6 +221,8 @@ func (s *Syncer) handleSuccess(fakeBinlog chan *pb.Binlog, lastTS *int64) {
 				lastSaveTS = ts
 				eventCounter.WithLabelValues("savepoint").Add(1)
 			}
+			delay := oracle.GetPhysical(time.Now()) - oracle.ExtractPhysical(uint64(ts))
+			checkpointDelayGauge.Set(float64(delay) / 1e3)
 		}
 	}
 

--- a/drainer/syncer.go
+++ b/drainer/syncer.go
@@ -222,7 +222,7 @@ func (s *Syncer) handleSuccess(fakeBinlog chan *pb.Binlog, lastTS *int64) {
 				eventCounter.WithLabelValues("savepoint").Add(1)
 			}
 			delay := oracle.GetPhysical(time.Now()) - oracle.ExtractPhysical(uint64(ts))
-			checkpointDelayGauge.Set(float64(delay) / 1e3)
+			checkpointDelayHistogram.Observe(float64(delay) / 1e3)
 		}
 	}
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix [Jira Issue](https://internal.pingcap.net/jira/browse/TOOL-1170)


### What is changed and how it works?

A new metric `checkpoint_delay = now() - most-recent-ts` is included.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

Manual test (confirmed that the new metric appeared in the /metrics endpoint):  
```
# HELP binlog_drainer_checkpoint_delay_seconds How much the downstream checkpoint lag behind
# TYPE binlog_drainer_checkpoint_delay_seconds gauge
binlog_drainer_checkpoint_delay_seconds 15.128
```

Code changes


Side effects


Related changes