### PR TITLE
pump: record levelDB iterator error during gc

### DIFF
--- a/pump/storage/storage.go
+++ b/pump/storage/storage.go
@@ -1099,6 +1099,10 @@ func (a *Append) PullCommitBinlog(ctx context.Context, last int64) <-chan []byte
 				last = decodeTSKey(iter.Key())
 			}
 			iter.Release()
+			err := iter.Error()
+			if err != nil {
+				log.Error("encounter iterator error", zap.Error(err))
+			}
 
 			select {
 			case <-ctx.Done():


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

LevelDB iterator may return error, better to check it after the iterator is exhausted 

### What is changed and how it works?

check error and add error log if needed

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Related changes

 - Need to cherry-pick to the release branch
