### PR TITLE
tests: Make sure the INSERT is executed before we starts droppling cols

### DIFF
--- a/tests/dailytest/case.go
+++ b/tests/dailytest/case.go
@@ -378,14 +378,15 @@ CREATE TABLE many_cols (
 	}
 	placeholders := builder.String()
 
+	// Insert a row with all columns set to empty string
+	insertSQL := fmt.Sprintf(`INSERT INTO many_cols(id, %s) VALUES (?, %s);`, cols, placeholders)
+	mustExec(db, insertSQL, 1)
+
 	var wg sync.WaitGroup
 
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		// Insert a row with all columns set to empty string
-		insertSQL := fmt.Sprintf(`INSERT INTO many_cols(id, %s) VALUES (?, %s);`, cols, placeholders)
-		mustExec(db, insertSQL, 1)
 
 		// Keep updating to generate DMLs while the other goroutine's dropping columns
 		updateSQL := `UPDATE many_cols SET val = ? WHERE id = ?;`


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Sometimes the goroutine that drops columns runs before we insert the row with all columns and cause error.

### What is changed and how it works?

Make sure the insertion happens before updating and column dropping starts.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test