### PR TITLE
tests: Stop pumps one by one to avoid stopping the upstream TiDB

### DIFF
--- a/tests/_utils/run_pump
+++ b/tests/_utils/run_pump
@@ -9,7 +9,7 @@ OUT_DIR=/tmp/tidb_binlog_test
 # kill pump, util no pump process is running
 while :
 do
-        pump_num=`ps aux > temp && grep "pump -log-file ${OUT_DIR}/pump_${PORT}.log" temp | wc -l && rm temp`
+        pump_num=`pgrep "pump -log-file ${OUT_DIR}/pump_${PORT}.log" | wc -l`
         if [ $pump_num -ne 0 ]; then
                 binlogctl -pd-urls 127.0.0.1:2379 -cmd pause-pump -node-id pump:$PORT || true
                 sleep 1


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

In the `restart` test, we tried to restart 2 pump instances at almost the same time with background jobs.
Meanwhile, another background job keeps inserting data into a test
table.
When prewriting a binlog for the inserted data and no pump instances is
available, TiDB would fail with critical error.


### What is changed and how it works?

Stop pumps synchronously.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Code changes


Side effects

Related changes