### PR TITLE
drainer: refine log when meeting duplicate binlog

### DIFF
--- a/drainer/merge.go
+++ b/drainer/merge.go
@@ -315,14 +315,17 @@ func (m *Merger) run() {
 			continue
 		}
 
-		if minBinlog.GetCommitTs() <= latestTS {
+		minBinlogTS := minBinlog.GetCommitTs()
+		if minBinlogTS < latestTS {
 			disorderBinlogCount.Add(1)
 			log.Error("binlog's commit ts less than the last ts",
-				zap.Int64("commit ts", minBinlog.GetCommitTs()),
+				zap.Int64("commit ts", minBinlogTS),
 				zap.Int64("last ts", latestTS))
+		} else if minBinlogTS == latestTS {
+			log.Warn("duplicate binlog", zap.Int64("commit ts", minBinlogTS))
 		} else {
 			m.output <- minBinlog
-			latestTS = minBinlog.GetCommitTs()
+			latestTS = minBinlogTS
 		}
 
 		m.Lock()


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

when drainer receives duplicate binlog, it will output an error log like `binlog's commit ts less than the last ts`

### What is changed and how it works?

Change log level to `Warn` for duplicate binlog

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

Side effects

Related changes

 - Need to cherry-pick to the release branch