### PR TITLE
pkg/sql: add missing error code of IgnoreDDLError

### DIFF
--- a/pkg/sql/sql.go
+++ b/pkg/sql/sql.go
@@ -156,7 +156,7 @@ func IgnoreDDLError(err error) bool {
 	case infoschema.ErrDatabaseExists.Code(), infoschema.ErrDatabaseNotExists.Code(), infoschema.ErrDatabaseDropExists.Code(),
 		infoschema.ErrTableExists.Code(), infoschema.ErrTableNotExists.Code(), infoschema.ErrTableDropExists.Code(),
 		infoschema.ErrColumnExists.Code(), infoschema.ErrColumnNotExists.Code(), infoschema.ErrIndexExists.Code(),
-		tddl.ErrCantDropFieldOrKey.Code(), tmysql.ErrDupKeyName:
+		infoschema.ErrKeyNotExists.Code(), tddl.ErrCantDropFieldOrKey.Code(), tmysql.ErrDupKeyName:
 		return true
 	default:
 		return false

--- a/pkg/sql/sql_test.go
+++ b/pkg/sql/sql_test.go
@@ -83,6 +83,7 @@ func (s *SQLErrSuite) TestGetSQLErrCode(c *C) {
 func (s *SQLErrSuite) TestIgnoreDDLError(c *C) {
 	c.Assert(IgnoreDDLError(&mysql.MySQLError{Number: 1146}), IsTrue)
 	c.Assert(IgnoreDDLError(&mysql.MySQLError{Number: 1032}), IsFalse)
+	c.Assert(IgnoreDDLError(&mysql.MySQLError{Number: 1176}), IsTrue)
 }
 
 type sqlSuite struct {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
IgnoreDDLError func is missing a ``` ErrKeyNotExists ``` error code in "pkg/sql" module.

### What is changed and how it works?
Add ```ErrKeyNotExists``` in IgnoreDDLError func.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

Side effects

Related changes
