### PR TITLE
pump/: Fix block at wait for MaxCommitTS when offline (#701)

### DIFF
--- a/pump/storage/sorter.go
+++ b/pump/storage/sorter.go
@@ -111,6 +111,13 @@ func (s *sorter) setResolver(resolver func(startTS int64) bool) {
 	s.resolver = resolver
 }
 
+func (s *sorter) allMatched() bool {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	return len(s.waitStartTS) == 0
+}
+
 func (s *sorter) pushTSItem(item sortItem) {
 	if s.isClosed() {
 		// i think we can just panic
@@ -135,6 +142,18 @@ func (s *sorter) pushTSItem(item sortItem) {
 
 func (s *sorter) run() {
 	defer s.wg.Done()
+
+	go func() {
+		// Avoid if no any more pushTSItem call so block at s.cond.Wait() in run() waiting the matching c-binlog
+		tick := time.NewTicker(1 * time.Second)
+		defer tick.Stop()
+		for range tick.C {
+			s.cond.Signal()
+			if s.isClosed() {
+				return
+			}
+		}
+	}()
 
 	var maxTSItem sortItem
 	for {
@@ -163,6 +182,7 @@ func (s *sorter) run() {
 				// we may get the C binlog soon at start up time
 				if time.Since(getTime) > time.Second {
 					if s.resolver != nil && s.resolver(item.start) {
+						delete(s.waitStartTS, item.start)
 						break
 					}
 				}

--- a/pump/storage/sorter_test.go
+++ b/pump/storage/sorter_test.go
@@ -33,6 +33,8 @@ func testSorter(c *check.C, items []sortItem, expectMaxCommitTS []int64) {
 		// we should never push item with commit ts less than lastGetSortItemTS, or something go wrong
 		if item.tp == pb.BinlogType_Commit {
 			c.Assert(item.commit, check.Greater, atomic.LoadInt64(&lastGetSortItemTS))
+		} else if item.tp == pb.BinlogType_Prewrite {
+			c.Assert(sorter.allMatched(), check.IsFalse)
 		}
 
 		if item.commit > maxTS {
@@ -51,6 +53,7 @@ func testSorter(c *check.C, items []sortItem, expectMaxCommitTS []int64) {
 	}
 
 	c.Assert(maxTS, check.Equals, maxCommitTS[len(maxCommitTS)-1])
+	c.Assert(sorter.allMatched(), check.IsTrue)
 }
 
 func (s *SorterSuite) TestSorter(c *check.C) {

--- a/pump/storage/storage.go
+++ b/pump/storage/storage.go
@@ -52,6 +52,9 @@ type Storage interface {
 
 	GetGCTS() int64
 
+	// AllMatched return if all the P-binlog have the matching C-binlog
+	AllMatched() bool
+
 	MaxCommitTS() int64
 
 	// GetBinlog return the binlog of ts
@@ -1214,4 +1217,9 @@ func openMetadataDB(kvDir string, cf *KVConfig) (*leveldb.DB, error) {
 	opt.WriteL0SlowdownTrigger = cf.WriteL0SlowdownTrigger
 
 	return leveldb.OpenFile(kvDir, &opt)
+}
+
+// AllMatched implement Storage.AllMatched
+func (a *Append) AllMatched() bool {
+	return a.sorter.allMatched()
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
* pump/: Fix block at wait for MaxCommitTS when offline

when offline:
1, ApplyAction change statue to be closing, reject write but accept fake
binlog
2, commitStatus() -> waitSafeToOffline(), we will write a fake binlog
and wait when storage.MaxCommitTS() >= commit ts of the fake binlog
...

after 1, may having some unwritten c-binlog(we will reject the write
request from tidb), and in sorter, block at s.cond.Wait case because no
more any item push.



### What is changed and how it works?
cherry-pick https://github.com/pingcap/tidb-binlog/pull/701

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

Side effects



Related changes


 - Need to be included in the release note