### PR TITLE
fix bug when some error occurs in loader arbiter's syncBinlog may block

### DIFF
--- a/arbiter/server.go
+++ b/arbiter/server.go
@@ -162,13 +162,7 @@ func (s *Server) Close() error {
 
 // Run runs the Server, will quit once encounter error or Server is closed
 func (s *Server) Run() error {
-	defer func() {
-		if s.downDB != nil {
-			s.downDB.Close()
-		} else {
-			log.Error("Invalid downDB address, please check the config")
-		}
-	}()
+	defer s.downDB.Close()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/arbiter/server.go
+++ b/arbiter/server.go
@@ -162,7 +162,13 @@ func (s *Server) Close() error {
 
 // Run runs the Server, will quit once encounter error or Server is closed
 func (s *Server) Run() error {
-	defer s.downDB.Close()
+	defer func() {
+		if s.downDB != nil {
+			s.downDB.Close()
+		} else {
+			log.Error("Invalid downDB address, please check the config")
+		}
+	}()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/arbiter/server.go
+++ b/arbiter/server.go
@@ -200,7 +200,6 @@ func (s *Server) Run() error {
 
 	wg.Wait()
 
-	// to pass go check
 	syncCancel()
 	if err != nil {
 		return errors.Trace(err)

--- a/arbiter/server.go
+++ b/arbiter/server.go
@@ -186,7 +186,7 @@ func (s *Server) Run() error {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		syncErr = syncBinlogs(s.kafkaReader.Messages(), s.load, syncCtx)
+		syncErr = syncBinlogs(syncCtx, s.kafkaReader.Messages(), s.load)
 		if syncErr != nil {
 			s.Close()
 		}
@@ -273,7 +273,7 @@ func (s *Server) loadStatus() (int, error) {
 	return status, errors.Trace(err)
 }
 
-func syncBinlogs(source <-chan *reader.Message, ld loader.Loader, ctx context.Context) (err error) {
+func syncBinlogs(ctx context.Context, source <-chan *reader.Message, ld loader.Loader) (err error) {
 	dest := ld.Input()
 	defer ld.Close()
 	for msg := range source {

--- a/arbiter/server.go
+++ b/arbiter/server.go
@@ -200,6 +200,8 @@ func (s *Server) Run() error {
 
 	wg.Wait()
 
+	// to pass go check
+	syncCancel()
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -288,7 +290,7 @@ func syncBinlogs(ctx context.Context, source <-chan *reader.Message, ld loader.L
 		select {
 		case dest <- txn:
 		case <-ctx.Done():
-			break
+			return nil
 		}
 
 		queueSizeGauge.WithLabelValues("kafka_reader").Set(float64(len(source)))

--- a/arbiter/server_test.go
+++ b/arbiter/server_test.go
@@ -407,7 +407,7 @@ func (s *syncBinlogsSuite) TestShouldSendBinlogToLoader(c *C) {
 	}()
 	ld := dummyLoader{input: dest}
 
-	err := syncBinlogs(source, &ld, context.Background())
+	err := syncBinlogs(context.Background(), source, &ld)
 	c.Assert(err, IsNil)
 
 	c.Assert(len(dest), Equals, 2)

--- a/arbiter/server_test.go
+++ b/arbiter/server_test.go
@@ -407,7 +407,7 @@ func (s *syncBinlogsSuite) TestShouldSendBinlogToLoader(c *C) {
 	}()
 	ld := dummyLoader{input: dest}
 
-	err := syncBinlogs(source, &ld)
+	err := syncBinlogs(source, &ld, context.Background())
 	c.Assert(err, IsNil)
 
 	c.Assert(len(dest), Equals, 2)

--- a/arbiter/server_test.go
+++ b/arbiter/server_test.go
@@ -428,7 +428,6 @@ func (s *syncBinlogsSuite) TestShouldQuitWhenSomeErrorOccurs(c *C) {
 	}
 	msg := s.createMsg("test42", "users", "alter table users add column gender smallint")
 	ctx, cancel := context.WithCancel(context.Background())
-	syncCtx, syncCancel := context.WithCancel(ctx)
 	defer cancel()
 	// start a routine keep sending msgs to kafka reader
 	go func() {
@@ -442,10 +441,10 @@ func (s *syncBinlogsSuite) TestShouldQuitWhenSomeErrorOccurs(c *C) {
 	}()
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- syncBinlogs(syncCtx, readerMsgs, dummyLoaderImpl)
+		errCh <- syncBinlogs(ctx, readerMsgs, dummyLoaderImpl)
 	}()
 
-	syncCancel()
+	cancel()
 	select {
 	case err := <-errCh:
 		c.Assert(err, IsNil)

--- a/arbiter/server_test.go
+++ b/arbiter/server_test.go
@@ -431,6 +431,10 @@ func (s *syncBinlogsSuite) TestShouldQuitWhenSomeErrorOccurs(c *C) {
 	defer cancel()
 	// start a routine keep sending msgs to kafka reader
 	go func() {
+		// make sure there will be some msgs in readerMsgs for test
+		for i := 0; i < 3; i++ {
+			readerMsgs <- msg
+		}
 		for {
 			select {
 			case <-ctx.Done():
@@ -438,8 +442,9 @@ func (s *syncBinlogsSuite) TestShouldQuitWhenSomeErrorOccurs(c *C) {
 			case readerMsgs <- msg:
 			}
 		}
+		close(readerMsgs)
 	}()
-	errCh := make(chan error, 1)
+	errCh := make(chan error)
 	go func() {
 		errCh <- syncBinlogs(ctx, readerMsgs, dummyLoaderImpl)
 	}()

--- a/arbiter/server_test.go
+++ b/arbiter/server_test.go
@@ -435,6 +435,7 @@ func (s *syncBinlogsSuite) TestShouldQuitWhenSomeErrorOccurs(c *C) {
 		for i := 0; i < 3; i++ {
 			readerMsgs <- msg
 		}
+		defer close(readerMsgs)
 		for {
 			select {
 			case <-ctx.Done():
@@ -442,7 +443,6 @@ func (s *syncBinlogsSuite) TestShouldQuitWhenSomeErrorOccurs(c *C) {
 			case readerMsgs <- msg:
 			}
 		}
-		close(readerMsgs)
 	}()
 	errCh := make(chan error)
 	go func() {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
[TOOL-1488](https://internal.pingcap.net/jira/browse/TOOL-1488)
When loader executes some dmls and meet an error in `loader.Run()`, it will shut down, report an error and stop dealing with chan `loader.input`. But `syncBinlogs` in `arbiter/server.go` will keep on pushing items into `loader.input`, when it get full, function `syncBinlogs` will be blocked and then arbiter will be unable to quit or issue the error.
### What is changed and how it works?
Add `syncCtx` and `select` in function `syncBinlogs` to avoid blocking.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
Modified arbiter will quit as we expect.
![image](https://user-images.githubusercontent.com/21104942/63007737-cd0b3d00-beb3-11e9-83ce-485b61079b60.png)

Code changes

Side effects

Related changes
