### PR TITLE
binlogctl: Only show offline nodes when explicitly told so

### DIFF
--- a/binlogctl/config.go
+++ b/binlogctl/config.go
@@ -64,17 +64,18 @@ const (
 type Config struct {
 	*flag.FlagSet
 
-	Command      string `toml:"cmd" json:"cmd"`
-	NodeID       string `toml:"node-id" json:"node-id"`
-	DataDir      string `toml:"data-dir" json:"data-dir"`
-	TimeZone     string `toml:"time-zone" json:"time-zone"`
-	EtcdURLs     string `toml:"pd-urls" json:"pd-urls"`
-	SSLCA        string `toml:"ssl-ca" json:"ssl-ca"`
-	SSLCert      string `toml:"ssl-cert" json:"ssl-cert"`
-	SSLKey       string `toml:"ssl-key" json:"ssl-key"`
-	State        string `toml:"state" json:"state"`
-	tls          *tls.Config
-	printVersion bool
+	Command          string `toml:"cmd" json:"cmd"`
+	NodeID           string `toml:"node-id" json:"node-id"`
+	DataDir          string `toml:"data-dir" json:"data-dir"`
+	TimeZone         string `toml:"time-zone" json:"time-zone"`
+	EtcdURLs         string `toml:"pd-urls" json:"pd-urls"`
+	SSLCA            string `toml:"ssl-ca" json:"ssl-ca"`
+	SSLCert          string `toml:"ssl-cert" json:"ssl-cert"`
+	SSLKey           string `toml:"ssl-key" json:"ssl-key"`
+	State            string `toml:"state" json:"state"`
+	ShowOfflineNodes bool   `toml:"state" json:"show-offline-nodes"`
+	tls              *tls.Config
+	printVersion     bool
 }
 
 // NewConfig returns an instance of configuration
@@ -91,6 +92,7 @@ func NewConfig() *Config {
 	cfg.FlagSet.StringVar(&cfg.SSLKey, "ssl-key", "", "Path of file that contains X509 key in PEM format for connection with cluster components.")
 	cfg.FlagSet.StringVar(&cfg.TimeZone, "time-zone", "", "set time zone if you want save time info in savepoint file, for example `Asia/Shanghai` for CST time, `Local` for local time")
 	cfg.FlagSet.StringVar(&cfg.State, "state", "", "set node's state, can set to online, pausing, paused, closing or offline.")
+	cfg.FlagSet.BoolVar(&cfg.ShowOfflineNodes, "show-offline-nodes", false, "include offline nodes when querying pumps/drainers")
 	cfg.FlagSet.BoolVar(&cfg.printVersion, "V", false, "prints version and exit")
 
 	return cfg

--- a/binlogctl/nodes.go
+++ b/binlogctl/nodes.go
@@ -34,7 +34,7 @@ var (
 )
 
 // QueryNodesByKind returns specified nodes, like pumps/drainers
-func QueryNodesByKind(urls string, kind string) error {
+func QueryNodesByKind(urls string, kind string, showOffline bool) error {
 	registry, err := createRegistryFuc(urls)
 	if err != nil {
 		return errors.Trace(err)
@@ -46,6 +46,9 @@ func QueryNodesByKind(urls string, kind string) error {
 	}
 
 	for _, n := range nodes {
+		if n.State == node.Offline && !showOffline {
+			continue
+		}
 		log.Info("query node", zap.String("type", kind), zap.Stringer("node", n))
 	}
 

--- a/binlogctl/nodes_test.go
+++ b/binlogctl/nodes_test.go
@@ -75,7 +75,7 @@ func (s *testNodesSuite) TestQueryNodesByKind(c *C) {
 	registerPumpForTest(c, "test", "127.0.0.1:8255")
 
 	// TODO: handle log information and add check
-	err := QueryNodesByKind("127.0.0.1:2379", "pumps")
+	err := QueryNodesByKind("127.0.0.1:2379", "pumps", false)
 	c.Assert(err, IsNil)
 }
 

--- a/cmd/binlogctl/main.go
+++ b/cmd/binlogctl/main.go
@@ -45,9 +45,9 @@ func main() {
 	case ctl.GenerateMeta:
 		err = ctl.GenerateMetaInfo(cfg)
 	case ctl.QueryPumps:
-		err = ctl.QueryNodesByKind(cfg.EtcdURLs, node.PumpNode)
+		err = ctl.QueryNodesByKind(cfg.EtcdURLs, node.PumpNode, cfg.ShowOfflineNodes)
 	case ctl.QueryDrainers:
-		err = ctl.QueryNodesByKind(cfg.EtcdURLs, node.DrainerNode)
+		err = ctl.QueryNodesByKind(cfg.EtcdURLs, node.DrainerNode, cfg.ShowOfflineNodes)
 	case ctl.UpdatePump:
 		err = ctl.UpdateNodeState(cfg.EtcdURLs, node.PumpNode, cfg.NodeID, cfg.State)
 	case ctl.UpdateDrainer:

--- a/tests/_utils/check_status
+++ b/tests/_utils/check_status
@@ -18,7 +18,7 @@ max_commit_ts_new=0
 
 for i in {1..15}
 do
-    binlogctl -pd-urls 127.0.0.1:2379 -cmd $NODE_KIND > $STATUS_LOG 2>&1
+    binlogctl -pd-urls 127.0.0.1:2379 -cmd $NODE_KIND -show-offline-nodes > $STATUS_LOG 2>&1
     cat $STATUS_LOG
 
     if [ $NODE_KIND == "pumps" ]; then 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Some users complain that pump/drainer nodes that have been turn off still appears in the list.


### What is changed and how it works?

Hide `offline` nodes by default, only show them when `-show-offline-nodes` is set.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test
    I set a drainer to `offline` and then check with `binlogctl drainers`.

Code changes


Side effects

Related changes

 - Need to update the documentation