### PR TITLE
Avoid risk of ignoring failed to read checkpoint

### DIFF
--- a/drainer/checkpoint/mysql.go
+++ b/drainer/checkpoint/mysql.go
@@ -94,7 +94,6 @@ func (sp *MysqlCheckPoint) Load() error {
 		sp.CommitTS = sp.initialCommitTS
 		return nil
 	case err != nil:
-		log.Errorf("select checkPoint error %v", err)
 		return errors.Annotatef(err, "QueryRow failed, sql: %s", selectSQL)
 	}
 

--- a/drainer/checkpoint/mysql.go
+++ b/drainer/checkpoint/mysql.go
@@ -86,29 +86,19 @@ func (sp *MysqlCheckPoint) Load() error {
 		sp.Unlock()
 	}()
 
-	sql := genSelectSQL(sp)
-	rows, err := querySQL(sp.db, sql)
-	if err != nil {
-		log.Errorf("select checkPoint error %v", err)
-		return errors.Trace(err)
-	}
-
 	var str string
-	for rows.Next() {
-		err = rows.Scan(&str)
-		if err != nil {
-			log.Errorf("rows Scan error %v", err)
-			return errors.Trace(err)
-		}
-	}
-
-	if len(str) == 0 {
+	selectSQL := genSelectSQL(sp)
+	err := sp.db.QueryRow(selectSQL).Scan(&str)
+	switch {
+	case err == sql.ErrNoRows:
 		sp.CommitTS = sp.initialCommitTS
 		return nil
+	case err != nil:
+		log.Errorf("select checkPoint error %v", err)
+		return errors.Annotatef(err, "QueryRow failed, sql: %s", selectSQL)
 	}
 
-	err = json.Unmarshal([]byte(str), sp)
-	if err != nil {
+	if err = json.Unmarshal([]byte(str), sp); err != nil {
 		return errors.Trace(err)
 	}
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
[TOOL-1520](https://internal.pingcap.net/jira/browse/TOOL-1520)
In previous `drainer/checkpoint/mysql.go:Load()` we use `query` to get the checkpoint data but never check the `row.Err()` which may skip some failures but the `checkpoint` is still updated.
### What is changed and how it works?
Modify `Load()` in mysql checkpoint. Current version will use `queryrow` instead of `query` to avoid missing some errors.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test


Code changes

Side effects


Related changes
