### PR TITLE
drainer: Log close error and long waits

### DIFF
--- a/drainer/syncer.go
+++ b/drainer/syncer.go
@@ -406,8 +406,7 @@ ForLoop:
 	select {
 	case <-wait:
 	case <-time.After(runWaitThreshold):
-		log.Error("Waiting too long for `Syncer.run` to quit.")
-		<-wait
+		panic("Waiting too long for `Syncer.run` to quit.")
 	}
 
 	close(s.closed)

--- a/drainer/syncer.go
+++ b/drainer/syncer.go
@@ -32,6 +32,10 @@ import (
 	pb "github.com/pingcap/tipb/go-binlog"
 )
 
+// runWaitThreshold is the expected time for `Syncer.run` to quit
+// normally, we take record if it takes longer than this value.
+var runWaitThreshold = 10 * time.Second
+
 // Syncer converts tidb binlog to the specified DB sqls, and sync it to target DB
 type Syncer struct {
 	schema *Schema
@@ -250,16 +254,15 @@ func (s *Syncer) savePoint(ts int64) {
 }
 
 func (s *Syncer) run() error {
-	var wg sync.WaitGroup
+	wait := make(chan struct{})
 
 	fakeBinlogCh := make(chan *pb.Binlog, 1024)
 	var lastSuccessTS int64
 	var fakeBinlogs []*pb.Binlog
 	var fakeBinlogPreAddTS []int64
 
-	wg.Add(1)
 	go func() {
-		defer wg.Done()
+		defer close(wait)
 		s.handleSuccess(fakeBinlogCh, &lastSuccessTS)
 	}()
 
@@ -396,7 +399,16 @@ ForLoop:
 
 	close(fakeBinlogCh)
 	cerr := s.dsyncer.Close()
-	wg.Wait()
+	if cerr != nil {
+		log.Error("Failed to close syncer", zap.Error(cerr))
+	}
+
+	select {
+	case <-wait:
+	case <-time.After(runWaitThreshold):
+		log.Error("Waiting too long for `Syncer.run` to quit.")
+		<-wait
+	}
 
 	close(s.closed)
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

[Related Issue](https://internal.pingcap.net/jira/browse/TOOL-1235?filter=-2)
The failure of `s.dsyncer.Close` may cause the following
`wg.Wait()` to block forever, we don't even have a chance to look at the
returned error.

### What is changed and how it works?

Log the close error before starting to block waiting, and log long
waits.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes


Side effects


Related changes