### PR TITLE
Revert "drainer: Log version info before other logs, fix #242"

### DIFF
--- a/cmd/drainer/main.go
+++ b/cmd/drainer/main.go
@@ -34,8 +34,6 @@ func main() {
 	runtime.GOMAXPROCS(runtime.NumCPU())
 	rand.Seed(time.Now().UTC().UnixNano())
 
-	version.PrintVersionInfo("Drainer")
-
 	cfg := drainer.NewConfig()
 	if err := cfg.Parse(os.Args[1:]); err != nil {
 		log.Fatal("verifying flags failed, See 'drainer --help'.", zap.Error(err))
@@ -44,6 +42,7 @@ func main() {
 	if err := util.InitLogger(cfg.LogLevel, cfg.LogFile); err != nil {
 		log.Fatal("Failed to initialize log", zap.Error(err))
 	}
+	version.PrintVersionInfo("Drainer")
 	log.Info("start drainer...", zap.Reflect("config", cfg))
 
 	bs, err := drainer.NewServer(cfg)


### PR DESCRIPTION
Reverts pingcap/tidb-binlog#638

it alway log the `[2019/06/21 21:12:25.917 +08:00] [INFO] [version.go:50.....`
```
➜  bin git:(master) ✗ ./drainer -V
[2019/06/21 21:12:25.917 +08:00] [INFO] [version.go:50] ["Welcome to Drainer"] ["Release Version"=v3.0.0-rc.2-18-ge77e090d] ["Git Commit Hash"=e77e090d6c7843e4226f91825bcfd5564b4f4837] ["Build TS"="2019-06-21 01:06:43"] ["Go Version"=go1.12.5] ["Go OS/Arch"=darwin/amd64]
Release Version: v3.0.0-rc.2-18-ge77e090d
Git Commit Hash: e77e090d6c7843e4226f91825bcfd5564b4f4837
Build TS: 2019-06-21 01:06:43
Go Version: go1.12.5
Go OS/Arch: darwin/amd64

➜  bin git:(master) ✗ ./drainer -h
[2019/06/21 21:12:28.587 +08:00] [INFO] [version.go:50] ["Welcome to Drainer"] ["Release Version"=v3.0.0-rc.2-18-ge77e090d] ["Git Commit Hash"=e77e090d6c7843e4226f91825bcfd5564b4f4837] ["Build TS"="2019-06-21 01:06:43"] ["Go Version"=go1.12.5] ["Go OS/Arch"=darwin/amd64]
Usage of drainer:
  -L string
    	log level: debug, info, warn, error, fatal (default "info")
  -V	print version information and exit
```