### PR TITLE
pump: Add support to stop write at a limit avaliable space

### DIFF
--- a/cmd/binlogctl/main.go
+++ b/cmd/binlogctl/main.go
@@ -17,6 +17,7 @@ import (
 	"flag"
 	"os"
 
+	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
 	ctl "github.com/pingcap/tidb-binlog/binlogctl"
 	"github.com/pingcap/tidb-binlog/pkg/node"
@@ -59,6 +60,8 @@ func main() {
 		err = ctl.ApplyAction(cfg.EtcdURLs, node.PumpNode, cfg.NodeID, close)
 	case ctl.OfflineDrainer:
 		err = ctl.ApplyAction(cfg.EtcdURLs, node.DrainerNode, cfg.NodeID, close)
+	default:
+		err = errors.NotSupportedf("cmd %s", cfg.Command)
 	}
 
 	if err != nil {

--- a/cmd/pump/pump.toml
+++ b/cmd/pump/pump.toml
@@ -33,8 +33,8 @@ pd-urls = "http://127.0.0.1:2379"
 
 # stop write when disk available space less then the configured size
 # 42 MB -> 42000000, 42 mib -> 44040192
-# default: 1 gib
-# stop-write-at-available-space = "1 gib"
+# default: 10 gib
+# stop-write-at-available-space = "10 gib"
 
 #
 # we suggest using the default config of the embedded LSM DB now, do not change it useless you know what you are doing

--- a/cmd/pump/pump.toml
+++ b/cmd/pump/pump.toml
@@ -30,6 +30,12 @@ pd-urls = "http://127.0.0.1:2379"
 # [storage]
 # Set to `true` (default) for best reliability, which prevents data loss when there is a power failure.
 # sync-log = true
+
+# stop write when disk available space less then the configured size
+# 42 MB -> 42000000, 42 mib -> 44040192
+# default: 1 gib
+# stop-write-at-available-space = "1 gib"
+
 #
 # we suggest using the default config of the embedded LSM DB now, do not change it useless you know what you are doing
 # [storage.kv]

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Shopify/toxiproxy v2.1.3+incompatible // indirect
 	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd // indirect
 	github.com/coreos/etcd v3.3.0-rc.0.0.20180530235116-2b3aa7e1d49d+incompatible
-	github.com/dustin/go-humanize v1.0.0 // indirect
+	github.com/dustin/go-humanize v1.0.0
 	github.com/eapache/go-resiliency v1.1.0 // indirect
 	github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21 // indirect
 	github.com/eapache/queue v0.0.0-20180227141424-093482f3f8ce // indirect

--- a/pump/server.go
+++ b/pump/server.go
@@ -146,6 +146,7 @@ func NewServer(cfg *Config) (*Server, error) {
 	options = options.WithSync(cfg.Storage.GetSyncLog())
 	options = options.WithKVChanCapacity(cfg.Storage.GetKVChanCapacity())
 	options = options.WithSlowWriteThreshold(cfg.Storage.GetSlowWriteThreshold())
+	options = options.WithStopWriteAtAvailableSpace(cfg.Storage.GetStopWriteAtAvailableSpace())
 
 	storage, err := storage.NewAppendWithResolver(cfg.DataDir, options, tiStore, lockResolver)
 	if err != nil {
@@ -177,12 +178,6 @@ func NewServer(cfg *Config) (*Server, error) {
 
 // WriteBinlog implements the gRPC interface of pump server
 func (s *Server) WriteBinlog(ctx context.Context, in *binlog.WriteBinlogReq) (*binlog.WriteBinlogResp, error) {
-	// pump client will write some empty Payload to detect whether pump is working, should avoid this
-	if in.Payload == nil {
-		ret := new(binlog.WriteBinlogResp)
-		return ret, nil
-	}
-
 	atomic.AddInt64(&s.writeBinlogCount, 1)
 	return s.writeBinlog(ctx, in, false)
 }

--- a/pump/server_test.go
+++ b/pump/server_test.go
@@ -46,14 +46,6 @@ type writeBinlogSuite struct{}
 
 var _ = Suite(&writeBinlogSuite{})
 
-func (s *writeBinlogSuite) TestIgnoreEmptyRequest(c *C) {
-	server := &Server{}
-	resp, err := server.WriteBinlog(context.Background(), &binlog.WriteBinlogReq{})
-	c.Assert(resp, NotNil)
-	c.Assert(err, IsNil)
-	c.Assert(server.writeBinlogCount, Equals, int64(0))
-}
-
 func (s *writeBinlogSuite) TestReturnErrIfClusterIDMismatched(c *C) {
 	server := &Server{clusterID: 42}
 	req := &binlog.WriteBinlogReq{}

--- a/pump/storage/errors.go
+++ b/pump/storage/errors.go
@@ -18,4 +18,7 @@ import "github.com/pingcap/errors"
 var (
 	// ErrWrongMagic means the magic number mismatch
 	ErrWrongMagic = errors.New("wrong magic")
+
+	// ErrNoAvailableSpace means no available space
+	ErrNoAvailableSpace = errors.New("no available space")
 )

--- a/pump/storage/storage.go
+++ b/pump/storage/storage.go
@@ -317,10 +317,11 @@ func (a *Append) updateSize() error {
 	size, err := getStorageSize(a.dir)
 	if err != nil {
 		return errors.Annotate(err, "update storage size failed")
-	} else {
-		storageSizeGauge.WithLabelValues("capacity").Set(float64(size.capacity))
-		storageSizeGauge.WithLabelValues("available").Set(float64(size.available))
 	}
+
+	storageSizeGauge.WithLabelValues("capacity").Set(float64(size.capacity))
+	storageSizeGauge.WithLabelValues("available").Set(float64(size.available))
+
 	atomic.StoreUint64(&a.storageSize.available, size.available)
 	atomic.StoreUint64(&a.storageSize.capacity, size.capacity)
 	return nil

--- a/pump/storage/storage.go
+++ b/pump/storage/storage.go
@@ -43,7 +43,8 @@ const (
 	maxTxnTimeoutSecond int64 = 600
 	chanCapacity              = 1 << 20
 	// if pump takes a long time to write binlog, pump will display the binlog meta information (unit: Second)
-	slowWriteThreshold = 1.0
+	slowWriteThreshold               = 1.0
+	defaultStopWriteAtAvailableSpace = 1 << 30
 )
 
 var (
@@ -80,8 +81,9 @@ var _ Storage = &Append{}
 
 // Append implement the Storage interface
 type Append struct {
-	dir  string
-	vlog *valueLog
+	dir         string
+	vlog        *valueLog
+	storageSize storageSize
 
 	metadata       *leveldb.DB
 	sorter         *sorter
@@ -223,6 +225,11 @@ func NewAppendWithResolver(dir string, options *Options, tiStore kv.Storage, tiL
 	}
 
 	append.wg.Add(1)
+	err = append.updateSize()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	go append.updateStatus()
 	return
 }
@@ -306,6 +313,19 @@ func (a *Append) handleSortItem(items <-chan sortItem) (quit chan struct{}) {
 	return quit
 }
 
+func (a *Append) updateSize() error {
+	size, err := getStorageSize(a.dir)
+	if err != nil {
+		return errors.Annotate(err, "update storage size failed")
+	} else {
+		storageSizeGauge.WithLabelValues("capacity").Set(float64(size.capacity))
+		storageSizeGauge.WithLabelValues("available").Set(float64(size.available))
+	}
+	atomic.StoreUint64(&a.storageSize.available, size.available)
+	atomic.StoreUint64(&a.storageSize.capacity, size.capacity)
+	return nil
+}
+
 func (a *Append) updateStatus() {
 	defer a.wg.Done()
 
@@ -335,12 +355,9 @@ func (a *Append) updateStatus() {
 				atomic.StoreInt64(&a.latestTS, ts)
 			}
 		case <-updateSize:
-			size, err := getStorageSize(a.dir)
+			err := a.updateSize()
 			if err != nil {
-				log.Error("update sotrage size failed", zap.Error(err))
-			} else {
-				storageSizeGauge.WithLabelValues("capacity").Set(float64(size.capacity))
-				storageSizeGauge.WithLabelValues("available").Set(float64(size.available))
+				log.Error("update size failed", zap.Error(err))
 			}
 		case <-logStatsTicker.C:
 			var stats leveldb.DBStats
@@ -355,6 +372,10 @@ func (a *Append) updateStatus() {
 			}
 		}
 	}
+}
+
+func (a *Append) writableOfSpace() bool {
+	return atomic.LoadUint64(&a.storageSize.available) > a.options.StopWriteAtAvailableSpace
 }
 
 // Write a commit binlog myself if the status is committed,
@@ -665,8 +686,25 @@ func (a *Append) MaxCommitTS() int64 {
 	return atomic.LoadInt64(&a.maxCommitTS)
 }
 
+func isFakeBinlog(binlog *pb.Binlog) bool {
+	return binlog.StartTs > 0 && binlog.StartTs == binlog.CommitTs
+}
+
 // WriteBinlog implement Storage.WriteBinlog
 func (a *Append) WriteBinlog(binlog *pb.Binlog) error {
+	if !a.writableOfSpace() {
+		// still accept fake binlog, so will not block drainer if fake binlog writes success
+		if !isFakeBinlog(binlog) {
+			return ErrNoAvailableSpace
+		}
+	}
+
+	// pump client will write some empty Payload to detect whether pump is working, should avoid this
+	// Unmarshal(nil) will success...
+	if binlog.StartTs == 0 && binlog.CommitTs == 0 {
+		return nil
+	}
+
 	return errors.Trace(a.writeBinlog(binlog).err)
 }
 
@@ -1049,8 +1087,8 @@ func (a *Append) PullCommitBinlog(ctx context.Context, last int64) <-chan []byte
 }
 
 type storageSize struct {
-	capacity  int
-	available int
+	capacity  uint64
+	available uint64
 }
 
 func getStorageSize(dir string) (size storageSize, err error) {
@@ -1077,8 +1115,8 @@ func getStorageSize(dir string) (size storageSize, err error) {
 	}
 
 	// Available blocks * size per block = available space in bytes
-	size.available = int(stat.Bavail) * int(bSize)
-	size.capacity = int(stat.Blocks) * int(bSize)
+	size.available = stat.Bavail * bSize
+	size.capacity = stat.Blocks * bSize
 
 	return
 }
@@ -1087,9 +1125,10 @@ func getStorageSize(dir string) (size storageSize, err error) {
 type Config struct {
 	SyncLog *bool `toml:"sync-log" json:"sync-log"`
 	// the channel to buffer binlog meta, pump will block write binlog request if the channel is full
-	KVChanCapacity     int       `toml:"kv_chan_cap" json:"kv_chan_cap"`
-	SlowWriteThreshold float64   `toml:"slow_write_threshold" json:"slow_write_threshold"`
-	KV                 *KVConfig `toml:"kv" json:"kv"`
+	KVChanCapacity            int            `toml:"kv_chan_cap" json:"kv_chan_cap"`
+	SlowWriteThreshold        float64        `toml:"slow_write_threshold" json:"slow_write_threshold"`
+	KV                        *KVConfig      `toml:"kv" json:"kv"`
+	StopWriteAtAvailableSpace *HumanizeBytes `toml:"stop-write-at-available-space" json:"stop-write-at-available-space"`
 }
 
 // GetKVChanCapacity return kv_chan_cap config option
@@ -1108,6 +1147,15 @@ func (c *Config) GetSlowWriteThreshold() float64 {
 	}
 
 	return c.SlowWriteThreshold
+}
+
+// GetStopWriteAtAvailableSpace return stop write available space
+func (c *Config) GetStopWriteAtAvailableSpace() uint64 {
+	if c.StopWriteAtAvailableSpace == nil {
+		return defaultStopWriteAtAvailableSpace
+	}
+
+	return c.StopWriteAtAvailableSpace.Uint64()
 }
 
 // GetSyncLog return sync-log config option

--- a/pump/storage/storage.go
+++ b/pump/storage/storage.go
@@ -44,7 +44,7 @@ const (
 	chanCapacity              = 1 << 20
 	// if pump takes a long time to write binlog, pump will display the binlog meta information (unit: Second)
 	slowWriteThreshold               = 1.0
-	defaultStopWriteAtAvailableSpace = 1 << 30
+	defaultStopWriteAtAvailableSpace = 10 * (1 << 30)
 )
 
 var (
@@ -316,7 +316,7 @@ func (a *Append) handleSortItem(items <-chan sortItem) (quit chan struct{}) {
 func (a *Append) updateSize() error {
 	size, err := getStorageSize(a.dir)
 	if err != nil {
-		return errors.Annotate(err, "update storage size failed")
+		return errors.Annotatef(err, "update storage size failed, dir: %s", a.dir)
 	}
 
 	storageSizeGauge.WithLabelValues("capacity").Set(float64(size.capacity))

--- a/pump/storage/util.go
+++ b/pump/storage/util.go
@@ -60,7 +60,7 @@ func (b *HumanizeBytes) UnmarshalText(text []byte) error {
 
 	n, err := humanize.ParseBytes(string(text))
 	if err != nil {
-		return errors.Annotatef(err, "test: %s", string(text))
+		return errors.Annotatef(err, "text: %s", string(text))
 	}
 
 	*b = HumanizeBytes(n)

--- a/pump/storage/util.go
+++ b/pump/storage/util.go
@@ -16,6 +16,8 @@ package storage
 import (
 	"encoding/binary"
 	"sync/atomic"
+
+	"github.com/dustin/go-humanize"
 )
 
 var tsKeyPrefix = []byte("ts:")
@@ -36,6 +38,30 @@ func encodeTSKey(ts int64) []byte {
 	binary.BigEndian.PutUint64(b, uint64(ts))
 
 	return buf
+}
+
+type HumanizeBytes uint64
+
+func (b HumanizeBytes) Uint64() uint64 {
+	return uint64(b)
+}
+
+// UnmarshalText implements UnmarshalText
+func (b *HumanizeBytes) UnmarshalText(text []byte) error {
+	var err error
+
+	if len(text) == 0 {
+		*b = 0
+		return nil
+	}
+
+	n, err := humanize.ParseBytes(string(text))
+	if err != nil {
+		return err
+	}
+
+	*b = HumanizeBytes(n)
+	return nil
 }
 
 // test helper

--- a/pump/storage/util.go
+++ b/pump/storage/util.go
@@ -40,8 +40,10 @@ func encodeTSKey(ts int64) []byte {
 	return buf
 }
 
+// HumanizeBytes is used for humanize configure
 type HumanizeBytes uint64
 
+// Uint64 return bytes
 func (b HumanizeBytes) Uint64() uint64 {
 	return uint64(b)
 }

--- a/pump/storage/util.go
+++ b/pump/storage/util.go
@@ -18,6 +18,7 @@ import (
 	"sync/atomic"
 
 	"github.com/dustin/go-humanize"
+	"github.com/pingcap/errors"
 )
 
 var tsKeyPrefix = []byte("ts:")
@@ -59,7 +60,7 @@ func (b *HumanizeBytes) UnmarshalText(text []byte) error {
 
 	n, err := humanize.ParseBytes(string(text))
 	if err != nil {
-		return err
+		return errors.Annotatef(err, "test: %s", string(text))
 	}
 
 	*b = HumanizeBytes(n)

--- a/pump/storage/util_test.go
+++ b/pump/storage/util_test.go
@@ -18,6 +18,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/BurntSushi/toml"
 	"github.com/pingcap/check"
 )
 
@@ -51,4 +52,23 @@ func (e *EncodeTSKeySuite) TestEncodeTSKey(c *check.C) {
 	})
 
 	c.Assert(sorted, check.IsTrue)
+}
+
+type UtilSuite struct{}
+
+var _ = check.Suite(&UtilSuite{})
+
+func (u *UtilSuite) TestHumanizeBytes(c *check.C) {
+	var s = struct {
+		DiskSize HumanizeBytes `toml:"disk_size" json:"disk_size"`
+	}{}
+
+	tomlData := `
+disk_size = "42 MB"
+
+	`
+
+	_, err := toml.Decode(tomlData, &s)
+	c.Assert(err, check.IsNil)
+	c.Assert(s.DiskSize.Uint64(), check.Equals, uint64(42*1000*1000))
 }

--- a/pump/storage/vlog.go
+++ b/pump/storage/vlog.go
@@ -42,10 +42,11 @@ const (
 
 // Options is the config options of Append and vlog
 type Options struct {
-	ValueLogFileSize   int64
-	Sync               bool
-	KVChanCapacity     int
-	SlowWriteThreshold float64
+	ValueLogFileSize          int64
+	Sync                      bool
+	KVChanCapacity            int
+	SlowWriteThreshold        float64
+	StopWriteAtAvailableSpace uint64
 
 	KVConfig *KVConfig
 }
@@ -63,6 +64,12 @@ func DefaultOptions() *Options {
 // WithKVConfig set the Config
 func (o *Options) WithKVConfig(kvConfig *KVConfig) *Options {
 	o.KVConfig = kvConfig
+	return o
+}
+
+// WithStopWriteAtAvailableSpace set the Config
+func (o *Options) WithStopWriteAtAvailableSpace(bytes uint64) *Options {
+	o.StopWriteAtAvailableSpace = bytes
 	return o
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
pump: Add support to stop write at a limit avaliable space

### What is changed and how it works?
Add a configuration to stop writes at a limit available space size.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
use `dd` make space less than configured size -> write failed -> delete file make enough space -> write succes 

Code changes

Side effects

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note