### PR TITLE
drainer/: Add ignore-txn-commit-ts to skip some txn

### DIFF
--- a/cmd/drainer/drainer.toml
+++ b/cmd/drainer/drainer.toml
@@ -52,6 +52,9 @@ safe-mode = false
 # valid values are "mysql", "file", "tidb", "flash", "kafka"
 db-type = "mysql"
 
+# ignore syncing the txn with specified commit ts to downstream
+ignore-txn-commit-ts = []
+
 # disable sync these schema
 ignore-schemas = "INFORMATION_SCHEMA,PERFORMANCE_SCHEMA,mysql"
 

--- a/drainer/config.go
+++ b/drainer/config.go
@@ -59,19 +59,20 @@ var (
 
 // SyncerConfig is the Syncer's configuration.
 type SyncerConfig struct {
-	StrSQLMode       *string            `toml:"sql-mode" json:"sql-mode"`
-	SQLMode          mysql.SQLMode      `toml:"-" json:"-"`
-	IgnoreSchemas    string             `toml:"ignore-schemas" json:"ignore-schemas"`
-	IgnoreTables     []filter.TableName `toml:"ignore-table" json:"ignore-table"`
-	TxnBatch         int                `toml:"txn-batch" json:"txn-batch"`
-	WorkerCount      int                `toml:"worker-count" json:"worker-count"`
-	To               *dsync.DBConfig    `toml:"to" json:"to"`
-	DoTables         []filter.TableName `toml:"replicate-do-table" json:"replicate-do-table"`
-	DoDBs            []string           `toml:"replicate-do-db" json:"replicate-do-db"`
-	DestDBType       string             `toml:"db-type" json:"db-type"`
-	DisableDispatch  bool               `toml:"disable-dispatch" json:"disable-dispatch"`
-	SafeMode         bool               `toml:"safe-mode" json:"safe-mode"`
-	DisableCausality bool               `toml:"disable-detect" json:"disable-detect"`
+	StrSQLMode        *string            `toml:"sql-mode" json:"sql-mode"`
+	SQLMode           mysql.SQLMode      `toml:"-" json:"-"`
+	IgnoreTxnCommitTS []int64            `toml:"ignore-txn-commit-ts" json:"ignore-txn-commit-ts"`
+	IgnoreSchemas     string             `toml:"ignore-schemas" json:"ignore-schemas"`
+	IgnoreTables      []filter.TableName `toml:"ignore-table" json:"ignore-table"`
+	TxnBatch          int                `toml:"txn-batch" json:"txn-batch"`
+	WorkerCount       int                `toml:"worker-count" json:"worker-count"`
+	To                *dsync.DBConfig    `toml:"to" json:"to"`
+	DoTables          []filter.TableName `toml:"replicate-do-table" json:"replicate-do-table"`
+	DoDBs             []string           `toml:"replicate-do-db" json:"replicate-do-db"`
+	DestDBType        string             `toml:"db-type" json:"db-type"`
+	DisableDispatch   bool               `toml:"disable-dispatch" json:"disable-dispatch"`
+	SafeMode          bool               `toml:"safe-mode" json:"safe-mode"`
+	DisableCausality  bool               `toml:"disable-detect" json:"disable-detect"`
 }
 
 // Config holds the configuration of drainer

--- a/drainer/syncer.go
+++ b/drainer/syncer.go
@@ -400,7 +400,7 @@ ForLoop:
 				s.itemsWg.Add(1)
 				lastAddComitTS = binlog.GetCommitTs()
 
-				log.Info("add ddl item to syncer, you can add this commit ts to `ignore-txn-commit-ts` for skip this ddl if need",
+				log.Info("add ddl item to syncer, you can add this commit ts to `ignore-txn-commit-ts` to skip this ddl if needed",
 					zap.String("sql", sql), zap.Int64("commit ts", binlog.CommitTs))
 
 				err = s.dsyncer.Sync(&dsync.Item{Binlog: binlog, PrewriteValue: nil, Schema: schema, Table: table})

--- a/drainer/syncer.go
+++ b/drainer/syncer.go
@@ -316,6 +316,11 @@ ForLoop:
 		commitTS := binlog.GetCommitTs()
 		jobID := binlog.GetDdlJobId()
 
+		if isIgnoreTxnCommitTS(s.cfg.IgnoreTxnCommitTS, commitTS) {
+			log.Warn("skip txn", zap.Stringer("binlog", b.binlog))
+			continue
+		}
+
 		if startTS == commitTS {
 			fakeBinlogs = append(fakeBinlogs, binlog)
 			fakeBinlogPreAddTS = append(fakeBinlogPreAddTS, lastAddComitTS)
@@ -394,6 +399,10 @@ ForLoop:
 				beginTime := time.Now()
 				s.itemsWg.Add(1)
 				lastAddComitTS = binlog.GetCommitTs()
+
+				log.Info("add ddl item to syncer, you can add this commit ts to `ignore-txn-commit-ts` for skip this ddl if need",
+					zap.String("sql", sql), zap.Int64("commit ts", binlog.CommitTs))
+
 				err = s.dsyncer.Sync(&dsync.Item{Binlog: binlog, PrewriteValue: nil, Schema: schema, Table: table})
 				if err != nil {
 					err = errors.Annotate(err, "add to dsyncer failed")
@@ -450,6 +459,15 @@ func filterTable(pv *pb.PrewriteValue, filter *filter.Filter, schema *Schema) (i
 	}
 
 	return
+}
+
+func isIgnoreTxnCommitTS(ignoreTxnCommitTS []int64, ts int64) bool {
+	for _, ignoreTS := range ignoreTxnCommitTS {
+		if ignoreTS == ts {
+			return true
+		}
+	}
+	return false
 }
 
 // Add adds binlogItem to the syncer's input channel

--- a/drainer/syncer_test.go
+++ b/drainer/syncer_test.go
@@ -173,6 +173,13 @@ func (s *syncerSuite) TestNewSyncer(c *check.C) {
 	c.Assert(syncer.GetLatestCommitTS(), check.Greater, lastNoneFakeTS)
 }
 
+func (s *syncerSuite) TestIsIgnoreTxnCommitTS(c *check.C) {
+	c.Assert(isIgnoreTxnCommitTS(nil, 1), check.IsFalse)
+	c.Assert(isIgnoreTxnCommitTS([]int64{1, 3}, 1), check.IsTrue)
+	c.Assert(isIgnoreTxnCommitTS([]int64{1, 3}, 2), check.IsFalse)
+	c.Assert(isIgnoreTxnCommitTS([]int64{1, 3}, 3), check.IsTrue)
+}
+
 func getEmptyPrewriteValue(schemaVersion int64, tableID int64) (data []byte) {
 	pv := &pb.PrewriteValue{
 		SchemaVersion: schemaVersion,


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
add ignore-txn-commit-ts to skip some txn.
use case: for some incompatible DDL, user may handle it manaually and want to skip this binlog, currentlly, usert can only change the checkpoint to skip this,  the process is tedious and prone to error.

### What is changed and how it works?
add `ignore-txn-commit-ts` support to skip specified commit ts txn

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
config `ignore-txn-commit-ts` and make sure it skip it

Code changes

Side effects

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
