### PR TITLE
pump/storage: Refactor, encapsulate writing and offset updating in logFile

### DIFF
--- a/pump/storage/log_test.go
+++ b/pump/storage/log_test.go
@@ -22,6 +22,7 @@ import (
 	"math/rand"
 	"os"
 	"path"
+	"path/filepath"
 	"strconv"
 
 	fuzz "github.com/google/gofuzz"
@@ -73,6 +74,18 @@ func (lfs *LogFileSuit) TearDownTest(c *check.C) {
 	os.Remove(lfs.lf.path)
 }
 
+func (lfs *LogFileSuit) TestWriteOffset(c *check.C) {
+	dir := c.MkDir()
+	f, err := newLogFile(1024, filepath.Join(dir, "1024.vlog"))
+	c.Assert(err, check.IsNil)
+	c.Assert(f.GetWriteOffset(), check.Equals, int64(0))
+
+	data := make([]byte, 379)
+	err = f.Write(data, true)
+	c.Assert(err, check.IsNil)
+	c.Assert(f.GetWriteOffset(), check.Equals, int64(379))
+}
+
 func (lfs *LogFileSuit) TestSeekToNextRecord(c *check.C) {
 	buffer := new(bytes.Buffer)
 
@@ -107,7 +120,6 @@ func (lfs *LogFileSuit) TestSeekToNextRecord(c *check.C) {
 			c.Assert(err, check.NotNil)
 			c.Assert(bytes, check.Equals, len(data)-idx)
 		}
-
 	}
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

When we need to make sure the `writableOffset` is for the file
corresponding to `maxFid`, we may write code like this:

```go
if fid == maxFid {
        // get writableOffset
}
```

To make this threadsafe, we have to introduce a lock.

### What is changed and how it works?

Separate the concern of the struct `valueLog` and `logFile`.

`valueLog` is a higher level interface to the binlog data files, it
manages a directory of `logFile`s.

`logFile` is responsible for saving data to individual files.

By allowing `LogFile` to manage its own `writeOffset`, we can be sure
that the offset is for the "current" file without using a lock.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes


Side effects


Related changes