### PR TITLE
tests: Rewrite updatePKUK to avoid outputing a lot of messages about generating PKs

### DIFF
--- a/tests/dailytest/case.go
+++ b/tests/dailytest/case.go
@@ -352,10 +352,7 @@ func updatePKUK(db *sql.DB, opNum int) error {
 	mustExec(db, "create table pkuk(pk int primary key, uk int, v int, unique key uk(uk));")
 
 	pks := make(map[int]struct{})
-	freePks := make([]int, maxKey)
-	for i := 0; i < maxKey; i++ {
-		freePks[i] = i
-	}
+	freePks := rand.Perm(maxKey)
 
 	nextPk := func() int {
 		return freePks[0]

--- a/tests/dailytest/case.go
+++ b/tests/dailytest/case.go
@@ -355,11 +355,20 @@ func updatePKUK(db *sql.DB, opNum int) error {
 	freePks := rand.Perm(maxKey)
 
 	nextPk := func() int {
+		rand.Shuffle(len(freePks), func(i, j int) {
+			freePks[i], freePks[j] = freePks[j], freePks[i]
+		})
 		return freePks[0]
 	}
 	addPK := func(pk int) {
 		pks[pk] = struct{}{}
-		freePks = freePks[1:]
+		var i, v int
+		for i, v = range freePks {
+			if v == pk {
+				break
+			}
+		}
+		freePks = append(freePks[:i], freePks[i+1:]...)
 	}
 	removePK := func(pk int) {
 		delete(pks, pk)

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -161,7 +161,7 @@ run_case() {
 }
 
 # List the case names to run, eg. ("binlog" "kafka")
-do_cases=("binlog")
+do_cases=()
 
 if [ ${#do_cases[@]} -eq 0 ]; then
     for script in ./*/run.sh; do

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -161,7 +161,7 @@ run_case() {
 }
 
 # List the case names to run, eg. ("binlog" "kafka")
-do_cases=()
+do_cases=("binlog")
 
 if [ ${#do_cases[@]} -eq 0 ]; then
     for script in ./*/run.sh; do


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

updatePKUK output a lot of logs for retrying to generate unused PKs.


### What is changed and how it works?

Record free PKs explicitly to avoid retrying.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Code changes


Side effects

Related changes