### PR TITLE
Change default cache count from 65536 to 512(#721)

### DIFF
--- a/drainer/config.go
+++ b/drainer/config.go
@@ -38,7 +38,7 @@ const (
 
 var (
 	maxBinlogItemCount     int
-	defaultBinlogItemCount = 16 << 12
+	defaultBinlogItemCount = 512
 	supportedCompressors   = [...]string{"gzip"}
 )
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Cherry pick of https://github.com/pingcap/tidb-binlog/pull/721
Current default cache count is too big which can easily cause OOM of drainer.
### What is changed and how it works?
The default size is changed from 65536 to 512.
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

Side effects

Related changes
