### PR TITLE
pump/storage: Avoid big inputs that slow down the unit test

### DIFF
--- a/pump/storage/storage_test.go
+++ b/pump/storage/storage_test.go
@@ -247,6 +247,8 @@ func (as *AppendSuit) TestReadWriteGCTS(c *check.C) {
 }
 
 // test helper to write binlogNum binlog to append
+// If `prewriteValueSize` is less than or equal to 0, the size of prewriteValue for
+// binlogs will be random integers between [1, 1024].
 func populateBinlog(b Log, append *Append, prewriteValueSize int, binlogNum int32) {
 	fixedValueSize := prewriteValueSize > 0
 	var prewriteValue []byte
@@ -279,7 +281,7 @@ func populateBinlog(b Log, append *Append, prewriteValueSize int, binlogNum int3
 				if fixedValueSize {
 					binlog.PrewriteValue = prewriteValue
 				} else {
-					size := 1 + rand.Intn(len(prewriteValue)-1)
+					size := 1 + rand.Intn(len(prewriteValue))
 					binlog.PrewriteValue = prewriteValue[:size]
 					b.Log("Setting prewrite value of length", size)
 				}

--- a/pump/storage/storage_test.go
+++ b/pump/storage/storage_test.go
@@ -115,16 +115,7 @@ func (as *AppendSuit) TestCloseAndOpenAgain(c *check.C) {
 }
 
 func (as *AppendSuit) TestWriteBinlogAndPullBack(c *check.C) {
-	as.testWriteBinlogAndPullBack(c, 128, 1)
-
-	// write a 500M binlog
-	as.testWriteBinlogAndPullBack(c, 500*1<<20, 1)
-
-	as.testWriteBinlogAndPullBack(c, 128, 1024)
-
-	as.testWriteBinlogAndPullBack(c, 128, 1024*10)
-
-	as.testWriteBinlogAndPullBack(c, 1<<20, 1024)
+	as.testWriteBinlogAndPullBack(c, -1, 1024)
 }
 
 func (as *AppendSuit) testWriteBinlogAndPullBack(c *check.C, prewriteValueSize int, binlogNum int32) {
@@ -257,17 +248,21 @@ func (as *AppendSuit) TestReadWriteGCTS(c *check.C) {
 
 // test helper to write binlogNum binlog to append
 func populateBinlog(b Log, append *Append, prewriteValueSize int, binlogNum int32) {
-	prewriteValue := make([]byte, prewriteValueSize)
+	fixedValueSize := prewriteValueSize > 0
+	var prewriteValue []byte
+	if fixedValueSize {
+		prewriteValue = make([]byte, prewriteValueSize)
+	} else {
+		prewriteValue = make([]byte, 1024)
+	}
 	var ts int64
 	getTS := func() int64 {
 		return atomic.AddInt64(&ts, 1)
 	}
 
-	goNum := 512
-
 	var wg sync.WaitGroup
 
-	for i := 0; i < goNum; i++ {
+	for i := 0; i < 10; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -281,10 +276,15 @@ func populateBinlog(b Log, append *Append, prewriteValueSize int, binlogNum int3
 				binlog.Tp = pb.BinlogType_Prewrite
 				startTS := getTS()
 				binlog.StartTs = startTS
-				binlog.PrewriteValue = prewriteValue
+				if fixedValueSize {
+					binlog.PrewriteValue = prewriteValue
+				} else {
+					size := 1 + rand.Intn(len(prewriteValue)-1)
+					binlog.PrewriteValue = prewriteValue[:size]
+					b.Log("Setting prewrite value of length", size)
+				}
 
-				err := append.WriteBinlog(binlog)
-				if err != nil {
+				if err := append.WriteBinlog(binlog); err != nil {
 					b.Fatal(err)
 				}
 
@@ -293,8 +293,7 @@ func populateBinlog(b Log, append *Append, prewriteValueSize int, binlogNum int3
 				binlog.Tp = pb.BinlogType_Commit
 				binlog.StartTs = startTS
 				binlog.CommitTs = getTS()
-				err = append.WriteBinlog(binlog)
-				if err != nil {
+				if err := append.WriteBinlog(binlog); err != nil {
 					b.Fatal(err)
 				}
 			}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

With big inputs like "writing a 500MB binlog", the unit tests of
pump/storage can be very slow.

### What is changed and how it works?

1. Remove big inputs.
1. Batch valueLog writes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes


Side effects


Related changes