### PR TITLE
drainer: support reading from relay log

### DIFF
--- a/cmd/drainer/drainer.toml
+++ b/cmd/drainer/drainer.toml
@@ -68,6 +68,8 @@ ignore-schemas = "INFORMATION_SCHEMA,PERFORMANCE_SCHEMA,mysql"
 relay-log-dir = ""
 # max file size of each relay log
 relay-log-size = 10485760
+# read buffer size of relay log
+relay-read-buf-size = 8
 
 #[[syncer.replicate-do-table]]
 #db-name ="test"

--- a/drainer/config.go
+++ b/drainer/config.go
@@ -72,6 +72,7 @@ type SyncerConfig struct {
 	DestDBType        string             `toml:"db-type" json:"db-type"`
 	RelayLogDir       string             `toml:"relay-log-dir" json:"relay-log-dir"`
 	RelayLogSize      int64              `toml:"relay-log-size" json:"relay-log-size"`
+	RelayReadBufSize  int                `toml:"relay-read-buf-size" json:"relay-read-buf-size"`
 	EnableDispatch    bool               `toml:"enable-dispatch" json:"enable-dispatch"`
 	SafeMode          bool               `toml:"safe-mode" json:"safe-mode"`
 	EnableCausality   bool               `toml:"enable-detect" json:"enable-detect"`
@@ -133,6 +134,7 @@ func NewConfig() *Config {
 	fs.StringVar(&cfg.SyncerCfg.DestDBType, "dest-db-type", "mysql", "target db type: mysql or tidb or file or kafka; see syncer section in conf/drainer.toml")
 	fs.StringVar(&cfg.SyncerCfg.RelayLogDir, "relay-log-dir", "", "path to relay log of syncer")
 	fs.Int64Var(&cfg.SyncerCfg.RelayLogSize, "relay-log-size", 10*1024*1024, "max file size of each relay log")
+	fs.IntVar(&cfg.SyncerCfg.RelayReadBufSize, "relay-read-buf-size", 8, "read buffer size of relay log")
 	fs.BoolVar(&cfg.SyncerCfg.EnableDispatch, "enable-dispatch", true, "enable dispatching sqls that in one same binlog; if set true, work-count and txn-batch would be useless")
 	fs.BoolVar(&cfg.SyncerCfg.SafeMode, "safe-mode", false, "enable safe mode to make syncer reentrant")
 	fs.BoolVar(&cfg.SyncerCfg.EnableCausality, "enable-detect", false, "enable detect causality")

--- a/drainer/relay/reader.go
+++ b/drainer/relay/reader.go
@@ -32,7 +32,7 @@ type Reader interface {
 	Run() context.CancelFunc
 
 	// Txns returns parsed transactions.
-	Txns() chan *loader.Txn
+	Txns() <-chan *loader.Txn
 
 	// Close releases resources.
 	Close() error
@@ -85,7 +85,8 @@ func (r *reader) Run() context.CancelFunc {
 				break
 			}
 
-			txn, err := loader.SlaveBinlogToTxn(slaveBinlog)
+			var txn *loader.Txn
+			txn, err = loader.SlaveBinlogToTxn(slaveBinlog)
 			if err != nil {
 				break
 			}
@@ -108,7 +109,7 @@ func (r *reader) Run() context.CancelFunc {
 }
 
 // Txns implements Reader interface.
-func (r *reader) Txns() chan *loader.Txn {
+func (r *reader) Txns() <-chan *loader.Txn {
 	return r.txns
 }
 

--- a/drainer/relay/reader.go
+++ b/drainer/relay/reader.go
@@ -1,0 +1,114 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package relay
+
+import (
+	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb-binlog/pkg/binlogfile"
+	"github.com/pingcap/tidb-binlog/pkg/loader"
+	obinlog "github.com/pingcap/tidb-tools/tidb-binlog/slave_binlog_proto/go-binlog"
+)
+
+var _ Reader = &reader{}
+
+// Reader is the interface for reading relay log.
+type Reader interface {
+	// Run reads relay log.
+	Run()
+
+	// Txns returns parsed transactions.
+	Txns() chan *loader.Txn
+
+	// Close releases resources.
+	Close() error
+
+	// Error returns error occurs in reading.
+	Error() <-chan error
+}
+
+type reader struct {
+	binlogger binlogfile.Binlogger
+	txns      chan *loader.Txn
+	err       chan error
+}
+
+// NewReader creates a relay reader.
+func NewReader(dir string) (Reader, error) {
+	binlogger, err := binlogfile.OpenBinlogger(dir, binlogfile.SegmentSizeBytes)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	return &reader{
+		binlogger: binlogger,
+		txns:      make(chan *loader.Txn, 8),
+	}, nil
+}
+
+// Run implements Reader interface.
+func (r *reader) Run() {
+	stop := make(chan struct{})
+	r.err = make(chan error, 1)
+	binlogChan, binlogErr := r.binlogger.ReadAll(stop)
+
+	go func() {
+		var err error
+		for binlog := range binlogChan {
+			slaveBinlog := new(obinlog.Binlog)
+			if err = slaveBinlog.Unmarshal(binlog.Payload); err != nil {
+				break
+			}
+
+			txn, err := loader.SlaveBinlogToTxn(slaveBinlog)
+			if err != nil {
+				break
+			}
+			r.txns <- txn
+		}
+		// If binlogger is not done, notify it to stop.
+		close(stop)
+		close(r.txns)
+
+		if err == nil {
+			err = <-binlogErr
+		}
+		if err != nil {
+			r.err <- err
+		}
+		close(r.err)
+	}()
+}
+
+// Txns implements Reader interface.
+func (r *reader) Txns() chan *loader.Txn {
+	return r.txns
+}
+
+// Error implements Reader interface.
+func (r *reader) Error() <-chan error {
+	return r.err
+}
+
+// Close implements Reader interface.
+func (r *reader) Close() error {
+	var err error
+	// If it's reading, wait until it's finished.
+	if r.err != nil {
+		err = <-r.err
+	}
+	if closeBinloggerErr := r.binlogger.Close(); err != nil {
+		err = closeBinloggerErr
+	}
+	return errors.Trace(err)
+}

--- a/drainer/relay/reader_test.go
+++ b/drainer/relay/reader_test.go
@@ -1,0 +1,134 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package relay
+
+import (
+	"os"
+	"path"
+
+	. "github.com/pingcap/check"
+	"github.com/pingcap/tidb-binlog/drainer/translator"
+	"github.com/pingcap/tidb-binlog/pkg/binlogfile"
+	"github.com/pingcap/tidb-binlog/pkg/file"
+	"github.com/pingcap/tidb-binlog/pkg/loader"
+)
+
+var _ = Suite(&testReaderSuite{})
+
+type testReaderSuite struct {
+	translator.BinlogGenrator
+}
+
+func (r *testReaderSuite) TestCreate(c *C) {
+	_, err := NewReader("")
+	c.Assert(err, NotNil)
+
+	_, err = NewReader("/")
+	c.Assert(err, NotNil)
+
+	dir := c.MkDir()
+	relayReader, err := NewReader(dir)
+	c.Assert(err, IsNil)
+	err = relayReader.Close()
+	c.Assert(err, IsNil)
+}
+
+func (r *testReaderSuite) TestReadBinlog(c *C) {
+	dir := c.MkDir()
+	r.SetDDL()
+	r.writeBinlog(c, dir)
+	txn := r.readBinlogAndCheck(c, dir, 1)
+	c.Assert(r.Table, Equals, txn.DDL.Table)
+	c.Assert(r.Schema, Equals, txn.DDL.Database)
+
+	r.SetInsert(c)
+	r.writeBinlog(c, dir)
+	txn = r.readBinlogAndCheck(c, dir, 2)
+	c.Assert(txn.DMLs[0].Tp, Equals, loader.InsertDMLType)
+
+	r.SetUpdate(c)
+	r.writeBinlog(c, dir)
+	txn = r.readBinlogAndCheck(c, dir, 3)
+	c.Assert(txn.DMLs[0].Tp, Equals, loader.UpdateDMLType)
+
+	r.SetDelete(c)
+	r.writeBinlog(c, dir)
+	txn = r.readBinlogAndCheck(c, dir, 4)
+	c.Assert(txn.DMLs[0].Tp, Equals, loader.DeleteDMLType)
+}
+
+func (r *testReaderSuite) writeBinlog(c *C, dir string) {
+	relayer, err := NewRelayer(dir, binlogfile.SegmentSizeBytes, r)
+	c.Assert(relayer, NotNil)
+	c.Assert(err, IsNil)
+	defer func() { c.Assert(relayer.Close(), IsNil) }()
+
+	_, err = relayer.WriteBinlog(r.Schema, r.Table, r.TiBinlog, r.PV)
+	c.Assert(err, IsNil)
+}
+
+func (r *testReaderSuite) readBinlogAndCheck(c *C, dir string, expectedNumber int) *loader.Txn {
+	relayReader, err := NewReader(dir)
+	c.Assert(relayReader, NotNil)
+	c.Assert(err, IsNil)
+	defer func() { c.Assert(relayReader.Close(), IsNil) }()
+
+	relayReader.Run()
+
+	var lastTxn *loader.Txn
+	number := 0
+	for txn := range relayReader.Txns() {
+		number++
+		lastTxn = txn
+	}
+	c.Assert(number, Equals, expectedNumber)
+	return lastTxn
+}
+
+func (r *testReaderSuite) TestReadBinlogError(c *C) {
+	dir := c.MkDir()
+	r.SetDDL()
+	r.writeBinlog(c, dir)
+
+	// Set the file mode to 0100
+	names, err := binlogfile.ReadBinlogNames(dir)
+	c.Assert(err, IsNil)
+	c.Assert(names, HasLen, 1)
+	fpath := path.Join(dir, names[0])
+	f, err := os.OpenFile(fpath, os.O_WRONLY, file.PrivateFileMode)
+	c.Assert(err, IsNil)
+	c.Assert(f.Chmod(0222), IsNil)
+	c.Assert(f.Close(), IsNil)
+
+	relayReader, err := NewReader(dir)
+	c.Assert(err, IsNil)
+	relayReader.Run()
+	c.Assert(<-relayReader.Error(), ErrorMatches, "*permission denied*")
+	c.Assert(relayReader.Close(), IsNil)
+
+	// Append some invalid data to the file.
+	f, err = os.OpenFile(fpath, os.O_WRONLY, 0222)
+	c.Assert(err, IsNil)
+	c.Assert(f.Chmod(file.PrivateFileMode), IsNil)
+	_, err = f.WriteString("test")
+	c.Assert(err, IsNil)
+	c.Assert(f.Close(), IsNil)
+
+	relayReader, err = NewReader(dir)
+	c.Assert(err, IsNil)
+	relayReader.Run()
+	// It's recovered by binlogger.
+	c.Assert(<-relayReader.Error(), IsNil)
+	c.Assert(relayReader.Close(), IsNil)
+}

--- a/drainer/relay/reader_test.go
+++ b/drainer/relay/reader_test.go
@@ -92,7 +92,7 @@ func (r *testReaderSuite) readBinlogAndCheck(c *C, dir string, expectedNumber in
 		number++
 		lastTxn = txn
 	}
-	c.Assert(<- relayReader.Error(), IsNil)
+	c.Assert(<-relayReader.Error(), IsNil)
 	c.Assert(number, Equals, expectedNumber)
 	return lastTxn
 }

--- a/drainer/relay/reader_test.go
+++ b/drainer/relay/reader_test.go
@@ -27,7 +27,7 @@ import (
 var _ = Suite(&testReaderSuite{})
 
 type testReaderSuite struct {
-	translator.BinlogGenrator
+	translator.BinlogGenerator
 }
 
 func (r *testReaderSuite) TestCreate(c *C) {

--- a/drainer/relay/relayer_test.go
+++ b/drainer/relay/relayer_test.go
@@ -47,19 +47,19 @@ func (r *testRelayerSuite) TestCreate(c *C) {
 
 func (r *testRelayerSuite) TestWriteBinlog(c *C) {
 	dir := c.MkDir()
-	relayer, err := NewRelayer(dir, binlogfile.SegmentSizeBytes, nil)
+	relayer, err := NewRelayer(dir, binlogfile.SegmentSizeBytes, r)
 	c.Assert(relayer, NotNil)
 	c.Assert(err, IsNil)
 	defer relayer.Close()
 
 	r.SetDDL()
-	pos1, err := relayer.WriteBinlog(r.Schema, r.Table, r.TiBinlog, nil)
+	pos1, err := relayer.WriteBinlog(r.Schema, r.Table, r.TiBinlog, r.PV)
 	c.Assert(err, IsNil)
 	c.Assert(pos1.Suffix, Equals, uint64(0))
 	c.Assert(pos1.Offset, Greater, int64(0))
 
 	r.SetInsert(c)
-	pos2, err := relayer.WriteBinlog(r.Schema, r.Table, r.TiBinlog, nil)
+	pos2, err := relayer.WriteBinlog(r.Schema, r.Table, r.TiBinlog, r.PV)
 	c.Assert(err, IsNil)
 	c.Assert(pos2.Suffix, Equals, uint64(0))
 	c.Assert(pos2.Offset, Greater, pos1.Offset)
@@ -67,13 +67,13 @@ func (r *testRelayerSuite) TestWriteBinlog(c *C) {
 
 func (r *testRelayerSuite) TestGCBinlog(c *C) {
 	dir := c.MkDir()
-	relayer, err := NewRelayer(dir, 10, nil)
+	relayer, err := NewRelayer(dir, 10, r)
 	c.Assert(relayer, NotNil)
 	c.Assert(err, IsNil)
 	defer relayer.Close()
 
 	r.SetDDL()
-	pos1, err := relayer.WriteBinlog(r.Schema, r.Table, r.TiBinlog, nil)
+	pos1, err := relayer.WriteBinlog(r.Schema, r.Table, r.TiBinlog, r.PV)
 	c.Assert(err, IsNil)
 	// There should be 2 files: the written file, the new created file.
 	// GC won't remove the first file now.
@@ -82,7 +82,7 @@ func (r *testRelayerSuite) TestGCBinlog(c *C) {
 	checkRelayLogNumber(c, dir, 2)
 
 	r.SetDDL()
-	pos2, err := relayer.WriteBinlog(r.Schema, r.Table, r.TiBinlog, nil)
+	pos2, err := relayer.WriteBinlog(r.Schema, r.Table, r.TiBinlog, r.PV)
 	c.Assert(err, IsNil)
 	// Rotate twice, so there would be 3 files.
 	checkRelayLogNumber(c, dir, 3)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Define `relay.Reader` that can read all relay logs, and return parsed transactions one by one. 
The last checkpoint should be passed to `Reader` after bootstrap so that transactions already synced last time should be ignored. But `binlogger` is not capable to write and read `CommitTS`, so it may be optimized in another PR.

### What is changed and how it works?
Define `relay.Reader` to read all relay logs and parse them to transactions.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - Has exported function/method change
 - Has exported variable/fields change

Side effects

 - Increased code complexity

Related changes

 - Need to update the documentation
 - Need to be included in the release note