### PR TITLE
Use mustExec to simplify SQL execution in test cases

### DIFF
--- a/tests/dailytest/case.go
+++ b/tests/dailytest/case.go
@@ -235,7 +235,7 @@ func RunCase(src *sql.DB, dst *sql.DB, schema string) {
 	tr.run(func(src *sql.DB) {
 		mustExec(src, "create table uindex(id int primary key, a1 int unique)")
 
-		mustExec(src, "insert into uindex(id, a1) values(1, 10),(2,20)")
+		mustExec(src, "insert into uindex(id, a1) values(1, 10), (2, 20)")
 
 		tx, err := src.Begin()
 		if err != nil {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

There are many duplicate code for executing SQLs and exitting on error.


### What is changed and how it works?

Reuse `mustExec`.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Code changes

Side effects

Related changes