### PR TITLE
Makefile: Version get the latest v4.0 tag for master

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ FILES := $$(find . -name '*.go' -type f | grep -vE 'vendor' | grep -vE 'binlog.p
 
 LDFLAGS += -X "github.com/pingcap/tidb-binlog/pkg/version.BuildTS=$(shell date -u '+%Y-%m-%d %I:%M:%S')"
 LDFLAGS += -X "github.com/pingcap/tidb-binlog/pkg/version.GitHash=$(shell git rev-parse HEAD)"
-LDFLAGS += -X "github.com/pingcap/tidb-binlog/pkg/version.ReleaseVersion=$(shell git describe --tags --dirty)"
+LDFLAGS += -X "github.com/pingcap/tidb-binlog/pkg/version.ReleaseVersion=$(shell git describe --tags --dirty --match 'v4.0*')"
 
 default: build buildsucc
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Version get the latest v4.0 tag for master
so we can keep release3.0 and master don't diverse and show different version for `-V`
### What is changed and how it works?
add `-match 'v4.0*` opt for git description

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Code changes

Side effects

 - Related changes

