### PR TITLE
loader: add a log when table not found

### DIFF
--- a/pkg/loader/util.go
+++ b/pkg/loader/util.go
@@ -21,6 +21,8 @@ import (
 	"strings"
 
 	"github.com/pingcap/errors"
+	"github.com/pingcap/log"
+	"go.uber.org/zap"
 )
 
 var (
@@ -58,6 +60,7 @@ func getTableInfo(db *gosql.DB, schema string, table string) (info *tableInfo, e
 
 	if info.columns, err = getColsOfTbl(db, schema, table); err != nil {
 		if err == ErrTableNotExist {
+			log.Warn("table not exist", zap.String("schema", schema), zap.String("table", table))
 			return nil, err
 		}
 		return nil, errors.Trace(err)

--- a/pkg/loader/util.go
+++ b/pkg/loader/util.go
@@ -21,8 +21,6 @@ import (
 	"strings"
 
 	"github.com/pingcap/errors"
-	"github.com/pingcap/log"
-	"go.uber.org/zap"
 )
 
 var (
@@ -59,11 +57,7 @@ func getTableInfo(db *gosql.DB, schema string, table string) (info *tableInfo, e
 	info = new(tableInfo)
 
 	if info.columns, err = getColsOfTbl(db, schema, table); err != nil {
-		if err == ErrTableNotExist {
-			log.Warn("table not exist", zap.String("schema", schema), zap.String("table", table))
-			return nil, err
-		}
-		return nil, errors.Trace(err)
+		return nil, errors.Annotatef(err, "table `%s`.`%s`", schema, table)
 	}
 
 	if info.uniqueKeys, err = getUniqKeys(db, schema, table); err != nil {

--- a/pkg/loader/util_test.go
+++ b/pkg/loader/util_test.go
@@ -19,6 +19,7 @@ import (
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	check "github.com/pingcap/check"
+	"github.com/pingcap/errors"
 )
 
 func Test(t *testing.T) { check.TestingT(t) }
@@ -41,7 +42,7 @@ func (cs *UtilSuite) TestGetTableInfoTableNotExist(c *check.C) {
 	mock.ExpectQuery(regexp.QuoteMeta(colsSQL)).WithArgs("test", "test1").WillReturnRows(columnRows)
 
 	_, err = getTableInfo(db, "test", "test1")
-	c.Assert(err, check.Equals, ErrTableNotExist)
+	c.Assert(errors.Cause(err), check.Equals, ErrTableNotExist)
 
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
add a log when table not found

### What is changed and how it works?
when table not found in `getTableInfo` function, we can't know which table was unfound.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration tes