### PR TITLE
Bug fix: a DDL p-binlog will be ignored when the c-binlog queried from TiKV

### DIFF
--- a/pump/storage/storage.go
+++ b/pump/storage/storage.go
@@ -1093,6 +1093,9 @@ func (a *Append) feedPreWriteValue(cbinlog *pb.Binlog) error {
 
 	cbinlog.StartTs = pbinlog.StartTs
 	cbinlog.PrewriteValue = pbinlog.PrewriteValue
+	cbinlog.DdlQuery = pbinlog.DdlQuery
+	cbinlog.DdlJobId = pbinlog.DdlJobId
+	cbinlog.DdlSchemaState = pbinlog.DdlSchemaState
 
 	return nil
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
The DDL `c-binlog`s sent from TiDB include `ddl query`, `ddl job id`. But the `c-binlog` queried from TiKV doesn't include this info. Unfortunately, pump never read the `ddl query`, `ddl job id` from `p-binlog`. So a DDL `p-binlog` will be ignored when the c-binlog queried from TiKV.
 
fix: #851
### What is changed and how it works?
Copy the `ddl query`, `ddl job id` from `p-binlog` to `c-binlog`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test