### PR TITLE
config txn-total-size-limit in tests

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -32,10 +32,16 @@ stop_services() {
 }
 
 start_upstream_tidb() {
+    cat - > "$OUT_DIR/tidb-config.toml" <<EOF
+[performance]
+txn-total-size-limit = 104857599
+EOF
+
     port=${1-4000}
     echo "Starting TiDB at port: $port..."
     tidb-server \
         -P $port \
+        -config "$OUT_DIR/tidb-config.toml" \
         --store tikv \
         --path 127.0.0.1:2379 \
         --enable-binlog=true \


### PR DESCRIPTION

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
latest version tidb fails to start up in tests/

### What is changed and how it works?
config txn-total-size-limit in tests

the latest tidb version has enlarge this and reject to start up if
txn-total-size-limit > 100 * (1<<20)

relate code:
295:	TxnTotalSizeLimit   uint64  `toml:"txn-total-size-limit" json:"txn-total-size-limit"`
724:		return fmt.Errorf("txn-total-size-limit should be less than %d with binlog enabled", 100<<20)
727:		return fmt.Errorf("txn-total-size-limit should be less than %d", 10<<30)


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test


Code changes
