### PR TITLE
storage.go: Make query tikv for ddl too

### DIFF
--- a/pump/storage/storage.go
+++ b/pump/storage/storage.go
@@ -505,7 +505,7 @@ func (a *Append) resolve(startTS int64) bool {
 
 		req := a.writeBinlog(cbinlog)
 		if req.err != nil {
-			log.Error("writeBinlog failed", zap.Error(req.err))
+			log.Error("write missing commit binlog failed", zap.Error(req.err))
 			return false
 		}
 

--- a/pump/storage/storage.go
+++ b/pump/storage/storage.go
@@ -505,10 +505,11 @@ func (a *Append) resolve(startTS int64) bool {
 
 		req := a.writeBinlog(cbinlog)
 		if req.err != nil {
-			log.Error("write missing committed binlog failed", 
-				  zap.Int64("start ts", startTS),
-				  zap.Uint64("commit ts", status.CommitTS()),
-				  zap.Bool("isDDL", pbinlog.GetDdlJobId() > 0)), zap.Error(req.err))
+			log.Error("write missing committed binlog failed",
+				zap.Int64("start ts", startTS),
+				zap.Uint64("commit ts", status.CommitTS()),
+				zap.Bool("isDDL", pbinlog.GetDdlJobId() > 0),
+				zap.Error(req.err))
 			return false
 		}
 
@@ -524,9 +525,10 @@ func (a *Append) resolve(startTS int64) bool {
 		err = a.metadata.Put(encodeTSKey(req.ts()), pointer, nil)
 		if err != nil {
 			log.Error("put missing committed binlog into metadata failed",
-				  zap.Int64("start ts", startTS),
-				  zap.Uint64("commit ts", status.CommitTS()),
-				  zap.Bool("isDDL", pbinlog.GetDdlJobId() > 0)), zap.Error(err)))
+				zap.Int64("start ts", startTS),
+				zap.Uint64("commit ts", status.CommitTS()),
+				zap.Bool("isDDL", pbinlog.GetDdlJobId() > 0),
+				zap.Error(err))
 			return false
 		}
 	}

--- a/pump/storage/storage.go
+++ b/pump/storage/storage.go
@@ -505,7 +505,10 @@ func (a *Append) resolve(startTS int64) bool {
 
 		req := a.writeBinlog(cbinlog)
 		if req.err != nil {
-			log.Error("write missing commit binlog failed", zap.Error(req.err))
+			log.Error("write missing committed binlog failed", 
+				  zap.Int64("start ts", startTS),
+				  zap.Uint64("commit ts", status.CommitTS()),
+				  zap.Bool("isDDL", pbinlog.GetDdlJobId() > 0)), zap.Error(req.err))
 			return false
 		}
 
@@ -520,7 +523,10 @@ func (a *Append) resolve(startTS int64) bool {
 
 		err = a.metadata.Put(encodeTSKey(req.ts()), pointer, nil)
 		if err != nil {
-			log.Error("put into metadata failed", zap.Error(req.err))
+			log.Error("put missing committed binlog into metadata failed",
+				  zap.Int64("start ts", startTS),
+				  zap.Uint64("commit ts", status.CommitTS()),
+				  zap.Bool("isDDL", pbinlog.GetDdlJobId() > 0)), zap.Error(err)))
 			return false
 		}
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Call CleanUp cmp for ddl binlog too.
may get the txn status from tikv or skip the binlog.

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 Code changes

 Side effects

Related changes

