### PR TITLE
fix pump server_test

### DIFF
--- a/pump/server_test.go
+++ b/pump/server_test.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"net/http"
 	"path"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -709,7 +710,7 @@ func (s *startServerSuite) TestStartPumpServer(c *C) {
 	cfg := &Config{
 		ListenAddr:        "http://127.0.0.1:8250",
 		AdvertiseAddr:     "http://127.0.0.1:8260",
-		Socket:            "unix://127.0.0.1:" + string(time.Now().UnixNano()) + "/hello/world",
+		Socket:            "unix://127.0.0.1:" + strconv.FormatInt(time.Now().UnixNano(), 10) + "/hello/world",
 		EtcdURLs:          strings.Join(etcdClient.Endpoints(), ","),
 		DataDir:           path.Join(c.MkDir(), "pump"),
 		HeartbeatInterval: 1500,

--- a/pump/server_test.go
+++ b/pump/server_test.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"net"
 	"net/http"
 	"path"
@@ -707,10 +708,12 @@ func (s *startServerSuite) TestStartPumpServer(c *C) {
 		return 0, nil
 	}
 	etcdClient := testEtcdCluster.RandClient()
+	r := rand.New(rand.NewSource(time.Now().Unix()))
+	randPort := int64(r.Intn(5536) + 60000)
 	cfg := &Config{
 		ListenAddr:        "http://127.0.0.1:8250",
 		AdvertiseAddr:     "http://127.0.0.1:8260",
-		Socket:            "unix://127.0.0.1:" + strconv.FormatInt(time.Now().UnixNano(), 10) + "/hello/world",
+		Socket:            "unix://127.0.0.1:" + strconv.FormatInt(randPort, 10) + "/hello/world",
 		EtcdURLs:          strings.Join(etcdClient.Endpoints(), ","),
 		DataDir:           path.Join(c.MkDir(), "pump"),
 		HeartbeatInterval: 1500,


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Refine Pump server test to avoid fault in `TestStartPumpServer`.

### What is changed and how it works?
Change `string` to `strconv.FormatInt`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

Side effects

Related changes
