### PR TITLE
drainer: Fix typo in struct name

### DIFF
--- a/drainer/relay/relayer_test.go
+++ b/drainer/relay/relayer_test.go
@@ -28,7 +28,7 @@ func TestRelayer(t *testing.T) {
 var _ = Suite(&testRelayerSuite{})
 
 type testRelayerSuite struct {
-	translator.BinlogGenrator
+	translator.BinlogGenerator
 }
 
 func (r *testRelayerSuite) TestCreate(c *C) {

--- a/drainer/sync/mysql_test.go
+++ b/drainer/sync/mysql_test.go
@@ -62,7 +62,7 @@ func (s *mysqlSuite) TestMySQLSyncerAvoidBlock(c *check.C) {
 		baseSyncer: newBaseSyncer(infoGetter),
 	}
 	go syncer.run()
-	gen := translator.BinlogGenrator{}
+	gen := translator.BinlogGenerator{}
 	gen.SetDDL()
 	item := &Item{
 		Binlog:        gen.TiBinlog,
@@ -139,7 +139,7 @@ func (s *mysqlSuite) TestMySQLSyncerWithRelayer(c *check.C) {
 	defer syncer.Close()
 
 	go syncer.run()
-	gen := translator.BinlogGenrator{}
+	gen := translator.BinlogGenerator{}
 	gen.SetDDL()
 
 	for i := 0; i < 5; i++ {

--- a/drainer/sync/syncer_test.go
+++ b/drainer/sync/syncer_test.go
@@ -98,7 +98,7 @@ func (s *syncerSuite) TestOpenAndClose(c *check.C) {
 }
 
 func (s *syncerSuite) TestGetFromSuccesses(c *check.C) {
-	gen := translator.BinlogGenrator{}
+	gen := translator.BinlogGenerator{}
 
 	// set up mysql db mock expect
 	s.mysqlMock.ExpectBegin()

--- a/drainer/translator/kafka_test.go
+++ b/drainer/translator/kafka_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 type testKafkaSuite struct {
-	BinlogGenrator
+	BinlogGenerator
 }
 
 var _ = check.Suite(&testKafkaSuite{})

--- a/drainer/translator/mysql_test.go
+++ b/drainer/translator/mysql_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 type testMysqlSuite struct {
-	BinlogGenrator
+	BinlogGenerator
 }
 
 var _ = check.Suite(&testMysqlSuite{})

--- a/drainer/translator/pb_test.go
+++ b/drainer/translator/pb_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 type testPbSuite struct {
-	BinlogGenrator
+	BinlogGenerator
 }
 
 var _ = check.Suite(&testPbSuite{})

--- a/drainer/translator/testing.go
+++ b/drainer/translator/testing.go
@@ -27,10 +27,10 @@ import (
 	ti "github.com/pingcap/tipb/go-binlog"
 )
 
-var _ TableInfoGetter = &BinlogGenrator{}
+var _ TableInfoGetter = &BinlogGenerator{}
 
-// BinlogGenrator is a test helper for generating some binlog.
-type BinlogGenrator struct {
+// BinlogGenerator is a test helper for generating some binlog.
+type BinlogGenerator struct {
 	TiBinlog *ti.Binlog
 	PV       *ti.PrewriteValue
 	Schema   string
@@ -43,7 +43,7 @@ type BinlogGenrator struct {
 	oldDatums []types.Datum
 }
 
-func (g *BinlogGenrator) reset() {
+func (g *BinlogGenerator) reset() {
 	g.TiBinlog = nil
 	g.PV = nil
 	g.Schema = ""
@@ -53,7 +53,7 @@ func (g *BinlogGenrator) reset() {
 }
 
 // SetDelete set the info to be a delete event
-func (g *BinlogGenrator) SetDelete(c *check.C) {
+func (g *BinlogGenerator) SetDelete(c *check.C) {
 	g.reset()
 	info := g.setEvent(c)
 
@@ -66,24 +66,24 @@ func (g *BinlogGenrator) SetDelete(c *check.C) {
 	})
 }
 
-func (g *BinlogGenrator) getDatums() (datums []types.Datum) {
+func (g *BinlogGenerator) getDatums() (datums []types.Datum) {
 	datums = g.datums
 	return
 }
 
-func (g *BinlogGenrator) getOldDatums() (datums []types.Datum) {
+func (g *BinlogGenerator) getOldDatums() (datums []types.Datum) {
 	datums = g.oldDatums
 	return
 }
 
 // TableByID implements TableInfoGetter interface
-func (g *BinlogGenrator) TableByID(id int64) (info *model.TableInfo, ok bool) {
+func (g *BinlogGenerator) TableByID(id int64) (info *model.TableInfo, ok bool) {
 	info, ok = g.id2info[id]
 	return
 }
 
 // SchemaAndTableName implements TableInfoGetter interface
-func (g *BinlogGenrator) SchemaAndTableName(id int64) (schema string, table string, ok bool) {
+func (g *BinlogGenerator) SchemaAndTableName(id int64) (schema string, table string, ok bool) {
 	names, ok := g.id2name[id]
 	if !ok {
 		return "", "", false
@@ -96,12 +96,12 @@ func (g *BinlogGenrator) SchemaAndTableName(id int64) (schema string, table stri
 }
 
 // IsDroppingColumn implements TableInfoGetter interface
-func (g *BinlogGenrator) IsDroppingColumn(id int64) bool {
+func (g *BinlogGenerator) IsDroppingColumn(id int64) bool {
 	return false
 }
 
 // SetDDL set up a ddl binlog.
-func (g *BinlogGenrator) SetDDL() {
+func (g *BinlogGenerator) SetDDL() {
 	g.reset()
 	g.TiBinlog = &ti.Binlog{
 		Tp:       ti.BinlogType_Commit,
@@ -115,7 +115,7 @@ func (g *BinlogGenrator) SetDDL() {
 	g.Table = "test"
 }
 
-func (g *BinlogGenrator) setEvent(c *check.C) *model.TableInfo {
+func (g *BinlogGenerator) setEvent(c *check.C) *model.TableInfo {
 	g.TiBinlog = &ti.Binlog{
 		Tp:       ti.BinlogType_Commit,
 		StartTs:  100,
@@ -136,7 +136,7 @@ func (g *BinlogGenrator) setEvent(c *check.C) *model.TableInfo {
 }
 
 // SetInsert set up a insert event binlog.
-func (g *BinlogGenrator) SetInsert(c *check.C) {
+func (g *BinlogGenerator) SetInsert(c *check.C) {
 	g.reset()
 	info := g.setEvent(c)
 
@@ -149,7 +149,7 @@ func (g *BinlogGenrator) SetInsert(c *check.C) {
 }
 
 // SetUpdate set up a update event binlog.
-func (g *BinlogGenrator) SetUpdate(c *check.C) {
+func (g *BinlogGenerator) SetUpdate(c *check.C) {
 	g.reset()
 	info := g.setEvent(c)
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix a typo in a struct name


### What is changed and how it works?

Genrator -> Generator


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test