### PR TITLE
tests: Reduce binlog_big test txn data

### DIFF
--- a/tests/dailytest/case.go
+++ b/tests/dailytest/case.go
@@ -229,10 +229,10 @@ func RunCase(src *sql.DB, dst *sql.DB, schema string) {
 		if err != nil {
 			log.S().Fatal(err)
 		}
-		// insert 50 * 1M
+		// insert 5 * 1M
 		// note limitation of TiDB: https://github.com/pingcap/docs/blob/733a5b0284e70c5b4d22b93a818210a3f6fbb5a0/FAQ.md#the-error-message-transaction-too-large-is-displayed
 		var data = make([]byte, 1<<20)
-		for i := 0; i < 50; i++ {
+		for i := 0; i < 5; i++ {
 			_, err = tx.Query("INSERT INTO binlog_big(id, data) VALUES(?, ?);", i, data)
 			if err != nil {
 				log.S().Fatal(err)


### PR DESCRIPTION
easy to meet "TiKV Server timeout" at CI while commit this txn

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
easy to meet "TiKV Server timeout" at CI while commit this txn

### What is changed and how it works?
reduce txn size of test case binlog_big

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Code changes

Side effects

Related changes

