### PR TITLE
arbiter: discard the repeated kafka message

### DIFF
--- a/arbiter/server.go
+++ b/arbiter/server.go
@@ -292,6 +292,7 @@ func syncBinlogs(ctx context.Context, source <-chan *reader.Message, ld loader.L
 		log.Debug("recv msg from kafka reader", zap.Int64("ts", msg.Binlog.CommitTs), zap.Int64("offset", msg.Offset))
 
 		if msg.Binlog.CommitTs <= receivedTs {
+			log.Info("skip repeated binlog", zap.Int64("ts", msg.Binlog.CommitTs), zap.Int64("offset", msg.Offset))
 			continue
 		}
 		receivedTs = msg.Binlog.CommitTs

--- a/arbiter/server.go
+++ b/arbiter/server.go
@@ -287,8 +287,15 @@ func (s *Server) loadStatus() (int, error) {
 func syncBinlogs(ctx context.Context, source <-chan *reader.Message, ld loader.Loader) (err error) {
 	dest := ld.Input()
 	defer ld.Close()
+	var receivedTs int64
 	for msg := range source {
 		log.Debug("recv msg from kafka reader", zap.Int64("ts", msg.Binlog.CommitTs), zap.Int64("offset", msg.Offset))
+
+		if msg.Binlog.CommitTs <= receivedTs {
+			continue
+		}
+		receivedTs = msg.Binlog.CommitTs
+
 		txn, err := loader.SlaveBinlogToTxn(msg.Binlog)
 		if err != nil {
 			log.Error("transfer binlog failed, program will stop handling data from loader", zap.Error(err))


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
we can‘t ensure that the message in kafka is unique, so we need discard the repeated kafka message

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test