### PR TITLE
pkg/binlogfile: Fix test

### DIFF
--- a/pkg/binlogfile/binlogger.go
+++ b/pkg/binlogfile/binlogger.go
@@ -338,7 +338,7 @@ func (b *binlogger) GC(days time.Duration, pos binlog.Pos) {
 		} else if time.Since(fi.ModTime()) > days {
 			log.Warn(
 				"binlog file is old enough to be garbage collected, but the position is behind the safe point",
-				zap.String("name", fileName), zap.Any("position", pos))
+				zap.String("name", fileName), zap.Stringer("position", &pos))
 		}
 	}
 }

--- a/pkg/binlogfile/binlogger.go
+++ b/pkg/binlogfile/binlogger.go
@@ -336,7 +336,9 @@ func (b *binlogger) GC(days time.Duration, pos binlog.Pos) {
 			}
 			log.Info("GC binlog file", zap.String("file name", fileName))
 		} else if time.Since(fi.ModTime()) > days {
-			log.Warn("binlog file is already reach the gc time, but data is not send to kafka, position is %v", zap.String("name", fileName), zap.Reflect("position", pos))
+			log.Warn(
+				"binlog file is old enough to be garbage collected, but the position is behind the safe point",
+				zap.String("name", fileName), zap.Any("position", pos))
 		}
 	}
 }

--- a/pkg/binlogfile/binlogger_test.go
+++ b/pkg/binlogfile/binlogger_test.go
@@ -232,7 +232,7 @@ func (s *testBinloggerSuite) TestGC(c *C) {
 		c.Assert(suffix, Equals, uint64(i))
 	}
 
-	// The one with index 0 should be collected
+	// The one with index 0 should be garbage collected
 	b.GC(time.Millisecond, binlog.Pos{Suffix: 1})
 	names, err = ReadBinlogNames(b.dir)
 	c.Assert(err, IsNil)

--- a/pkg/binlogfile/binlogger_test.go
+++ b/pkg/binlogfile/binlogger_test.go
@@ -206,6 +206,7 @@ func (s *testBinloggerSuite) TestGC(c *C) {
 	dir := c.MkDir()
 	bl, err := OpenBinlogger(dir)
 	c.Assert(err, IsNil)
+	// 1. A binlog file with index 0 is created at this point
 	defer func() {
 		err := CloseBinlogger(bl)
 		c.Assert(err, IsNil)
@@ -214,16 +215,31 @@ func (s *testBinloggerSuite) TestGC(c *C) {
 	b, ok := bl.(*binlogger)
 	c.Assert(ok, IsTrue)
 	err = b.rotate()
+	// 2. rotate creates a new binlog file with index 1
 	c.Assert(err, IsNil)
 
+	// No binlog files should be collected,
+	// because both of the files has an index that's >= 0
 	time.Sleep(10 * time.Millisecond)
-	b.GC(time.Millisecond, binlog.Pos{})
+	b.GC(time.Millisecond, binlog.Pos{Suffix: 0})
 
 	names, err := ReadBinlogNames(b.dir)
 	c.Assert(err, IsNil)
 	c.Assert(names, HasLen, 2)
-	c.Assert(names[0], Equals, BinlogName(0))
-	c.Assert(names[1], Equals, BinlogName(1))
+	for i, name := range names {
+		suffix, _, err := ParseBinlogName(name)
+		c.Assert(err, IsNil)
+		c.Assert(suffix, Equals, uint64(i))
+	}
+
+	// The one with index 0 should be collected
+	b.GC(time.Millisecond, binlog.Pos{Suffix: 1})
+	names, err = ReadBinlogNames(b.dir)
+	c.Assert(err, IsNil)
+	c.Assert(names, HasLen, 1)
+	suffix, _, err := ParseBinlogName(names[0])
+	c.Assert(err, IsNil)
+	c.Assert(suffix, Equals, uint64(1))
 }
 
 func (s *testBinloggerSuite) TestSeekBinlog(c *C) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->


One of the unit tests of pkg/binlogfile sometimes
[fails](https://internal.pingcap.net/idc-jenkins/blue/organizations/jenkins/binlog_ghpr_unit_test/detail/binlog_ghpr_unit_test/476/pipeline/):

```
[2019/06/14 09:57:29.008 +08:00] [WARN] [binlogger.go:339] ["binlog file
is already reach the gc time, but data is not send to kafka, position is
%v"]
[name=/tmp/check-6129484611666145821/2/binlog-0000000000000000-20190614095728]
[position={}]


----------------------------------------------------------------------

FAIL: binlogger_test.go:205: testBinloggerSuite.TestGC


binlogger_test.go:225:

    c.Assert(names[0], Equals, BinlogName(0))

... obtained string = "binlog-0000000000000000-20190614095728"

... expected string = "binlog-0000000000000000-20190614095729"
```

### What is changed and how it works?

Don't use `BinlogName` when checking the result, because it calls
`time.Now` under the hood and may return different names for the same
index.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes


Side effects


Related changes