### PR TITLE
tests: fix the value range when checking exec txn histogram

### DIFF
--- a/pkg/sql/sql_test.go
+++ b/pkg/sql/sql_test.go
@@ -126,20 +126,29 @@ const (
 )
 
 func (s *sqlSuite) TestExecuteTxnSuccess(c *C) {
+	var (
+		delay1 time.Duration = 201
+		delay2 time.Duration = 101
+	)
 	s.mock.ExpectBegin()
 	s.mock.ExpectExec(testQuery1).
 		WithArgs(1).
-		WillDelayFor(time.Millisecond * 201).
+		WillDelayFor(time.Millisecond * delay1).
 		WillReturnResult(sqlmock.NewResult(18, 102))
 	s.mock.ExpectExec(testQuery2).
 		WithArgs(0).
-		WillDelayFor(time.Millisecond * 101).
+		WillDelayFor(time.Millisecond * delay2).
 		WillReturnResult(sqlmock.NewResult(19, 63))
 	s.mock.ExpectCommit()
 
+	startTime := time.Now()
 	histogram := prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{Buckets: prometheus.LinearBuckets(0, 0.1, 5)},
 		[]string{"exec"},
+	)
+	histogramFix := prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{Buckets: prometheus.LinearBuckets(0, 0.1, 5)},
+		[]string{"execFix"},
 	)
 	err := ExecuteTxnWithHistogram(
 		s.db,
@@ -148,6 +157,16 @@ func (s *sqlSuite) TestExecuteTxnSuccess(c *C) {
 		histogram,
 	)
 	c.Assert(err, IsNil)
+	diffDuration := time.Since(startTime.Add(time.Millisecond * time.Duration((delay1 + delay2))))
+
+	// there exists some code running between db exec and prometheus histogram observation,
+	// so we calcuate the diff duration to make the sample_sum check more accurate.
+	var metricFix io_prometheus_client.Metric
+	histogramFix.WithLabelValues("execFix").Observe((time.Millisecond * delay1).Seconds())
+	histogramFix.WithLabelValues("execFix").Observe((time.Millisecond*delay2 + diffDuration).Seconds())
+	err = histogramFix.WithLabelValues("execFix").Write(&metricFix)
+	c.Assert(err, IsNil)
+	upperBound := metricFix.Histogram.GetSampleSum()
 
 	// extract the content of the histogram.
 	var metric io_prometheus_client.Metric
@@ -155,8 +174,8 @@ func (s *sqlSuite) TestExecuteTxnSuccess(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(metric.Histogram.GetSampleCount(), Equals, uint64(2))
 	sum := metric.Histogram.GetSampleSum()
-	c.Assert(sum, GreaterEqual, 0.302)
-	c.Assert(sum, LessEqual, 0.357)
+	c.Assert(sum, Greater, 0.302)
+	c.Assert(sum, Less, upperBound)
 	buckets := metric.Histogram.GetBucket()
 	c.Assert(buckets, HasLen, 5)
 	c.Logf("buckets = %q", buckets)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
In `ExecuteTxn` test, we execute two SQLs with some delay (101ms, 201ms) via sql mock.
the original check range for histogram sample_sum is [0.302, 0.357], these two metrics bound reflect the delay from `txn.Exec(...)` to `histogram.WithLabelValues("exec").Observe(...)`, from  302ms to 357ms.
We can have a more accurate upper bound based on execution time observing from test case. (sometime the execution time may even exceed 357ms)

### What is changed and how it works?
change the check range to (0.302, observing upper bound)

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
