### PR TITLE
pump: Make the pump/storage unit tests faster

### DIFF
--- a/pump/storage/bench_test.go
+++ b/pump/storage/bench_test.go
@@ -75,7 +75,7 @@ func benchmarkPull(b *testing.B, prewriteValueSize int, binlogNum int) {
 	append := newAppend(b)
 	defer os.RemoveAll(append.dir)
 
-	populateBinlog(b, append, prewriteValueSize, int32(binlogNum))
+	populateBinlog(b, append, prewriteValueSize, binlogNum)
 
 	runtime.GC()
 	b.ResetTimer()

--- a/pump/storage/storage.go
+++ b/pump/storage/storage.go
@@ -907,7 +907,7 @@ func (a *Append) writeToValueLog(reqs chan *request) chan *request {
 					size = 0
 					bufReqs = bufReqs[:0]
 				}
-			case <-time.After(time.Millisecond):
+			default:
 				if len(bufReqs) > 0 {
 					write(bufReqs)
 					size = 0

--- a/pump/storage/storage.go
+++ b/pump/storage/storage.go
@@ -907,7 +907,7 @@ func (a *Append) writeToValueLog(reqs chan *request) chan *request {
 					size = 0
 					bufReqs = bufReqs[:0]
 				}
-			default:
+			case <-time.After(time.Millisecond):
 				if len(bufReqs) > 0 {
 					write(bufReqs)
 					size = 0

--- a/pump/storage/storage_test.go
+++ b/pump/storage/storage_test.go
@@ -263,7 +263,7 @@ func populateBinlog(b Log, append *Append, prewriteValueSize int, binlogNum int)
 
 	seq := make(chan struct{}, 10)
 	go func() {
-		for i := 0 ; i < binlogNum; i++ {
+		for i := 0; i < binlogNum; i++ {
 			seq <- struct{}{}
 		}
 		close(seq)

--- a/pump/storage/vlog_test.go
+++ b/pump/storage/vlog_test.go
@@ -138,6 +138,7 @@ func (vs *VlogSuit) TestCloseAndOpen(c *check.C) {
 
 	n := 10
 	reqs := make([]*request, 0, n*3)
+	batch := make([]*request, 0, 3)
 	for i := 0; i < n; i++ {
 		// close and open back every time
 		var err = vlog.close()
@@ -147,13 +148,15 @@ func (vs *VlogSuit) TestCloseAndOpen(c *check.C) {
 		err = vlog.open(dirPath, opt)
 		c.Assert(err, check.IsNil)
 
+		batch = batch[:0]
 		// write a few request
 		for j := 0; j < 3; j++ {
 			req := randRequest()
-			reqs = append(reqs, req)
-			err = vlog.write([]*request{req})
-			c.Assert(err, check.IsNil)
+			batch = append(batch, req)
 		}
+		err = vlog.write(batch)
+		c.Assert(err, check.IsNil)
+		reqs = append(reqs, batch...)
 	}
 
 	c.Log("reqs len: ", len(reqs))

--- a/pump/storage/vlog_test.go
+++ b/pump/storage/vlog_test.go
@@ -97,7 +97,7 @@ func (vs *VlogSuit) TestBatchWriteRead(c *check.C) {
 	testBatchWriteRead(c, 128, DefaultOptions())
 
 	// set small valueLogFileSize, so we can test multi log file case
-	testBatchWriteRead(c, 1024, DefaultOptions().WithValueLogFileSize(500))
+	testBatchWriteRead(c, 1024, DefaultOptions().WithValueLogFileSize(3000))
 }
 
 func testBatchWriteRead(c *check.C, reqNum int, options *Options) {
@@ -168,12 +168,12 @@ func (vs *VlogSuit) TestCloseAndOpen(c *check.C) {
 }
 
 func (vs *VlogSuit) TestGCTS(c *check.C) {
-	vlog := newVlogWithOptions(c, DefaultOptions().WithValueLogFileSize(512))
+	vlog := newVlogWithOptions(c, DefaultOptions().WithValueLogFileSize(2048))
 	defer os.RemoveAll(vlog.dirPath)
 
 	payload := make([]byte, 128)
 	requests := make([]*request, 100)
-	// 100 * 128 > 512 guarantees that multiple log files are created
+	// 100 * 128 > 2048 guarantees that multiple log files are created
 	for i := 0; i < len(requests); i++ {
 		requests[i] = &request{
 			startTS: int64(i),


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

It still takes about 15 seconds to run.

### What is changed and how it works?

Make it faster, the new run time is about 6.5 seconds.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes


Side effects


Related changes