### PR TITLE
drainer: fix failure to update BIT columns with downstream TiDB

### DIFF
--- a/tests/update_bit1/drainer.toml
+++ b/tests/update_bit1/drainer.toml
@@ -1,0 +1,18 @@
+detect-interval = 10
+data-dir = '/tmp/tidb_binlog_test/update_bit1'
+pd-urls = 'http://127.0.0.1:2379'
+
+[syncer]
+ignore-schemas = 'INFORMATION_SCHEMA,PERFORMANCE_SCHEMA,mysql'
+txn-batch = 1
+worker-count = 1
+disable-dispatch = false
+safe-mode = false
+db-type = 'mysql'
+replicate-do-db = ['update_bit1']
+
+[syncer.to]
+host = '127.0.0.1'
+user = 'root'
+password = ''
+port = 3306

--- a/tests/update_bit1/run.sh
+++ b/tests/update_bit1/run.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+set -e
+
+cd "$(dirname "$0")"
+
+run_drainer &
+
+run_sql 'DROP DATABASE IF EXISTS update_bit1;'
+run_sql 'CREATE DATABASE update_bit1;'
+run_sql 'CREATE TABLE update_bit1.t(a BIT(1) NOT NULL);'
+run_sql 'INSERT INTO update_bit1.t VALUES (0x01);'
+
+sleep 3
+
+down_run_sql 'SELECT HEX(a) FROM update_bit1.t;'
+check_contains 'HEX(a): 1'
+
+# Verify fix for TOOL-1346.
+
+run_sql 'UPDATE update_bit1.t SET a = 0x00;'
+
+sleep 3
+
+down_run_sql 'SELECT HEX(a) FROM update_bit1.t;'
+check_contains 'HEX(a): 0'
+
+killall drainer


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Issue TOOL-1346, which is caused by pingcap/tidb#10988.

### What is changed and how it works?

Encode BIT types as integers instead of byte strings. Since the longest value is BIT(64), it is safe to always convert as `uint64`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
    * Verified the repro steps in TOOL-1346 are no longer reproducible.

Code changes

Side effects

Related changes

 - Need to cherry-pick to the release branch
    * Needs to cherry-pick to the release-2.1 branch.
