### PR TITLE
fix deadlock while drainer.Syncer panic

### DIFF
--- a/drainer/syncer.go
+++ b/drainer/syncer.go
@@ -258,6 +258,8 @@ func (s *Syncer) savePoint(ts, slaveTS int64) {
 }
 
 func (s *Syncer) run() error {
+	defer close(s.closed)
+
 	wait := make(chan struct{})
 
 	fakeBinlogCh := make(chan *pb.Binlog, 1024)
@@ -421,8 +423,6 @@ ForLoop:
 	case <-time.After(runWaitThreshold):
 		panic("Waiting too long for `Syncer.run` to quit.")
 	}
-
-	close(s.closed)
 
 	// return the origin error if has, or the close error
 	if err != nil {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
we start `Syncer` goroutine in `drainer`
```
s.tg.GoNoPanic("syncer", func() {
	defer func() { go s.Close() }()
	if err := s.syncer.Start(); err != nil {
		log.Error("syncer exited abnormal", zap.Error(err))
	}
})
```

if `s.syncer` panic (like kafka producer panic), `s.syncer.Start()` would exit directly and  the logics will happen 
* drainer calls `s.syncer.Close()` in `s.Close()`
* `s.syncer.Close()` would wait `<- s.syncer.closed` take effetcs,
* but `s.syncer.closed` only can be closed in `s.syncer.run()`

### What is changed and how it works?

add `defer close(s.syncer.closed)` in `s.syncer.run()`

### Check List <!--REMOVE the items that are not applicable-->