### PR TITLE
fix iter may not be Released in some cases

### DIFF
--- a/pump/storage/storage.go
+++ b/pump/storage/storage.go
@@ -700,7 +700,7 @@ func (a *Append) doGCTS(ts int64) {
 		var lastKey []byte
 
 		if iter == nil {
-			log.Info("create new gc iter", zap.Int64("ts", ts),
+			log.Info("New LevelDB iterator created for GC", zap.Int64("ts", ts),
 				zap.Int64("start", decodeTSKey(irange.Start)),
 				zap.Int64("limit", decodeTSKey(irange.Limit)))
 			iter = a.metadata.NewIterator(irange, nil)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
When error happened in loop,  iter may not be released. And when `l0Num >= l0Trigger`, we better release the iter, it may be affect compaction operation.

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note