### PR TITLE
fix pump pull pop bug while closing pump

### DIFF
--- a/pump/server.go
+++ b/pump/server.go
@@ -83,6 +83,7 @@ type Server struct {
 	wg         sync.WaitGroup
 	gcDuration time.Duration
 	triggerGC  chan time.Time
+	pullClose  chan struct{}
 	metrics    *util.MetricClient
 	// save the last time we write binlog to Storage
 	// if long time not write, we can write a fake binlog
@@ -181,6 +182,7 @@ func NewServer(cfg *Config) (*Server, error) {
 		pdCli:      pdCli,
 		cfg:        cfg,
 		triggerGC:  make(chan time.Time),
+		pullClose:  make(chan struct{}),
 	}, nil
 }
 
@@ -278,12 +280,14 @@ func (s *Server) PullBinlogs(in *binlog.PullBinlogReq, stream binlog.Pump_PullBi
 		log.Error("drainer request a purged binlog TS, some binlog events may be loss", zap.Int64("gc TS", gcTS), zap.Reflect("request", in))
 	}
 
-	ctx, cancel := context.WithCancel(s.ctx)
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	binlogs := s.storage.PullCommitBinlog(ctx, last)
 
 	for {
 		select {
+		case <-s.pullClose:
+			return nil
 		case data, ok := <-binlogs:
 			if !ok {
 				return nil
@@ -857,6 +861,7 @@ func (s *Server) Close() {
 	s.commitStatus()
 	log.Info("commit status done")
 
+	close(s.pullClose)
 	// stop the gRPC server
 	s.gs.GracefulStop()
 	log.Info("grpc is stopped")

--- a/pump/server_test.go
+++ b/pump/server_test.go
@@ -733,7 +733,8 @@ func (s *startServerSuite) TestStartPumpServer(c *C) {
 		gcDuration: time.Duration(cfg.GC) * 24 * time.Hour,
 		pdCli:      nil,
 		cfg:        cfg,
-		triggerGC:  make(chan time.Time)}
+		triggerGC:  make(chan time.Time),
+		pullClose:  make(chan struct{})}
 	defer func() {
 		close(sig)
 		p.Close()


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
cherry-pick of https://github.com/pingcap/tidb-binlog/pull/739
When we try to close pump server, we will cancel `s.ctx` first. But we wish that `storage` will pull storaged binlogs until drainer receives them. Then pump can safely quit. But if we use `s.ctx` for `storage.PullCommitBinlog` it will quit at first and drainer may no longer receive binlog from this pump.

### What is changed and how it works?
Change `s.ctx` to `context.Background()` and add `s.pullClose` channel to control the closure of `PullBinlogs`. Run `close(s.pullClose)` after `commitStatus`.

### Check List <!--REMOVE the items that are not applicable-->


Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

Side effects

Related changes
