### PR TITLE
optimize drainer syncer quit

### DIFF
--- a/drainer/syncer.go
+++ b/drainer/syncer.go
@@ -377,14 +377,16 @@ ForLoop:
 
 			err = s.schema.handlePreviousDDLJobIfNeed(b.job.BinlogInfo.SchemaVersion)
 			if err != nil {
-				return errors.Trace(err)
+				err = errors.Trace(err)
+				break ForLoop
 			}
 
 			sql := b.job.Query
 			var schema, table string
 			schema, table, err = s.schema.getSchemaTableAndDelete(b.job.BinlogInfo.SchemaVersion)
 			if err != nil {
-				return errors.Trace(err)
+				err = errors.Trace(err)
+				break ForLoop
 			}
 
 			if s.filter.SkipSchemaAndTable(schema, table) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
In `syncer.run` if we quit directly channel `syncer.closed` will not be closed and drainer will get blocked while closing.

### What is changed and how it works?
Change `return` to `break ForLoop`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

Side effects

Related changes
