### PR TITLE
Add metric for batch write kv

### DIFF
--- a/pump/storage/storage.go
+++ b/pump/storage/storage.go
@@ -1346,6 +1346,7 @@ func (a *Append) writeBatchToKV(bufReqs []*request) error {
 			a.headPointer = bufReqs[len(bufReqs)-1].valuePointer
 			return nil
 		}
+		errorCount.WithLabelValues("batch_write_kv").Add(1.0)
 
 		// when write to vlog success, but the disk is full when write to KV here, it will cause write err
 		// we just retry of quit when Append is closed


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
In some extreme cases, when leveldb write failed, pump server may be entering an infinite loop

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No Test
