### PR TITLE
reparo: refine integration test

### DIFF
--- a/pkg/loader/load.go
+++ b/pkg/loader/load.go
@@ -493,7 +493,7 @@ func newBatchManager(s *loaderImpl) *batchManager {
 		fDDLSuccessCallback: func(txn *Txn) {
 			s.markSuccess(txn)
 			if _, err := s.refreshTableInfo(txn.DDL.Database, txn.DDL.Table); err != nil {
-				log.Errorf("refresh table info failed, %v", err)
+				log.Error("refresh table info failed", zap.Error(err))
 			}
 		},
 	}

--- a/pkg/loader/load.go
+++ b/pkg/loader/load.go
@@ -545,6 +545,10 @@ func (b *batchManager) put(txn *Txn) error {
 	// we always executor the previous dmls when we meet ddl,
 	// and executor ddl one by one.
 	if txn.isDDL() {
+		if len(txn.DDL.Database) == 0 {
+			return errors.Errorf("get DDL Txn with empty database, ddl: %s", txn.DDL.SQL)
+		}
+
 		if err := b.execAccumulatedDMLs(); err != nil {
 			return errors.Trace(err)
 		}

--- a/pkg/loader/load.go
+++ b/pkg/loader/load.go
@@ -206,6 +206,8 @@ func (s *loaderImpl) Close() {
 var utilGetTableInfo = getTableInfo
 
 func (s *loaderImpl) refreshTableInfo(schema string, table string) (info *tableInfo, err error) {
+	log.Info("refresh table info", zap.String("schema", schema), zap.String("table", table))
+
 	if len(schema) == 0 {
 		return nil, errors.New("schema is empty")
 	}

--- a/pkg/loader/load.go
+++ b/pkg/loader/load.go
@@ -495,7 +495,7 @@ func newBatchManager(s *loaderImpl) *batchManager {
 		fDDLSuccessCallback: func(txn *Txn) {
 			s.markSuccess(txn)
 			if _, err := s.refreshTableInfo(txn.DDL.Database, txn.DDL.Table); err != nil {
-				log.Error("refresh table info failed", zap.Error(err))
+				log.Error("refresh table info failed", zap.String("database", txn.DDL.Database), zap.String("table", txn.DDL.Table), zap.Error(err))
 			}
 		},
 	}

--- a/pkg/loader/load.go
+++ b/pkg/loader/load.go
@@ -206,6 +206,14 @@ func (s *loaderImpl) Close() {
 var utilGetTableInfo = getTableInfo
 
 func (s *loaderImpl) refreshTableInfo(schema string, table string) (info *tableInfo, err error) {
+	if len(schema) == 0 {
+		return nil, errors.New("schema is empty")
+	}
+
+	if len(table) == 0 {
+		return nil, nil
+	}
+
 	info, err = utilGetTableInfo(s.db, schema, table)
 	if err != nil {
 		return info, errors.Trace(err)
@@ -484,7 +492,9 @@ func newBatchManager(s *loaderImpl) *batchManager {
 		fExecDDL:             s.execDDL,
 		fDDLSuccessCallback: func(txn *Txn) {
 			s.markSuccess(txn)
-			s.refreshTableInfo(txn.DDL.Database, txn.DDL.Table)
+			if _, err := s.refreshTableInfo(txn.DDL.Database, txn.DDL.Table); err != nil {
+				log.Errorf("refresh table info failed, %v", err)
+			}
 		},
 	}
 }

--- a/pkg/loader/load_test.go
+++ b/pkg/loader/load_test.go
@@ -133,7 +133,7 @@ func (cs *LoadSuite) TestSetDMLInfo(c *check.C) {
 	}()
 	ld := loaderImpl{}
 
-	dml := DML{}
+	dml := DML{Database: "test", Table: "t1"}
 	c.Assert(dml.info, check.IsNil)
 	err := ld.setDMLInfo(&dml)
 	c.Assert(err, check.IsNil)

--- a/reparo/syncer/translate.go
+++ b/reparo/syncer/translate.go
@@ -36,6 +36,9 @@ func pbBinlogToTxn(binlog *pb.Binlog) (txn *loader.Txn, err error) {
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
+		if len(txn.DDL.Database) == 0 {
+			return nil, errors.Errorf("can't parse database name from DDL %s", binlog.DdlQuery)
+		}
 	case pb.BinlogType_DML:
 		data := binlog.DmlData
 		for _, event := range data.GetEvents() {

--- a/reparo/syncer/translate.go
+++ b/reparo/syncer/translate.go
@@ -190,7 +190,7 @@ func parserSchemaTableFromDDL(ddlQuery string) (schema, table string, err error)
 			}
 			table = node.Table.Name.O
 		case *ast.DropTableStmt:
-			// now only support drop one table in a ddl
+			// FIXME: may drop more than one table in a ddl
 			if len(node.Tables[0].Schema.O) != 0 {
 				schema = node.Tables[0].Schema.O
 			}

--- a/reparo/syncer/translate.go
+++ b/reparo/syncer/translate.go
@@ -156,9 +156,12 @@ func parserSchemaTableFromDDL(ddlQuery string) (schema, table string, err error)
 		return "", "", err
 	}
 
+	haveUseStmt := false
+
 	for _, stmt := range stmts {
 		switch node := stmt.(type) {
 		case *ast.UseStmt:
+			haveUseStmt = true
 			schema = node.DBName
 		case *ast.CreateDatabaseStmt:
 			schema = node.Name
@@ -202,6 +205,16 @@ func parserSchemaTableFromDDL(ddlQuery string) (schema, table string, err error)
 			table = node.NewTable.Name.O
 		default:
 			return "", "", errors.Errorf("unknown ddl type, ddl: %s", ddlQuery)
+		}
+	}
+
+	if haveUseStmt {
+		if len(stmts) != 2 {
+			return "", "", errors.Errorf("invalid ddl %s", ddlQuery)
+		}
+	} else {
+		if len(stmts) != 1 {
+			return "", "", errors.Errorf("invalid ddl %s", ddlQuery)
 		}
 	}
 

--- a/reparo/syncer/translate_test.go
+++ b/reparo/syncer/translate_test.go
@@ -36,7 +36,9 @@ func (s *testTranslateSuite) TestPBBinlogToTxn(c *check.C) {
 			DdlQuery: []byte("use db1; create table table1(id int)"),
 		}: {
 			DDL: &loader.DDL{
-				SQL: "use db1; create table table1(id int)",
+				SQL:      "use db1; create table table1(id int)",
+				Database: "db1",
+				Table:    "table1",
 			},
 		},
 		{

--- a/tests/reparo/binlog.go
+++ b/tests/reparo/binlog.go
@@ -1,0 +1,76 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"os"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/pingcap/errors"
+	"github.com/pingcap/log"
+	"github.com/pingcap/tidb-binlog/tests/dailytest"
+	"github.com/pingcap/tidb-binlog/tests/util"
+)
+
+func main() {
+	cfg := util.NewConfig()
+	err := cfg.Parse(os.Args[1:])
+	switch errors.Cause(err) {
+	case nil:
+	case flag.ErrHelp:
+		os.Exit(0)
+	default:
+		log.S().Errorf("parse cmd flags err %s\n", err)
+		os.Exit(2)
+	}
+
+	sourceDB, err := util.CreateDB(cfg.SourceDBCfg)
+	if err != nil {
+		log.S().Fatal(err)
+	}
+	defer func() {
+		if err := util.CloseDB(sourceDB); err != nil {
+			log.S().Errorf("Failed to close source database: %s\n", err)
+		}
+	}()
+
+	tableSQLs := []string{`
+	create table ptest(
+		a int primary key,
+		b double NOT NULL DEFAULT 2.0,
+		c varchar(10) NOT NULL,
+		d time unique
+	);
+	`,
+		`
+	create table itest(
+		a int,
+		b double NOT NULL DEFAULT 2.0,
+		c varchar(10) NOT NULL,
+		d time unique,
+		PRIMARY KEY(a, b)
+	);
+	`,
+		`
+	create table ntest(
+		a int,
+		b double NOT NULL DEFAULT 2.0,
+		c varchar(10) NOT NULL,
+		d time unique
+	);
+	`}
+
+	dailytest.RunDailyTest(sourceDB, tableSQLs, cfg.WorkerCount, cfg.JobCount, cfg.Batch)
+}

--- a/tests/reparo/config.toml
+++ b/tests/reparo/config.toml
@@ -1,0 +1,14 @@
+# Importer Configuration.
+
+log-level = "info"
+
+worker-count = 10
+job-count = 1000
+batch = 10
+
+[source-db]
+host = "127.0.0.1"
+user = "root"
+password = ""
+name = "reparo_test"
+port = 4000

--- a/tests/reparo/config.toml
+++ b/tests/reparo/config.toml
@@ -1,4 +1,4 @@
-# Importer Configuration.
+# daily test config
 
 log-level = "info"
 

--- a/tests/reparo/reparo.toml
+++ b/tests/reparo/reparo.toml
@@ -3,7 +3,7 @@ data-dir = "/tmp/tidb_binlog_test/data.drainer"
 
 # log-file = ""
 # log-rotate = "hour"
-log-level = "info"
+log-level = "debug"
 
 # start-datetime and stop-datetime enable you to pick a range of binlog to reparo.
 # The datetime format is like '2018-02-28 12:12:12'.
@@ -18,7 +18,6 @@ log-level = "info"
 # dest-type choose a destination, which value can be "mysql", "print".
 # for print, it just prints decoded value.
 dest-type = "mysql"
-#compression = "gzip"
 
 # 如果指定的 dest-type 为 mysql 或 tidb，需要配置 dest-db。
 [dest-db]

--- a/tests/reparo/run.sh
+++ b/tests/reparo/run.sh
@@ -9,19 +9,15 @@ ms=$(date +'%s')
 ts=$(($ms*1000<<18))
 args="-initial-commit-ts=$ts"
 down_run_sql "DROP DATABASE IF EXISTS tidb_binlog"
+run_sql "CREATE DATABASE IF NOT EXISTS \`reparo_test\`"
+
 rm -rf /tmp/tidb_binlog_test/data.drainer
 
 run_drainer "$args" &
 
-run_sql "DROP DATABASE IF EXISTS \`reparo_test\`;"
-run_sql "CREATE DATABASE \`reparo_test\`"
-run_sql "CREATE TABLE \`reparo_test\`.\`test\`(\`id\` int, \`name\` varchar(10), \`all\` varchar(10), PRIMARY KEY(\`id\`))"
+GO111MODULE=on go build -o out
 
-run_sql "INSERT INTO \`reparo_test\`.\`test\` VALUES(1, 'a', 'a'), (2, 'b', 'b')"
-run_sql "INSERT INTO \`reparo_test\`.\`test\` VALUES(3, 'c', 'c'), (4, 'd', 'c')"
-run_sql "UPDATE \`reparo_test\`.\`test\` SET \`name\` = 'bb' where \`id\` = 2"
-run_sql "DELETE FROM \`reparo_test\`.\`test\` WHERE \`id\` = '1'"
-run_sql "INSERT INTO \`reparo_test\`.\`test\` VALUES(5, 'e', 'e')"
+./out -config ./config.toml > ${OUT_DIR-/tmp}/$TEST_NAME.out 2>&1
 
 sleep 5
 

--- a/tests/reparo/sync_diff_inspector.toml
+++ b/tests/reparo/sync_diff_inspector.toml
@@ -23,7 +23,7 @@ use-checksum=true
 
 [[check-tables]]
 schema = "reparo_test"
-tables = ["test"]
+tables = ["~.*"]
 
 [target-db]
 host = "127.0.0.1"


### PR DESCRIPTION

### What problem does this PR solve? <!--add issue link with summary if exists-->
reparo's integration test is too simple, should refine it

### What is changed and how it works?
1. use daily test in reparo's integration test
2. find a bug, after exec DDL, loader will refresh table info, but the DDL.Database and DDL.Table is empty, and the DML will execute failed because use old table info.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Integration test

Related changes

 - Need to cherry-pick to the release branch