### PR TITLE
drainer: Log version info before other logs, fix #242

### DIFF
--- a/cmd/drainer/main.go
+++ b/cmd/drainer/main.go
@@ -34,6 +34,8 @@ func main() {
 	runtime.GOMAXPROCS(runtime.NumCPU())
 	rand.Seed(time.Now().UTC().UnixNano())
 
+	version.PrintVersionInfo("Drainer")
+
 	cfg := drainer.NewConfig()
 	if err := cfg.Parse(os.Args[1:]); err != nil {
 		log.Fatal("verifying flags failed, See 'drainer --help'.", zap.Error(err))
@@ -42,7 +44,6 @@ func main() {
 	if err := util.InitLogger(cfg.LogLevel, cfg.LogFile); err != nil {
 		log.Fatal("Failed to initialize log", zap.Error(err))
 	}
-	version.PrintVersionInfo("Drainer")
 	log.Info("start drainer...", zap.Reflect("config", cfg))
 
 	bs, err := drainer.NewServer(cfg)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix issue #242.

Make sure users can see which version of drainer they are using easily,
even when it fails to start because of misconfiguration.

### What is changed and how it works?

Log version info when drainer is started.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test
   Added an invalid `zookeeper-addrs` to drainer.toml and make sure that
the version info was still outputed.

Code changes


Side effects


Related changes