### PR TITLE
vlog.go: Fix wrongly maintain the offset of file in memory (#640)

### DIFF
--- a/pump/storage/vlog.go
+++ b/pump/storage/vlog.go
@@ -298,6 +298,8 @@ func (vlog *valueLog) write(reqs []*request) error {
 
 	toDisk := func() error {
 		n, err := curFile.fd.Write(vlog.buf.Bytes())
+		atomic.AddInt64(&vlog.writableLogOffset, int64(n))
+
 		if err != nil {
 			return errors.Annotatef(err, "unable to write to log file: %s", curFile.path)
 		}
@@ -308,7 +310,6 @@ func (vlog *valueLog) write(reqs []*request) error {
 			}
 		}
 
-		atomic.AddInt64(&vlog.writableLogOffset, int64(n))
 		for _, req := range bufReqs {
 			curFile.updateMaxTS(req.ts())
 		}

--- a/pump/storage/vlog_test.go
+++ b/pump/storage/vlog_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path"
 	"strconv"
+	"syscall"
 	"time"
 
 	fuzz "github.com/google/gofuzz"
@@ -208,4 +209,60 @@ func (vps *ValuePointerSuite) TestValuePointerMarshalBinary(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	c.Assert(vp, check.Equals, expect)
+}
+
+// Test when no disk space write fail
+// and should recover after disk space are free up
+// set file size resource limit to make it write fail like no disk space
+func (vs *VlogSuit) TestNoSpace(c *check.C) {
+	dir := c.MkDir()
+	c.Log("use dir: ", dir)
+
+	var origRlimit syscall.Rlimit
+	err := syscall.Getrlimit(syscall.RLIMIT_FSIZE, &origRlimit)
+	c.Assert(err, check.IsNil)
+
+	// set file size limit to be 20k
+	err = syscall.Setrlimit(syscall.RLIMIT_FSIZE, &syscall.Rlimit{Cur: 20 * 1024, Max: origRlimit.Max})
+	c.Assert(err, check.IsNil)
+
+	defer func() {
+		err = syscall.Setrlimit(syscall.RLIMIT_FSIZE, &origRlimit)
+		c.Assert(err, check.IsNil)
+	}()
+
+	vlog := new(valueLog)
+	err = vlog.open(dir, DefaultOptions())
+	c.Assert(err, check.IsNil)
+
+	// 1k payload per record
+	payload := make([]byte, 1024)
+	req := &request{
+		payload: payload,
+	}
+
+	// should be enough space to write 19 records
+	for i := 0; i < 19; i++ {
+		err = vlog.write([]*request{req})
+		c.Assert(err, check.IsNil)
+	}
+
+	// failed because only 20k space available and may write a incomplete record
+	err = vlog.write([]*request{req})
+	c.Assert(err, check.NotNil)
+
+	// increase file size limit to be 40k
+	err = syscall.Setrlimit(syscall.RLIMIT_FSIZE, &syscall.Rlimit{Cur: 40 * 1024, Max: origRlimit.Max})
+	c.Assert(err, check.IsNil)
+
+	// should write success now
+	err = vlog.write([]*request{req})
+	c.Assert(err, check.IsNil)
+
+	// read back normally
+	_, err = vlog.readValue(req.valuePointer)
+	c.Assert(err, check.IsNil)
+
+	err = vlog.close()
+	c.Assert(err, check.IsNil)
 }


### PR DESCRIPTION


<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
cherry-pick https://github.com/pingcap/tidb-binlog/pull/640


### What is changed and how it works?
cherry-pick https://github.com/pingcap/tidb-binlog/pull/640

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
Code changes

Side effects

 Related changes

- Need to be included in the release note