### PR TITLE
pump.Storage: fix possible panic if start ts is greater than max commit ts when pull binlog 

### DIFF
--- a/pump/storage/sorter.go
+++ b/pump/storage/sorter.go
@@ -15,6 +15,7 @@ package storage
 
 import (
 	"container/list"
+	"fmt"
 	"math/rand"
 	"sync"
 	"sync/atomic"
@@ -90,6 +91,11 @@ type sortItem struct {
 	start  int64
 	commit int64
 	tp     pb.BinlogType
+}
+
+// String implements fmt.Stringer
+func (s *sortItem) String() string {
+	return fmt.Sprintf("{start: %d, commit: %d, tp: %v}", s.start, s.commit, s.tp)
 }
 
 type sorter struct {

--- a/pump/storage/vlog.go
+++ b/pump/storage/vlog.go
@@ -120,6 +120,20 @@ func (r *request) String() string {
 	return fmt.Sprintf("{ts: %d, payload len: %d, valuePointer: %+v}", r.ts(), len(r.payload), r.valuePointer)
 }
 
+type batchRequest []*request
+
+// String implements fmt.Stringer
+func (b *batchRequest) String() string {
+	s := new(strings.Builder)
+	s.WriteString("{")
+	for _, r := range []*request(*b) {
+		s.WriteString(r.String())
+	}
+	s.WriteString("}")
+
+	return s.String()
+}
+
 type valuePointer struct {
 	Fid    uint32
 	Offset int64

--- a/pump/storage/vlog.go
+++ b/pump/storage/vlog.go
@@ -128,6 +128,7 @@ func (b *batchRequest) String() string {
 	s.WriteString("{")
 	for _, r := range []*request(*b) {
 		s.WriteString(r.String())
+		s.WriteByte(',')
 	}
 	s.WriteString("}")
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
in pull binlog, if start ts is greater than max commit ts, pump may panic because goleveldb's bug https://github.com/syndtr/goleveldb/issues/224 

### What is changed and how it works?
add a check in storage
and update some log by the way

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test

Related changes

 - Need to cherry-pick to the release branch