### PR TITLE
Bug fix: a DDL p-binlog will be ignored when the c-binlog queried from TiKV(#852)

### DIFF
--- a/pump/storage/storage.go
+++ b/pump/storage/storage.go
@@ -983,7 +983,6 @@ func (a *Append) feedPreWriteValue(cbinlog *pb.Binlog) error {
 	cbinlog.PrewriteValue = pbinlog.PrewriteValue
 	cbinlog.DdlQuery = pbinlog.DdlQuery
 	cbinlog.DdlJobId = pbinlog.DdlJobId
-	cbinlog.DdlSchemaState = pbinlog.DdlSchemaState
 
 	return nil
 }

--- a/pump/storage/storage.go
+++ b/pump/storage/storage.go
@@ -981,6 +981,9 @@ func (a *Append) feedPreWriteValue(cbinlog *pb.Binlog) error {
 
 	cbinlog.StartTs = pbinlog.StartTs
 	cbinlog.PrewriteValue = pbinlog.PrewriteValue
+	cbinlog.DdlQuery = pbinlog.DdlQuery
+	cbinlog.DdlJobId = pbinlog.DdlJobId
+	cbinlog.DdlSchemaState = pbinlog.DdlSchemaState
 
 	return nil
 }

--- a/pump/storage/storage_test.go
+++ b/pump/storage/storage_test.go
@@ -326,13 +326,12 @@ func (as *AppendSuit) TestFeedPreWriteValue(c *check.C) {
 	defer cleanAppend(a)
 
 	expectPBinlog := &pb.Binlog{
-		Tp:             pb.BinlogType_Prewrite,
-		StartTs:        42,
-		PrewriteKey:    []byte("PrewriteKey"),
-		PrewriteValue:  []byte("PrewriteValue"),
-		DdlQuery:       []byte("create table t(a int);"),
-		DdlJobId:       6,
-		DdlSchemaState: 5,
+		Tp:            pb.BinlogType_Prewrite,
+		StartTs:       42,
+		PrewriteKey:   []byte("PrewriteKey"),
+		PrewriteValue: []byte("PrewriteValue"),
+		DdlQuery:      []byte("create table t(a int);"),
+		DdlJobId:      6,
 	}
 
 	req := a.writeBinlog(expectPBinlog)
@@ -356,7 +355,6 @@ func (as *AppendSuit) TestFeedPreWriteValue(c *check.C) {
 	c.Assert(cBinlog.PrewriteValue, check.BytesEquals, expectPBinlog.PrewriteValue)
 	c.Assert(cBinlog.DdlQuery, check.BytesEquals, expectPBinlog.DdlQuery)
 	c.Assert(cBinlog.DdlJobId, check.Equals, expectPBinlog.DdlJobId)
-	c.Assert(cBinlog.DdlSchemaState, check.Equals, expectPBinlog.DdlSchemaState)
 }
 
 type OpenDBSuit struct {

--- a/pump/storage/storage_test.go
+++ b/pump/storage/storage_test.go
@@ -321,6 +321,44 @@ func (as *AppendSuit) TestResolve(c *check.C) {
 	// is there a fake or mock kv.Storage and tikv.LockResolver to easy the test?
 }
 
+func (as *AppendSuit) TestFeedPreWriteValue(c *check.C) {
+	a := newAppend(c)
+	defer cleanAppend(a)
+
+	expectPBinlog := &pb.Binlog{
+		Tp:             pb.BinlogType_Prewrite,
+		StartTs:        42,
+		PrewriteKey:    []byte("PrewriteKey"),
+		PrewriteValue:  []byte("PrewriteValue"),
+		DdlQuery:       []byte("create table t(a int);"),
+		DdlJobId:       6,
+		DdlSchemaState: 5,
+	}
+
+	req := a.writeBinlog(expectPBinlog)
+	c.Assert(req.err, check.IsNil)
+
+	cBinlog := &pb.Binlog{
+		Tp:       pb.BinlogType_Commit,
+		StartTs:  42,
+		CommitTs: 50,
+	}
+	req = a.writeBinlog(cBinlog)
+	c.Assert(req.err, check.IsNil)
+
+	err := a.feedPreWriteValue(cBinlog)
+	c.Assert(err, check.IsNil)
+
+	c.Assert(cBinlog.StartTs, check.Equals, expectPBinlog.StartTs)
+	c.Assert(cBinlog.CommitTs, check.Equals, int64(50))
+	c.Assert(cBinlog.Tp, check.Equals, pb.BinlogType_Commit)
+	c.Assert(cBinlog.PrewriteKey, check.IsNil)
+	c.Assert(cBinlog.PrewriteValue, check.BytesEquals, expectPBinlog.PrewriteValue)
+	c.Assert(cBinlog.DdlQuery, check.BytesEquals, expectPBinlog.DdlQuery)
+	c.Assert(cBinlog.DdlJobId, check.Equals, expectPBinlog.DdlJobId)
+	c.Assert(cBinlog.DdlSchemaState, check.Equals, expectPBinlog.DdlSchemaState)
+}
+
 type OpenDBSuit struct {
 	dir string
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
The DDL `c-binlog`s sent from TiDB include `ddl query`, `ddl job id`. But the `c-binlog` queried from TiKV doesn't include this info. Unfortunately, pump never read the `ddl query`, `ddl job id` from `p-binlog`. So a DDL `p-binlog` will be ignored when the c-binlog queried from TiKV.
 
fix: #851

cherry-pick #852
### What is changed and how it works?
Copy the `ddl query`, `ddl job id` from `p-binlog` to `c-binlog`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test


