### PR TITLE
Avoid repeated called of NewIterator which might be slow

### DIFF
--- a/pump/storage/metrics.go
+++ b/pump/storage/metrics.go
@@ -38,7 +38,7 @@ var (
 		prometheus.CounterOpts{
 			Namespace: "binlog",
 			Subsystem: "pump_storage",
-			Name:      "deleted_kv",
+			Name:      "deleted_kv_total",
 			Help:      "deleted kv number",
 		})
 

--- a/pump/storage/metrics.go
+++ b/pump/storage/metrics.go
@@ -26,6 +26,22 @@ var (
 			Help:      "gc ts of storage",
 		})
 
+	doneGcTSGauge = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "binlog",
+			Subsystem: "pump_storage",
+			Name:      "done_gc_ts",
+			Help:      "the metadata and vlog after this gc ts has been collected",
+		})
+
+	deletedKv = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: "binlog",
+			Subsystem: "pump_storage",
+			Name:      "deleted_kv",
+			Help:      "deleted kv number",
+		})
+
 	storageSizeGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: "binlog",
@@ -97,6 +113,8 @@ var (
 // InitMetircs register the metrics to registry
 func InitMetircs(registry *prometheus.Registry) {
 	registry.MustRegister(gcTSGauge)
+	registry.MustRegister(doneGcTSGauge)
+	registry.MustRegister(deletedKv)
 	registry.MustRegister(maxCommitTSGauge)
 	registry.MustRegister(tikvQueryCount)
 	registry.MustRegister(errorCount)

--- a/pump/storage/storage.go
+++ b/pump/storage/storage.go
@@ -718,8 +718,8 @@ func (a *Append) doGCTS(ts int64) {
 
 		if len(lastKey) > 0 {
 			a.vlog.gcTS(decodeTSKey(lastKey))
+			doneGcTSGauge.Set(float64(oracle.ExtractPhysical(uint64(decodeTSKey(lastKey)))))
 		}
-		doneGcTSGauge.Set(float64(oracle.ExtractPhysical(uint64(decodeTSKey(lastKey)))))
 		log.Info("has delete", zap.Int("delete num", deleteNum))
 	}
 

--- a/pump/storage/storage.go
+++ b/pump/storage/storage.go
@@ -698,6 +698,7 @@ func (a *Append) doGCTS(ts int64) {
 				if err != nil {
 					log.Error("write batch failed", zap.Error(err))
 				}
+				deletedKv.Add(float64(batch.Len()))
 				batch.Reset()
 				deleteBatch++
 			}
@@ -709,8 +710,8 @@ func (a *Append) doGCTS(ts int64) {
 				if err != nil {
 					log.Error("write batch failed", zap.Error(err))
 				}
+				deletedKv.Add(float64(batch.Len()))
 				batch.Reset()
-				deletedKv.Add(float64(deleteBatch * 1024))
 			}
 			break
 		}
@@ -718,7 +719,6 @@ func (a *Append) doGCTS(ts int64) {
 		if len(lastKey) > 0 {
 			a.vlog.gcTS(decodeTSKey(lastKey))
 		}
-		deletedKv.Add(float64(deleteBatch * 1024))
 		doneGcTSGauge.Set(float64(oracle.ExtractPhysical(uint64(decodeTSKey(lastKey)))))
 		log.Info("has delete", zap.Int("delete num", deleteNum))
 	}

--- a/pump/storage/storage.go
+++ b/pump/storage/storage.go
@@ -660,6 +660,12 @@ func (a *Append) doGCTS(ts int64) {
 
 	deleteNum := 0
 
+	irange := &util.Range{
+		Start: encodeTSKey(0),
+		Limit: encodeTSKey(ts + 1),
+	}
+	iter := a.metadata.NewIterator(irange, nil)
+
 	for {
 		nStr, err := a.metadata.GetProperty("leveldb.num-files-at-level0")
 		if err != nil {
@@ -678,12 +684,6 @@ func (a *Append) doGCTS(ts int64) {
 			time.Sleep(5 * time.Second)
 			continue
 		}
-
-		irange := &util.Range{
-			Start: encodeTSKey(0),
-			Limit: encodeTSKey(ts + 1),
-		}
-		iter := a.metadata.NewIterator(irange, nil)
 
 		deleteBatch := 0
 		var lastKey []byte


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
When the size of metadata(storage with leveldb) grown very large, pump storage gc will be very slowly. The reason for this bug is the `seek` operation in `goleveldb` spend too much time.

### What is changed and how it works? 
we `seek` only one time on the `init` process of GC, instead of `seek` every time before `vlog gc`.
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
Passed
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code
