### PR TITLE
Turn fatal error listening on 127.0.0.1/localhost into a warning (was #561)

### DIFF
--- a/drainer/config.go
+++ b/drainer/config.go
@@ -234,7 +234,7 @@ func (cfg *Config) validate() error {
 	}
 
 	if !util.IsValidateListenHost(host) {
-		log.Fatal("invalid listen addr, drainer will register this ip into etcd, pump must access drainer, change the listen addr config", zap.String("listen addr", host))
+		log.Warn("pump may not be able to access drainer using this listen addr config", zap.String("listen addr", host))
 	}
 
 	// check EtcdEndpoints


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
Drainer logs a fatal error when it encounters an attempt to bind to 127.0.0.1 or localhost. The concern seems to be that pump will not be able to contact the drainer in this case? This is not a very reasonable assumption, since someone might run a local cluster for testing or use port forwarding.

### What is changed and how it works?
This PR changes the fatal error to a warning.