### PR TITLE
*: Preallocate space for slices and strings

### DIFF
--- a/drainer/translator/pb.go
+++ b/drainer/translator/pb.go
@@ -244,10 +244,10 @@ func encodeRow(row []types.Datum, colName []string, tp []byte, mysqlType []strin
 			return nil, errors.Trace(err)
 		}
 		col := pb.Column{
-			Name: colName[i],
-			Tp: []byte{tp[i]},
+			Name:      colName[i],
+			Tp:        []byte{tp[i]},
 			MysqlType: mysqlType[i],
-			Value: val,
+			Value:     val,
 		}
 
 		colVal, err := col.Marshal()
@@ -274,10 +274,10 @@ func encodeUpdateRow(oldRow []types.Datum, newRow []types.Datum, colName []strin
 			return nil, errors.Trace(err)
 		}
 		col := pb.Column{
-			Name: colName[i],
-			Tp: []byte{tp[i]},
-			MysqlType: mysqlType[i],
-			Value: val,
+			Name:         colName[i],
+			Tp:           []byte{tp[i]},
+			MysqlType:    mysqlType[i],
+			Value:        val,
 			ChangedValue: changedVal,
 		}
 

--- a/pkg/dml/dml.go
+++ b/pkg/dml/dml.go
@@ -17,9 +17,13 @@ import "strings"
 
 // GenColumnPlaceholders generates placeholders in question mark format,like "?,?,?".
 func GenColumnPlaceholders(length int) string {
-	values := make([]string, length)
+	var b strings.Builder
+	b.Grow(2 * length)
 	for i := 0; i < length; i++ {
-		values[i] = "?"
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteByte('?')
 	}
-	return strings.Join(values, ",")
+	return b.String()
 }

--- a/pkg/loader/executor.go
+++ b/pkg/loader/executor.go
@@ -119,7 +119,7 @@ func (e *executor) bulkDelete(deletes []*DML) error {
 	}
 
 	var sqls strings.Builder
-	var argss []interface{}
+	argss := make([]interface{}, 0, len(deletes))
 
 	for _, dml := range deletes {
 		sql, args := dml.sql()

--- a/pkg/loader/model.go
+++ b/pkg/loader/model.go
@@ -103,7 +103,7 @@ func (dml *DML) primaryKeys() []string {
 func (dml *DML) primaryKeyValues() []interface{} {
 	names := dml.primaryKeys()
 
-	var values []interface{}
+	values := make([]interface{}, 0, len(names))
 	for _, name := range names {
 		v := dml.Values[name]
 		values = append(values, v)
@@ -145,7 +145,7 @@ func (dml *DML) oldPrimaryKeyValues() []interface{} {
 
 	names := dml.primaryKeys()
 
-	var values []interface{}
+	values := make([]interface{}, 0, len(names))
 	for _, name := range names {
 		v := dml.OldValues[name]
 		values = append(values, v)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Space of some slices and strings with known size are not preallocated.
(As reported by the static analysis tool:
[prealloc](https://github.com/alexkohler/prealloc))

### What is changed and how it works?

Preallocate space for slices and strings of known size.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes


Side effects


Related changes