### PR TITLE
pump/storge: Measure time taken to write to disk, to rotate and fsync

### DIFF
--- a/pump/storage/log.go
+++ b/pump/storage/log.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
@@ -211,7 +212,9 @@ func (lf *logFile) Write(data []byte, sync bool) error {
 		return errors.Annotatef(err, "unable to write to log file: %s", lf.path)
 	}
 	if sync {
+		fsyncT0 := time.Now()
 		err = lf.fdatasync()
+		writeBinlogTimeHistogram.WithLabelValues("fsync").Observe(time.Since(fsyncT0).Seconds())
 		if err != nil {
 			return errors.Annotatef(err, "fdatasync file %s failed", lf.path)
 		}


### PR DESCRIPTION
cherry-pick #773 to release-3.1

---

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

We only measurer the time taken to write a batch of binlogs at the top level.
But we have no other measurementt to help us figure out which step is taking up most of the time.


### What is changed and how it works?

Add 3 metrics:

1. Time taken to write a buf
1. Time taken to rotate
1. Time taken to fsync


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes


Side effects


Related changes

 - Need to update the documentation
 - Need to update the `tidb-ansible` repository