### PR TITLE
pump: getSafeGCTSOForDrainers should be usable after Close

### DIFF
--- a/pump/server.go
+++ b/pump/server.go
@@ -500,7 +500,7 @@ func (s *Server) gcBinlogFile() {
 				continue
 			}
 
-			safeTSO, err := s.getSafeGCTSOForDrainers()
+			safeTSO, err := s.getSafeGCTSOForDrainers(s.ctx)
 			if err != nil {
 				log.Warn("get save gc tso for drainers failed", zap.Error(err))
 				continue
@@ -518,10 +518,10 @@ func (s *Server) gcBinlogFile() {
 	}
 }
 
-func (s *Server) getSafeGCTSOForDrainers() (int64, error) {
+func (s *Server) getSafeGCTSOForDrainers(ctx context.Context) (int64, error) {
 	pumpNode := s.node.(*pumpNode)
 
-	drainers, err := pumpNode.Nodes(s.ctx, "drainers")
+	drainers, err := pumpNode.Nodes(ctx, "drainers")
 	if err != nil {
 		return 0, errors.Trace(err)
 	}
@@ -702,7 +702,7 @@ func (s *Server) waitSafeToOffline(ctx context.Context) error {
 	for {
 		select {
 		case <-time.After(time.Second):
-			safeTSO, err := s.getSafeGCTSOForDrainers()
+			safeTSO, err := s.getSafeGCTSOForDrainers(ctx)
 			if err != nil {
 				log.Error("Failed to get safe GCTS", zap.Error(err))
 				break


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

When we call `Close` on the server, it first calls `cancel`
to stop all related background jobs. If we reuse `s.ctx` in
`getSafeGCTSOForDrainers` after `Close`, nothing useful can be done.


### What is changed and how it works?

Make `ctx` a parameter, so that when calling `getSafeGCTSOForDrainers`
after `Close` we can pass in a different context.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Code changes


Side effects


Related changes