### PR TITLE
pump: Allow 127.0.0.1 for advertise-addr

### DIFF
--- a/pump/config.go
+++ b/pump/config.go
@@ -205,11 +205,8 @@ func (cfg *Config) validate() error {
 	if err != nil {
 		return errors.Errorf("bad AdvertiseAddr host format: %s, %v", urladv.Host, err)
 	}
-	if !util.IsValidateListenHost(host) || host == "0.0.0.0" {
-		isTestEnv := os.Getenv("BINLOG_TEST") == "1"
-		if !(isTestEnv && host == "127.0.0.1") {
-			return errors.Errorf("invalid advertiseAddr host: %v", host)
-		}
+	if len(host) == 0 || host == "0.0.0.0" {
+		return errors.Errorf("invalid advertiseAddr host: %v", host)
 	}
 
 	// check socketAddr

--- a/pump/config_test.go
+++ b/pump/config_test.go
@@ -40,15 +40,9 @@ func (s *testConfigSuite) TestValidate(c *C) {
 	err = cfg.validate()
 	c.Check(err, ErrorMatches, ".*advertiseAddr.*")
 
-	os.Setenv("BINLOG_TEST", "1")
 	cfg.AdvertiseAddr = "http://127.0.0.1:8250"
 	err = cfg.validate()
 	c.Check(err, IsNil)
-
-	os.Unsetenv("BINLOG_TEST")
-	cfg.AdvertiseAddr = "http://127.0.0.1:8250"
-	err = cfg.validate()
-	c.Check(err, ErrorMatches, ".*advertiseAddr.*")
 
 	cfg.AdvertiseAddr = "http://192.168.11.11:8250"
 	err = cfg.validate()


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Allow 127.0.0.1 for testing.


### What is changed and how it works?

Check for empty host and 0.0.0.0 explicitly.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes


Side effects


Related changes