### PR TITLE
add node-id cmd to specify drainer's node-id

### DIFF
--- a/cmd/drainer/README.md
+++ b/cmd/drainer/README.md
@@ -41,6 +41,8 @@ Usage of drainer:
       prometheus pushgateway address, leaves it empty will disable prometheus push
   -metrics-interval int
       prometheus client push interval in second, set "0" to disable prometheus push (default 15)
+  -node-id string
+      the ID of drainer node; if not specified, we will generate one from hostname and the listening port
   -pd-urls string
       a comma separated list of PD endpoints (default "http://127.0.0.1:2379")
   -safe-mode

--- a/cmd/pump/README.md
+++ b/cmd/pump/README.md
@@ -34,7 +34,7 @@ pump is a daemon that receives realtime binlog from tidb-server and writes in se
   -metrics-interval int
       prometheus client push interval in second, set "0" to disable prometheus push (default 15)
   -node-id string
-      the ID of pump node; if not specify, we will generate one from hostname and the listening port
+      the ID of pump node; if not specified, we will generate one from hostname and the listening port
   -pd-urls string
       a comma separated list of the PD endpoints (default "http://127.0.0.1:2379")
   -zookeeper-addrs string

--- a/drainer/config.go
+++ b/drainer/config.go
@@ -65,6 +65,7 @@ type SyncerConfig struct {
 type Config struct {
 	*flag.FlagSet   `json:"-"`
 	LogLevel        string          `toml:"log-level" json:"log-level"`
+	NodeID          string          `toml:"node-id" json:"node-id"`
 	ListenAddr      string          `toml:"addr" json:"addr"`
 	AdvertiseAddr   string          `toml:"advertise-addr" json:"advertise-addr"`
 	DataDir         string          `toml:"data-dir" json:"data-dir"`
@@ -98,6 +99,7 @@ func NewConfig() *Config {
 		fmt.Fprintln(os.Stderr, "Usage of drainer:")
 		fs.PrintDefaults()
 	}
+	fs.StringVar(&cfg.NodeID, "node-id", "", "the ID of drainer node; if not specified, we will generate one from hostname and the listening port")
 	fs.StringVar(&cfg.ListenAddr, "addr", util.DefaultListenAddr(8249), "addr (i.e. 'host:port') to listen on for drainer connections")
 	fs.StringVar(&cfg.AdvertiseAddr, "advertise-addr", "", "addr(i.e. 'host:port') to advertise to the public, default to be the same value as -addr")
 	fs.StringVar(&cfg.DataDir, "data-dir", defaultDataDir, "drainer data directory path (default data.drainer)")

--- a/pump/config.go
+++ b/pump/config.go
@@ -81,7 +81,7 @@ func NewConfig() *Config {
 		fs.PrintDefaults()
 	}
 
-	fs.StringVar(&cfg.NodeID, "node-id", "", "the ID of pump node; if not specify, we will generate one from hostname and the listening port")
+	fs.StringVar(&cfg.NodeID, "node-id", "", "the ID of pump node; if not specified, we will generate one from hostname and the listening port")
 	fs.StringVar(&cfg.ListenAddr, "addr", util.DefaultListenAddr(8250), "addr(i.e. 'host:port') to listen on for client traffic")
 	fs.StringVar(&cfg.AdvertiseAddr, "advertise-addr", "", "addr(i.e. 'host:port') to advertise to the public")
 	fs.StringVar(&cfg.Socket, "socket", "", "unix socket addr to listen on for client traffic")


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
[TOOL-1410](https://internal.pingcap.net/jira/browse/TOOL-1410)

### What is changed and how it works?
Modify drainer/server.go. If user specifies a node-id, drainer ID will be set as this value. If not, drainer will automatically generate a node ID referring to the listening host name and port.
cherry-pick https://github.com/pingcap/tidb-binlog/pull/684

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

Side effects

Related changes
