### PR TITLE
handle Recover job and fix can't close internally

### DIFF
--- a/drainer/schema.go
+++ b/drainer/schema.go
@@ -326,7 +326,7 @@ func (s *Schema) handleDDL(job *model.Job) (schemaName string, tableName string,
 		schemaName = schema.Name.O
 		tableName = table.Name.O
 
-	case model.ActionCreateTable, model.ActionCreateView:
+	case model.ActionCreateTable, model.ActionCreateView, model.ActionRecoverTable:
 		table := job.BinlogInfo.TableInfo
 		if table == nil {
 			return "", "", "", errors.NotFoundf("table %d", job.TableID)

--- a/drainer/server.go
+++ b/drainer/server.go
@@ -216,7 +216,7 @@ func (s *Server) heartbeat(ctx context.Context) <-chan error {
 	s.tg.Go("heartbeat", func() {
 		defer func() {
 			close(errc)
-			s.Close()
+			defer func() { go s.Close() }()
 		}()
 
 		for {
@@ -251,7 +251,7 @@ func (s *Server) Start() error {
 	}()
 
 	s.tg.GoNoPanic("collect", func() {
-		defer s.Close()
+		defer func() { go s.Close() }()
 		s.collector.Start(s.ctx)
 	})
 
@@ -262,7 +262,7 @@ func (s *Server) Start() error {
 	}
 
 	s.tg.GoNoPanic("syncer", func() {
-		defer s.Close()
+		defer func() { go s.Close() }()
 		if err := s.syncer.Start(); err != nil {
 			log.Error("syncer exited abnormal", zap.Error(err))
 		}

--- a/drainer/server.go
+++ b/drainer/server.go
@@ -216,7 +216,7 @@ func (s *Server) heartbeat(ctx context.Context) <-chan error {
 	s.tg.Go("heartbeat", func() {
 		defer func() {
 			close(errc)
-			defer func() { go s.Close() }()
+			go s.Close()
 		}()
 
 		for {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

reviewed after https://github.com/pingcap/tidb-binlog/pull/673 

### What problem does this PR solve? <!--add issue link with summary if exists-->
- handle Recover job, don't error in schema by falling to the default case inside `handleDDL`
- fix can't close internally
    Note if in the taskGroup.Go if we call s.Close()
    it will wait on the taskGroup in the Close() implement
    but we are still clock in the closure pass into Go for calling
    s.Close(), so it will call Done inside taskGroup and will block in
    Wait(), this is a dead lock.
### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
run `recover table a` and fail(exec at downstream and the downstream not support) and quit

Code changes



Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
