### PR TITLE
binlogctl: return error when cmd not supported

### DIFF
--- a/cmd/binlogctl/main.go
+++ b/cmd/binlogctl/main.go
@@ -17,6 +17,7 @@ import (
 	"flag"
 	"os"
 
+	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
 	ctl "github.com/pingcap/tidb-binlog/binlogctl"
 	"github.com/pingcap/tidb-binlog/pkg/node"
@@ -59,6 +60,8 @@ func main() {
 		err = ctl.ApplyAction(cfg.EtcdURLs, node.PumpNode, cfg.NodeID, close)
 	case ctl.OfflineDrainer:
 		err = ctl.ApplyAction(cfg.EtcdURLs, node.DrainerNode, cfg.NodeID, close)
+	default:
+		err = errors.Errorf("cmd %s not supported", cfg.Command)
 	}
 
 	if err != nil {

--- a/cmd/binlogctl/main.go
+++ b/cmd/binlogctl/main.go
@@ -61,7 +61,7 @@ func main() {
 	case ctl.OfflineDrainer:
 		err = ctl.ApplyAction(cfg.EtcdURLs, node.DrainerNode, cfg.NodeID, close)
 	default:
-		err = errors.Errorf("cmd %s not supported", cfg.Command)
+		err = errors.NotSupportedf("cmd %s", cfg.Command)
 	}
 
 	if err != nil {


### PR DESCRIPTION

### What problem does this PR solve? <!--add issue link with summary if exists-->
binlogctl not return error when cmd is not supported



### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test

Related changes

 - Need to cherry-pick to the release branch