### PR TITLE
add node-id cmd to specify drainer's node-id

### DIFF
--- a/cmd/drainer/README.md
+++ b/cmd/drainer/README.md
@@ -42,7 +42,7 @@ Usage of drainer:
   -metrics-interval int
       prometheus client push interval in second, set "0" to disable prometheus push (default 15)
   -node-id string
-      the ID of drainer node; if not specify, we will generate one from hostname and the listening port
+      the ID of drainer node; if not specified, we will generate one from hostname and the listening port
   -pd-urls string
       a comma separated list of PD endpoints (default "http://127.0.0.1:2379")
   -safe-mode

--- a/cmd/drainer/README.md
+++ b/cmd/drainer/README.md
@@ -41,6 +41,8 @@ Usage of drainer:
       prometheus pushgateway address, leaves it empty will disable prometheus push
   -metrics-interval int
       prometheus client push interval in second, set "0" to disable prometheus push (default 15)
+  -node-id string
+      the ID of drainer node; if not specify, we will generate one from hostname and the listening port
   -pd-urls string
       a comma separated list of PD endpoints (default "http://127.0.0.1:2379")
   -safe-mode

--- a/cmd/pump/README.md
+++ b/cmd/pump/README.md
@@ -34,7 +34,7 @@ pump is a daemon that receives realtime binlog from tidb-server and writes in se
   -metrics-interval int
       prometheus client push interval in second, set "0" to disable prometheus push (default 15)
   -node-id string
-      the ID of pump node; if not specify, we will generate one from hostname and the listening port
+      the ID of pump node; if not specified, we will generate one from hostname and the listening port
   -pd-urls string
       a comma separated list of the PD endpoints (default "http://127.0.0.1:2379")
   -zookeeper-addrs string

--- a/drainer/config.go
+++ b/drainer/config.go
@@ -110,7 +110,7 @@ func NewConfig() *Config {
 		fmt.Fprintln(os.Stderr, "Usage of drainer:")
 		fs.PrintDefaults()
 	}
-	fs.StringVar(&cfg.NodeID, "node-id", "", "the ID of drainer node; if not specify, we will generate one from hostname and the listening port")
+	fs.StringVar(&cfg.NodeID, "node-id", "", "the ID of drainer node; if not specified, we will generate one from hostname and the listening port")
 	fs.StringVar(&cfg.ListenAddr, "addr", util.DefaultListenAddr(8249), "addr (i.e. 'host:port') to listen on for drainer connections")
 	fs.StringVar(&cfg.AdvertiseAddr, "advertise-addr", "", "addr(i.e. 'host:port') to advertise to the public, default to be the same value as -addr")
 	fs.StringVar(&cfg.DataDir, "data-dir", defaultDataDir, "drainer data directory path (default data.drainer)")

--- a/drainer/config.go
+++ b/drainer/config.go
@@ -78,6 +78,7 @@ type SyncerConfig struct {
 type Config struct {
 	*flag.FlagSet   `json:"-"`
 	LogLevel        string          `toml:"log-level" json:"log-level"`
+	NodeID          string          `toml:"node-id" json:"node-id"`
 	ListenAddr      string          `toml:"addr" json:"addr"`
 	AdvertiseAddr   string          `toml:"advertise-addr" json:"advertise-addr"`
 	DataDir         string          `toml:"data-dir" json:"data-dir"`
@@ -109,6 +110,7 @@ func NewConfig() *Config {
 		fmt.Fprintln(os.Stderr, "Usage of drainer:")
 		fs.PrintDefaults()
 	}
+	fs.StringVar(&cfg.NodeID, "node-id", "", "the ID of drainer node; if not specify, we will generate one from hostname and the listening port")
 	fs.StringVar(&cfg.ListenAddr, "addr", util.DefaultListenAddr(8249), "addr (i.e. 'host:port') to listen on for drainer connections")
 	fs.StringVar(&cfg.AdvertiseAddr, "advertise-addr", "", "addr(i.e. 'host:port') to advertise to the public, default to be the same value as -addr")
 	fs.StringVar(&cfg.DataDir, "data-dir", defaultDataDir, "drainer data directory path (default data.drainer)")

--- a/drainer/server.go
+++ b/drainer/server.go
@@ -86,12 +86,9 @@ func init() {
 
 // NewServer return a instance of binlog-server
 func NewServer(cfg *Config) (*Server, error) {
-	var ID string
-	if cfg.NodeID != "" {
-		ID = cfg.NodeID
-	} else {
+	if cfg.NodeID == "" {
 		var err error
-		ID, err = genDrainerID(cfg.ListenAddr)
+		cfg.NodeID, err = genDrainerID(cfg.ListenAddr)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -154,10 +151,10 @@ func NewServer(cfg *Config) (*Server, error) {
 		return nil, errors.Annotatef(err, "invalid configuration of advertise addr(%s)", cfg.AdvertiseAddr)
 	}
 
-	status := node.NewStatus(ID, advURL.Host, node.Online, 0, syncer.GetLatestCommitTS(), util.GetApproachTS(latestTS, latestTime))
+	status := node.NewStatus(cfg.NodeID, advURL.Host, node.Online, 0, syncer.GetLatestCommitTS(), util.GetApproachTS(latestTS, latestTime))
 
 	return &Server{
-		ID:        ID,
+		ID:        cfg.NodeID,
 		host:      advURL.Host,
 		cfg:       cfg,
 		collector: c,

--- a/drainer/server.go
+++ b/drainer/server.go
@@ -86,9 +86,15 @@ func init() {
 
 // NewServer return a instance of binlog-server
 func NewServer(cfg *Config) (*Server, error) {
-	ID, err := genDrainerID(cfg.ListenAddr)
-	if err != nil {
-		return nil, errors.Trace(err)
+	var ID string
+	if cfg.NodeID != "" {
+		ID = cfg.NodeID
+	} else {
+		var err error
+		ID, err = genDrainerID(cfg.ListenAddr)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
 	}
 
 	if err := os.MkdirAll(cfg.DataDir, 0700); err != nil {

--- a/pump/config.go
+++ b/pump/config.go
@@ -93,7 +93,7 @@ func NewConfig() *Config {
 		fs.PrintDefaults()
 	}
 
-	fs.StringVar(&cfg.NodeID, "node-id", "", "the ID of pump node; if not specify, we will generate one from hostname and the listening port")
+	fs.StringVar(&cfg.NodeID, "node-id", "", "the ID of pump node; if not specified, we will generate one from hostname and the listening port")
 	fs.StringVar(&cfg.ListenAddr, "addr", util.DefaultListenAddr(8250), "addr(i.e. 'host:port') to listen on for client traffic")
 	fs.StringVar(&cfg.AdvertiseAddr, "advertise-addr", "", "addr(i.e. 'host:port') to advertise to the public")
 	fs.StringVar(&cfg.Socket, "socket", "", "unix socket addr to listen on for client traffic")


### PR DESCRIPTION

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
[TOOL-1410](https://internal.pingcap.net/jira/browse/TOOL-1410)

### What is changed and how it works?
Modify `drainer/server.go`. If user specifies a node-id, drainer ID will be set as this value. If not, drainer will automatically generate a node ID referring to the listening host name and port.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
    * Change the `tests/run.sh:119` from `run_drainer -L debug &`
       to `    run_drainer -L debug -node-id binlog:group &`
    * Execute `./tests/run.sh` and check `/tmp/tidb-binlog-test/drainer.log`
    * Execution result without change `tests/run.sh:119`:
    ![image](https://user-images.githubusercontent.com/21104942/61517138-198c6580-aa39-11e9-8e8c-8f015d810ae7.png)
    * Execution result after change `tests/run.sh:119`:
    ![image](https://user-images.githubusercontent.com/21104942/61517090-fb266a00-aa38-11e9-9fa0-2df74f917dd9.png)


Code changes

Side effects

Related changes
