### PR TITLE
drainer: Clear the cache instead of refreshing after DDL to avoid unnecessary queries

### DIFF
--- a/pkg/loader/load.go
+++ b/pkg/loader/load.go
@@ -237,6 +237,10 @@ func (s *loaderImpl) Close() {
 
 var utilGetTableInfo = getTableInfo
 
+func (s *loaderImpl) invalidateTableInfo(schema string, table string) {
+	s.tableInfos.Delete(quoteSchema(schema, table))
+}
+
 func (s *loaderImpl) refreshTableInfo(schema string, table string) (info *tableInfo, err error) {
 	log.Info("refresh table info", zap.String("schema", schema), zap.String("table", table))
 
@@ -559,9 +563,7 @@ func newBatchManager(s *loaderImpl) *batchManager {
 		fDDLSuccessCallback: func(txn *Txn) {
 			s.markSuccess(txn)
 			if needRefreshTableInfo(txn.DDL.SQL) {
-				if _, err := s.refreshTableInfo(txn.DDL.Database, txn.DDL.Table); err != nil {
-					log.Error("refresh table info failed", zap.String("database", txn.DDL.Database), zap.String("table", txn.DDL.Table), zap.Error(err))
-				}
+				s.invalidateTableInfo(txn.DDL.Database, txn.DDL.Table)
 			}
 		},
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

`loader` try to query the latest `TableInfo` from the downstream db after executing a DDL.
Sometimes there's no DMLs depending on the table in between two DDLs, it would be wasteful to query everytime.


### What is changed and how it works?

Just invalidate the cached `TableInfo`, the next DML that needs this info would call `getTableInfo` and query the latest info.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test