### PR TITLE
load.go: set max idle conns as worker count

### DIFF
--- a/pkg/loader/load.go
+++ b/pkg/loader/load.go
@@ -142,6 +142,7 @@ func NewLoader(db *gosql.DB, opt ...Option) (Loader, error) {
 	}
 
 	db.SetMaxOpenConns(opts.workerCount)
+	db.SetMaxIdleConns(opts.workerCount)
 
 	return s, nil
 }


### PR DESCRIPTION
the default value is only 2, and may change for future release of go
when the worker count if hight, this will cause two many connection
create and close.

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
set max idle conns as worker count

the default value is only 2, and may change for future release of go
when the worker count if hight, this will cause two many connection
create and close every time we use `sql.DB`.

### What is changed and how it works?
set max idle conns as worker count

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
worker-count = 64

before this pr, it may create and close connection frequencly, and not port available more.
need wait `TIME_WAIT` before reuse port.
```
[2019/05/21 10:17:49.618 +08:00] [ERROR] [util.go:147] [singleExec] [error="dial tcp 172.16.4.71:3306: connect: cannot assign requested address"] [errorVerbose="dial tcp 172.16.4.71:3306: connect: cannot assign requested address\ngithub.com/pingcap/errors.AddStack\n\t/home/jenkins/workspace/release_tidb_3.0/go/pkg/mod/github.com/pingcap/errors@v0.11.0/errors.go:174\ngithub.com/pingcap/errors.Trace\n\t/home/jenkins/workspace/release_tidb_3.0/go/pkg/mod/github.com/pingcap/errors@v0.11.0/juju_adaptor.go:12\ngithub.com/pingcap/tidb-binlog/pkg/loader.(*executor).begin\n\t/home/jenkins/workspace/release_tidb_3.0/go/src/github.com/pingcap/tidb-binlog/pkg/loader/executor.go:107\ngithub.com/pingcap/tidb-binlog/pkg/loader.(*executor).singleExec\n\t/home/jenkins/workspace/release_tidb_3.0/go/src/github.com/pingcap/tidb-binlog/pkg/loader/executor.go:261\ngithub.com/pingcap/tidb-binlog/pkg/loader.(*executor).singleExecRetry.func1\n\t/home/jenkins/workspace/release_tidb_3.0/go/src/github.com/pingcap/tidb-binlog/pkg/loader/executor.go:250\ngithub.com/pingcap/tidb-binlog/pkg/util.RetryOnError\n\t/home/jenkins/workspace/release_tidb_3.0/go/src/github.com/pingcap/tidb-binlog/pkg/util/util.go:142\ngithub.com/pingcap/tidb-binlog/pkg/loader.(*executor).singleExecRetry\n\t/home/jenkins/workspace/release_tidb_3.0/go/src/github.com/pingcap/tidb-binlog/pkg/loader/executor.go:249\ngithub.com/pingcap/tidb-binlog/pkg/loader.(*loaderImpl).execByHash.func1\n\t/home/jenkins/workspace/release_tidb_3.0/go/src/github.com/pingcap/tidb-binlog/pkg/loader/load.go:292\ngolang.org/x/sync/errgroup.(*Group).Go.func1\n\t/home/jenkins/workspace/release_tidb_3.0/go/pkg/mod/golang.org/x/sync@v0.0.0-20180314180146-1d60e4601c6f/errgroup/errgroup.go:58\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1337"]
```

after this pr: for insert stably 70+ K/s
<img width="801" alt="Screen Shot 2019-05-21 at 1 29 33 PM" src="https://user-images.githubusercontent.com/1681864/58071193-6b964380-7bce-11e9-8c65-9d0cbe943494.png">


Code changes



Side effects

Related changes

