### PR TITLE
tests: No need to wait for seconds before closing

### DIFF
--- a/pump/storage/storage_test.go
+++ b/pump/storage/storage_test.go
@@ -191,9 +191,14 @@ func (as *AppendSuit) TestCloseAndOpenAgain(c *check.C) {
 	append, err = NewAppend(append.dir, append.options)
 	c.Assert(err, check.IsNil)
 
+	origHdlPtrSaveInt := handlePtrSaveInterval
+	handlePtrSaveInterval = time.Millisecond
+	defer func() {
+		handlePtrSaveInterval = origHdlPtrSaveInt
+	}()
 	// populate some data and close open back to check the status
 	populateBinlog(c, append, 128, 1)
-	time.Sleep(time.Second * 3)
+	time.Sleep(time.Millisecond * 100)
 
 	gcTS := append.gcTS
 	maxCommitTS := append.maxCommitTS


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Make `TestCloseAndOpenAgain` -- which is one of the slowest test case --
faster.

We had to wait for about 3 seconds before closing because
`handleSortItems` only save maxCommitTS and handlePointer at most
once per second. But when testing, we don't want to wait for so long.


### What is changed and how it works?

Make the interval an variable, so that we can override it with shorter
durations in the test case.

Now we are waiting milliseconds instead of seconds.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes


Side effects


Related changes