### PR TITLE
pump: Add config to set cap buf of kv_chan

### DIFF
--- a/cmd/pump/pump.toml
+++ b/cmd/pump/pump.toml
@@ -31,6 +31,7 @@ pd-urls = "http://127.0.0.1:2379"
 # Set to `true` (default) for best reliability, which prevents data loss when there is a power failure.
 # sync-log = true
 #
+# kv_chan_cap = 0
 # we suggest using the default config of the embedded LSM DB now, do not change it useless you know what you are doing
 # [storage.kv]
 # block-cache-capacity = 8388608

--- a/cmd/pump/pump.toml
+++ b/cmd/pump/pump.toml
@@ -35,6 +35,7 @@ pd-urls = "http://127.0.0.1:2379"
 # kv_chan_cap = 4194304
 #
 # if pump takes a long time to write binlog, pump will display the binlog meta information
+# now the unit is `Second`
 # slow_write_duration = 2
 #
 # we suggest using the default config of the embedded LSM DB now, do not change it useless you know what you are doing

--- a/cmd/pump/pump.toml
+++ b/cmd/pump/pump.toml
@@ -31,13 +31,6 @@ pd-urls = "http://127.0.0.1:2379"
 # Set to `true` (default) for best reliability, which prevents data loss when there is a power failure.
 # sync-log = true
 #
-# the channel to buffer binlog meta, pump will block write binlog request if the channel is full
-# kv_chan_cap = 4194304
-#
-# if pump takes a long time to write binlog, pump will display the binlog meta information
-# now the unit is `Second`
-# slow_write_duration = 2
-#
 # we suggest using the default config of the embedded LSM DB now, do not change it useless you know what you are doing
 # [storage.kv]
 # block-cache-capacity = 8388608

--- a/cmd/pump/pump.toml
+++ b/cmd/pump/pump.toml
@@ -31,7 +31,12 @@ pd-urls = "http://127.0.0.1:2379"
 # Set to `true` (default) for best reliability, which prevents data loss when there is a power failure.
 # sync-log = true
 #
-# kv_chan_cap = 0
+# the channel to buffer binlog meta, pump will block write binlog request if the channel is full
+# kv_chan_cap = 4194304
+#
+# if pump takes a long time to write binlog, pump will display the binlog meta information
+# slow_write_duration = 2
+#
 # we suggest using the default config of the embedded LSM DB now, do not change it useless you know what you are doing
 # [storage.kv]
 # block-cache-capacity = 8388608

--- a/pump/server.go
+++ b/pump/server.go
@@ -142,8 +142,8 @@ func NewServer(cfg *Config) (*Server, error) {
 	options := storage.DefaultOptions()
 	options = options.WithKVConfig(cfg.Storage.KV)
 	options = options.WithSync(cfg.Storage.GetSyncLog())
-	options = options.WithKVChanCap(cfg.Storage.GetKVChanCap())
-	options = options.WithSlowWriteDuration(cfg.Storage.GetSlowWriteDuration())
+	options = options.WithChanCapacity(cfg.Storage.GetChanCapacity())
+	options = options.WithSlowWriteThreshold(cfg.Storage.GetSlowWriteThreshold())
 
 	storage, err := storage.NewAppendWithResolver(cfg.DataDir, options, tiStore, lockResolver)
 	if err != nil {

--- a/pump/server.go
+++ b/pump/server.go
@@ -142,6 +142,7 @@ func NewServer(cfg *Config) (*Server, error) {
 	options := storage.DefaultOptions()
 	options = options.WithKVConfig(cfg.Storage.KV)
 	options = options.WithSync(cfg.Storage.GetSyncLog())
+	options = options.WithKVChanCap(cfg.Storage.GetKVChanCap())
 
 	storage, err := storage.NewAppendWithResolver(cfg.DataDir, options, tiStore, lockResolver)
 	if err != nil {

--- a/pump/server.go
+++ b/pump/server.go
@@ -143,6 +143,7 @@ func NewServer(cfg *Config) (*Server, error) {
 	options = options.WithKVConfig(cfg.Storage.KV)
 	options = options.WithSync(cfg.Storage.GetSyncLog())
 	options = options.WithKVChanCap(cfg.Storage.GetKVChanCap())
+	options = options.WithSlowWriteDuration(cfg.Storage.GetSlowWriteDuration())
 
 	storage, err := storage.NewAppendWithResolver(cfg.DataDir, options, tiStore, lockResolver)
 	if err != nil {

--- a/pump/server.go
+++ b/pump/server.go
@@ -142,7 +142,7 @@ func NewServer(cfg *Config) (*Server, error) {
 	options := storage.DefaultOptions()
 	options = options.WithKVConfig(cfg.Storage.KV)
 	options = options.WithSync(cfg.Storage.GetSyncLog())
-	options = options.WithChanCapacity(cfg.Storage.GetChanCapacity())
+	options = options.WithKVChanCapacity(cfg.Storage.GetKVChanCapacity())
 	options = options.WithSlowWriteThreshold(cfg.Storage.GetSlowWriteThreshold())
 
 	storage, err := storage.NewAppendWithResolver(cfg.DataDir, options, tiStore, lockResolver)

--- a/pump/storage/storage.go
+++ b/pump/storage/storage.go
@@ -619,7 +619,7 @@ func (a *Append) writeBinlog(binlog *pb.Binlog) *request {
 		}
 
 		if duration > a.options.SlowWriteDuration {
-			log.Warn("take a long time to write binlog", zap.Stringer("binlog type", binlog.Tp), zap.Int64("commit TS", binlog.StartTs), zap.Int64("start TS", binlog.CommitTs), zap.Int("length", len(binlog.PrewriteValue)))
+			log.Warn("take a long time to write binlog", zap.Stringer("binlog type", binlog.Tp), zap.Int64("commit TS", binlog.CommitTs), zap.Int64("start TS", binlog.StartTs), zap.Int("length", len(binlog.PrewriteValue)))
 		}
 	}()
 

--- a/pump/storage/storage.go
+++ b/pump/storage/storage.go
@@ -40,8 +40,10 @@ import (
 
 const (
 	maxTxnTimeoutSecond int64 = 600
-	chanSize                  = 1 << 20
-	slowWriteDuration         = 1.0
+	// the channel to buffer binlog meta, pump will block write binlog request if the channel is full
+	chanSize = 1 << 20
+	// if pump takes a long time to write binlog, pump will display the binlog meta information (unit: Second)
+	slowWriteDuration = 1.0
 )
 
 var (

--- a/pump/storage/storage.go
+++ b/pump/storage/storage.go
@@ -40,8 +40,7 @@ import (
 
 const (
 	maxTxnTimeoutSecond int64 = 600
-	// the channel to buffer binlog meta, pump will block write binlog request if the channel is full
-	chanCapacity = 1 << 20
+	chanCapacity              = 1 << 20
 	// if pump takes a long time to write binlog, pump will display the binlog meta information (unit: Second)
 	slowWriteThreshold = 1.0
 )
@@ -722,7 +721,7 @@ func (a *Append) batchRequest(reqs chan *request, maxBatchNum int) chan []*reque
 }
 
 func (a *Append) writeToValueLog(reqs chan *request) chan *request {
-	done := make(chan *request, a.options.ChanCapacity)
+	done := make(chan *request, a.options.KVChanCapacity)
 
 	go func() {
 		defer close(done)
@@ -1024,19 +1023,20 @@ func getStorageSize(dir string) (size storageSize, err error) {
 
 // Config holds the configuration of storage
 type Config struct {
-	SyncLog            *bool     `toml:"sync-log" json:"sync-log"`
-	ChanCapacity       int       `toml:"kv_chan_cap" json:"kv_chan_cap"`
+	SyncLog *bool `toml:"sync-log" json:"sync-log"`
+	// the channel to buffer binlog meta, pump will block write binlog request if the channel is full
+	KVChanCapacity     int       `toml:"kv_chan_cap" json:"kv_chan_cap"`
 	SlowWriteThreshold float64   `toml:"slow_write_threshold" json:"slow_write_threshold"`
 	KV                 *KVConfig `toml:"kv" json:"kv"`
 }
 
-// GetChanCapacity return kv_chan_cap config option
-func (c *Config) GetChanCapacity() int {
-	if c.ChanCapacity <= 0 {
+// GetKVChanCapacity return kv_chan_cap config option
+func (c *Config) GetKVChanCapacity() int {
+	if c.KVChanCapacity <= 0 {
 		return chanCapacity
 	}
 
-	return c.ChanCapacity
+	return c.KVChanCapacity
 }
 
 // GetSlowWriteThreshold return slow write threshold

--- a/pump/storage/storage.go
+++ b/pump/storage/storage.go
@@ -135,7 +135,7 @@ func NewAppendWithResolver(dir string, options *Options, tiStore kv.Storage, tiL
 		return nil, errors.Trace(err)
 	}
 
-	writeCh := make(chan *request, chanSize)
+	writeCh := make(chan *request, options.KVChanCap)
 	append = &Append{
 		dir:            dir,
 		vlog:           vlog,
@@ -1016,8 +1016,18 @@ func getStorageSize(dir string) (size storageSize, err error) {
 
 // Config holds the configuration of storage
 type Config struct {
-	SyncLog *bool     `toml:"sync-log" json:"sync-log"`
-	KV      *KVConfig `toml:"kv" json:"kv"`
+	SyncLog   *bool     `toml:"sync-log" json:"sync-log"`
+	KVChanCap int       `toml:"kv_chan_cap" json:"kv_chan_cap"`
+	KV        *KVConfig `toml:"kv" json:"kv"`
+}
+
+// GetKVChanCap return kv_chan_cap config option
+func (c *Config) GetKVChanCap() int {
+	if c.KVChanCap <= 0 {
+		return chanSize
+	}
+
+	return c.KVChanCap
 }
 
 // GetSyncLog return sync-log config option

--- a/pump/storage/vlog.go
+++ b/pump/storage/vlog.go
@@ -44,7 +44,7 @@ const (
 type Options struct {
 	ValueLogFileSize   int64
 	Sync               bool
-	ChanCapacity       int
+	KVChanCapacity     int
 	SlowWriteThreshold float64
 
 	KVConfig *KVConfig
@@ -55,7 +55,7 @@ func DefaultOptions() *Options {
 	return &Options{
 		ValueLogFileSize:   500 * (1 << 20),
 		Sync:               true,
-		ChanCapacity:       chanCapacity,
+		KVChanCapacity:     chanCapacity,
 		SlowWriteThreshold: slowWriteThreshold,
 	}
 }
@@ -78,9 +78,9 @@ func (o *Options) WithValueLogFileSize(size int64) *Options {
 	return o
 }
 
-// WithChanCapacity set the ChanCapacity
-func (o *Options) WithChanCapacity(capacity int) *Options {
-	o.ChanCapacity = capacity
+// WithKVChanCapacity set the ChanCapacity
+func (o *Options) WithKVChanCapacity(capacity int) *Options {
+	o.KVChanCapacity = capacity
 	return o
 }
 

--- a/pump/storage/vlog.go
+++ b/pump/storage/vlog.go
@@ -44,6 +44,7 @@ const (
 type Options struct {
 	ValueLogFileSize int64
 	Sync             bool
+	KVChanCap        int
 
 	KVConfig *KVConfig
 }
@@ -65,6 +66,12 @@ func (o *Options) WithKVConfig(kvConfig *KVConfig) *Options {
 // WithValueLogFileSize set the ValueLogFileSize
 func (o *Options) WithValueLogFileSize(size int64) *Options {
 	o.ValueLogFileSize = size
+	return o
+}
+
+// WithKVChanCap set the KVChanCap
+func (o *Options) WithKVChanCap(size int) *Options {
+	o.KVChanCap = size
 	return o
 }
 

--- a/pump/storage/vlog.go
+++ b/pump/storage/vlog.go
@@ -42,9 +42,10 @@ const (
 
 // Options is the config options of Append and vlog
 type Options struct {
-	ValueLogFileSize int64
-	Sync             bool
-	KVChanCap        int
+	ValueLogFileSize  int64
+	Sync              bool
+	KVChanCap         int
+	SlowWriteDuration float64
 
 	KVConfig *KVConfig
 }
@@ -52,14 +53,22 @@ type Options struct {
 // DefaultOptions return the default options
 func DefaultOptions() *Options {
 	return &Options{
-		ValueLogFileSize: 500 * (1 << 20),
-		Sync:             true,
+		ValueLogFileSize:  500 * (1 << 20),
+		Sync:              true,
+		KVChanCap:         chanSize,
+		SlowWriteDuration: slowWriteDuration,
 	}
 }
 
 // WithKVConfig set the Config
 func (o *Options) WithKVConfig(kvConfig *KVConfig) *Options {
 	o.KVConfig = kvConfig
+	return o
+}
+
+// WithSlowWriteDuration set the Config
+func (o *Options) WithSlowWriteDuration(duration float64) *Options {
+	o.SlowWriteDuration = duration
 	return o
 }
 

--- a/pump/storage/vlog.go
+++ b/pump/storage/vlog.go
@@ -42,10 +42,10 @@ const (
 
 // Options is the config options of Append and vlog
 type Options struct {
-	ValueLogFileSize  int64
-	Sync              bool
-	KVChanCap         int
-	SlowWriteDuration float64
+	ValueLogFileSize   int64
+	Sync               bool
+	ChanCapacity       int
+	SlowWriteThreshold float64
 
 	KVConfig *KVConfig
 }
@@ -53,10 +53,10 @@ type Options struct {
 // DefaultOptions return the default options
 func DefaultOptions() *Options {
 	return &Options{
-		ValueLogFileSize:  500 * (1 << 20),
-		Sync:              true,
-		KVChanCap:         chanSize,
-		SlowWriteDuration: slowWriteDuration,
+		ValueLogFileSize:   500 * (1 << 20),
+		Sync:               true,
+		ChanCapacity:       chanCapacity,
+		SlowWriteThreshold: slowWriteThreshold,
 	}
 }
 
@@ -66,9 +66,9 @@ func (o *Options) WithKVConfig(kvConfig *KVConfig) *Options {
 	return o
 }
 
-// WithSlowWriteDuration set the Config
-func (o *Options) WithSlowWriteDuration(duration float64) *Options {
-	o.SlowWriteDuration = duration
+// WithSlowWriteThreshold set the Config
+func (o *Options) WithSlowWriteThreshold(threshold float64) *Options {
+	o.SlowWriteThreshold = threshold
 	return o
 }
 
@@ -78,9 +78,9 @@ func (o *Options) WithValueLogFileSize(size int64) *Options {
 	return o
 }
 
-// WithKVChanCap set the KVChanCap
-func (o *Options) WithKVChanCap(size int) *Options {
-	o.KVChanCap = size
+// WithChanCapacity set the ChanCapacity
+func (o *Options) WithChanCapacity(capacity int) *Options {
+	o.ChanCapacity = capacity
 	return o
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
let user to set 
* the kv channel capacity to buffer  more binlog meta
* output binlog meta information if pump take a long time to write binlog


### What is changed and how it works?
add configuration items for pump storage under [storage] configuration

``` 
# the channel to buffer binlog meta, pump will block write binlog request if the channel is full
# kv_chan_cap = 4194304
#
# if pump takes a long time to write binlog, pump will display the binlog meta information
# slow_write_threshold = 2
```


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Manual test (add detailed scripts or steps below)