### PR TITLE
pump/: Fix get L0 files num and trigger vlog.gcTS step by step

### DIFF
--- a/cmd/binlogctl/main.go
+++ b/cmd/binlogctl/main.go
@@ -17,6 +17,7 @@ import (
 	"flag"
 	"os"
 
+	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
 	ctl "github.com/pingcap/tidb-binlog/binlogctl"
 	"github.com/pingcap/tidb-binlog/pkg/node"
@@ -59,6 +60,8 @@ func main() {
 		err = ctl.ApplyAction(cfg.EtcdURLs, node.PumpNode, cfg.NodeID, close)
 	case ctl.OfflineDrainer:
 		err = ctl.ApplyAction(cfg.EtcdURLs, node.DrainerNode, cfg.NodeID, close)
+	default:
+		err = errors.NotSupportedf("cmd %s", cfg.Command)
 	}
 
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/soheilhy/cmux v0.1.2
 	github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72 // indirect
 	github.com/spf13/pflag v1.0.3 // indirect
-	github.com/syndtr/goleveldb v1.0.1-0.20190318030020-c3a204f8e965
+	github.com/syndtr/goleveldb v1.0.1-0.20190625010220-02440ea7a285
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5 // indirect
 	github.com/unrolled/render v0.0.0-20180807193321-4206df6ff701
 	github.com/zanmato1984/clickhouse v1.3.4-0.20181106115746-3e9a6b9beb12

--- a/go.sum
+++ b/go.sum
@@ -182,8 +182,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/syndtr/goleveldb v1.0.1-0.20190318030020-c3a204f8e965 h1:1oFLiOyVl+W7bnBzGhf7BbIv9loSFQcieWWYIjLqcAw=
-github.com/syndtr/goleveldb v1.0.1-0.20190318030020-c3a204f8e965/go.mod h1:9OrXJhf154huy1nPWmuSrkgjPUtUNhA+Zmy+6AESzuA=
+github.com/syndtr/goleveldb v1.0.1-0.20190625010220-02440ea7a285 h1:uSDYjYejelKyceA6DiCsngFof9jAyeaSyX9XC5a1a7Q=
+github.com/syndtr/goleveldb v1.0.1-0.20190625010220-02440ea7a285/go.mod h1:9OrXJhf154huy1nPWmuSrkgjPUtUNhA+Zmy+6AESzuA=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5 h1:LnC5Kc/wtumK+WB441p7ynQJzVuNRJiqddSIE3IlSEQ=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/twinj/uuid v0.0.0-20150629100731-70cac2bcd273 h1:YqFyfcgqxQqjpRr0SEG0Z555J/3kPqDL/xmRyeAaX/0=

--- a/pump/server.go
+++ b/pump/server.go
@@ -76,6 +76,7 @@ type Server struct {
 	cancel     context.CancelFunc
 	wg         sync.WaitGroup
 	gcDuration time.Duration
+	triggerGC  chan time.Time
 	metrics    *util.MetricClient
 	// save the last time we write binlog to Storage
 	// if long time not write, we can write a fake binlog
@@ -172,6 +173,7 @@ func NewServer(cfg *Config) (*Server, error) {
 		gcDuration: time.Duration(cfg.GC) * 24 * time.Hour,
 		pdCli:      pdCli,
 		cfg:        cfg,
+		triggerGC:  make(chan time.Time),
 	}, nil
 }
 
@@ -389,6 +391,7 @@ func (s *Server) Start() error {
 	router.HandleFunc("/state/{nodeID}/{action}", s.ApplyAction).Methods("PUT")
 	router.HandleFunc("/drainers", s.AllDrainers).Methods("GET")
 	router.HandleFunc("/debug/binlog/{ts}", s.BinlogByTS).Methods("GET")
+	router.HandleFunc("/debug/gc/trigger", s.TriggerGC).Methods("GET")
 	http.Handle("/", router)
 	prometheus.DefaultGatherer = registry
 	http.Handle("/metrics", promhttp.Handler())
@@ -500,26 +503,29 @@ func (s *Server) gcBinlogFile() {
 		case <-s.ctx.Done():
 			log.Info("gcBinlogFile exit")
 			return
+		case <-s.triggerGC:
+			log.Info("trigger gc now")
 		case <-time.After(gcInterval):
-			if s.gcDuration == 0 {
-				continue
-			}
-
-			safeTSO, err := s.getSafeGCTSOForDrainers(s.ctx)
-			if err != nil {
-				log.Warn("get save gc tso for drainers failed", zap.Error(err))
-				continue
-			}
-			log.Info("get safe ts for drainers success", zap.Int64("ts", safeTSO))
-
-			millisecond := time.Now().Add(-s.gcDuration).UnixNano() / 1000 / 1000
-			gcTS := int64(oracle.EncodeTSO(millisecond))
-			if safeTSO < gcTS {
-				gcTS = safeTSO
-			}
-			log.Info("send gc request to storage", zap.Int64("ts", gcTS))
-			s.storage.GCTS(gcTS)
 		}
+
+		if s.gcDuration == 0 {
+			continue
+		}
+
+		safeTSO, err := s.getSafeGCTSOForDrainers(s.ctx)
+		if err != nil {
+			log.Warn("get save gc tso for drainers failed", zap.Error(err))
+			continue
+		}
+		log.Info("get safe ts for drainers success", zap.Int64("ts", safeTSO))
+
+		millisecond := time.Now().Add(-s.gcDuration).UnixNano() / 1000 / 1000
+		gcTS := int64(oracle.EncodeTSO(millisecond))
+		if safeTSO < gcTS {
+			gcTS = safeTSO
+		}
+		log.Info("send gc request to storage", zap.Int64("ts", gcTS))
+		s.storage.GCTS(gcTS)
 	}
 }
 
@@ -575,6 +581,16 @@ func (s *Server) AllDrainers(w http.ResponseWriter, r *http.Request) {
 // Status exposes pumps' status to HTTP handler.
 func (s *Server) Status(w http.ResponseWriter, r *http.Request) {
 	s.PumpStatus().Status(w, r)
+}
+
+// TriggerGC trigger pump to gc now
+func (s *Server) TriggerGC(w http.ResponseWriter, r *http.Request) {
+	select {
+	case s.triggerGC <- time.Now():
+		fmt.Fprintln(w, "trigger gc success")
+	case <-time.After(time.Second):
+		fmt.Fprintln(w, "gc is working")
+	}
 }
 
 // BinlogByTS exposes api get get binlog by ts

--- a/pump/server.go
+++ b/pump/server.go
@@ -391,7 +391,7 @@ func (s *Server) Start() error {
 	router.HandleFunc("/state/{nodeID}/{action}", s.ApplyAction).Methods("PUT")
 	router.HandleFunc("/drainers", s.AllDrainers).Methods("GET")
 	router.HandleFunc("/debug/binlog/{ts}", s.BinlogByTS).Methods("GET")
-	router.HandleFunc("/debug/gc/trigger", s.TriggerGC).Methods("GET")
+	router.HandleFunc("/debug/gc/trigger", s.TriggerGC).Methods("POST")
 	http.Handle("/", router)
 	prometheus.DefaultGatherer = registry
 	http.Handle("/metrics", promhttp.Handler())
@@ -588,7 +588,7 @@ func (s *Server) TriggerGC(w http.ResponseWriter, r *http.Request) {
 	select {
 	case s.triggerGC <- time.Now():
 		fmt.Fprintln(w, "trigger gc success")
-	case <-time.After(time.Second):
+	default:
 		fmt.Fprintln(w, "gc is working")
 	}
 }

--- a/pump/storage/storage.go
+++ b/pump/storage/storage.go
@@ -612,16 +612,14 @@ func (a *Append) doGCTS(ts int64) {
 	for {
 		nStr, err := a.metadata.GetProperty("leveldb.num-files-at-level0")
 		if err != nil {
-			log.Error("GetProperty failed", zap.Error(err))
-			time.Sleep(5 * time.Second)
-			continue
+			log.Error("get `leveldb.num-files-at-level0` property failed", zap.Error(err))
+			return
 		}
 
 		l0Num, err := strconv.Atoi(nStr)
 		if err != nil {
-			log.Error("parse int failed", zap.String("str", nStr), zap.Error(err))
-			time.Sleep(5 * time.Second)
-			continue
+			log.Error("parse `leveldb.num-files-at-level0` result to int failed", zap.String("str", nStr), zap.Error(err))
+			return
 		}
 
 		if l0Num >= l0Trigger {

--- a/pump/storage/vlog.go
+++ b/pump/storage/vlog.go
@@ -478,6 +478,7 @@ func (vlog *valueLog) gcTS(gcTS int64) {
 		if err != nil {
 			log.Error("remove file failed", zap.String("path", logFile.path), zap.Error(err))
 		}
+		log.Info("remove file", zap.String("path", logFile.path))
 		logFile.lock.Unlock()
 	}
 }

--- a/pump/storage/vlog.go
+++ b/pump/storage/vlog.go
@@ -450,6 +450,8 @@ func (vlog *valueLog) scan(start valuePointer, fn func(vp valuePointer, record *
 
 // delete data <= gcTS
 func (vlog *valueLog) gcTS(gcTS int64) {
+	log.Info("gc vlog", zap.Int64("ts", gcTS))
+
 	vlog.filesLock.Lock()
 	var toDeleteFiles []*logFile
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Refine gc of pump

### What is changed and how it works?
1, Add a API to trigger gc
2, Check L0 files by *GetProperty* instead of Stats
Stats can't get the right L0 files num, see:
https://github.com/syndtr/goleveldb/pull/283/files
3, call vlog.gcTS step by step, help free space quickly
4,   update goleveldb dependency
    only one new commit
    https://github.com/syndtr/goleveldb/commit/02440ea7a28525b3079783ad9c27083994a42366
    Fix the stat about levels of the Stats API



### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
call `debug/gc/trigger`

Code changes

Side effects

 Related changes

 - Need to cherry-pick to the release branch
 - Need to be included in the release note