### PR TITLE
binlogctl: Use registry.Node to get a single node directly

### DIFF
--- a/binlogctl/nodes_test.go
+++ b/binlogctl/nodes_test.go
@@ -23,10 +23,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pingcap/errors"
-
 	"github.com/coreos/etcd/integration"
 	. "github.com/pingcap/check"
+	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb-binlog/pkg/etcd"
 	"github.com/pingcap/tidb-binlog/pkg/node"
 )

--- a/binlogctl/nodes_test.go
+++ b/binlogctl/nodes_test.go
@@ -23,6 +23,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pingcap/errors"
+
 	"github.com/coreos/etcd/integration"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb-binlog/pkg/etcd"
@@ -63,7 +65,7 @@ func (s *testNodesSuite) TestApplyAction(c *C) {
 	registerPumpForTest(c, "test", url)
 
 	err := ApplyAction("127.0.0.1:2379", "pumps", "test2", PausePump)
-	c.Assert(err, ErrorMatches, "nodeID test2 not found")
+	c.Assert(errors.IsNotFound(err), IsTrue)
 
 	// TODO: handle log information and add check
 	err = ApplyAction("127.0.0.1:2379", "pumps", "test", PausePump)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

`registry.Nodes` is used to get all nodes before searching for the node
with the specified ID.

### What is changed and how it works?

Use `registry.Node` to look up the specified node ID directly.

The error output for nodes not found is a little different from before,
since the error is logged directly.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test

Code changes


Side effects


Related changes