### PR TITLE
Add sync mode config to allow mismatch column number

### DIFF
--- a/cmd/drainer/drainer.toml
+++ b/cmd/drainer/drainer.toml
@@ -90,6 +90,10 @@ host = "127.0.0.1"
 user = "root"
 password = ""
 port = 3306
+# 1: SyncFullColumn, 2: SyncPartialColumn
+# when setting SyncPartialColumn drainer will allow the downstream schema
+# having more or less column numbers and relax sql mode by removing STRICT_TRANS_TABLES.
+# sync-mode = 1
 
 [syncer.to.checkpoint]
 # only support mysql or tidb now, you can uncomment this to control where the checkpoint is saved.

--- a/drainer/sync/mysql.go
+++ b/drainer/sync/mysql.go
@@ -15,6 +15,7 @@ package sync
 
 import (
 	"database/sql"
+	"strings"
 	"sync"
 
 	"github.com/pingcap/errors"
@@ -55,6 +56,27 @@ func NewMysqlSyncer(cfg *DBConfig, tableInfoGetter translator.TableInfoGetter, w
 		}))
 	}
 
+	if cfg.SyncMode != 0 {
+		mode := loader.SyncMode(cfg.SyncMode)
+		opts = append(opts, loader.SyncModeOption(mode))
+
+		if mode == loader.SyncPartialColumn {
+			var oldMode, newMode string
+			oldMode, newMode, err = relaxSQLMode(db)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+
+			if newMode != oldMode {
+				db.Close()
+				db, err = createDB(cfg.User, cfg.Password, cfg.Host, cfg.Port, &newMode)
+				if err != nil {
+					return nil, errors.Trace(err)
+				}
+			}
+		}
+	}
+
 	loader, err := loader.NewLoader(db, opts...)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -70,6 +92,29 @@ func NewMysqlSyncer(cfg *DBConfig, tableInfoGetter translator.TableInfoGetter, w
 	go s.run()
 
 	return s, nil
+}
+
+// set newMode as the oldMode query from db by removing "STRICT_TRANS_TABLES".
+func relaxSQLMode(db *sql.DB) (oldMode string, newMode string, err error) {
+	row := db.QueryRow("SELECT @@SESSION.sql_mode;")
+	err = row.Scan(&oldMode)
+	if err != nil {
+		return "", "", errors.Trace(err)
+	}
+
+	toRemove := "STRICT_TRANS_TABLES"
+	newMode = oldMode
+
+	if !strings.Contains(oldMode, toRemove) {
+		return
+	}
+
+	// concatenated by "," like: mode1,mode2
+	newMode = strings.Replace(newMode, toRemove+",", "", -1)
+	newMode = strings.Replace(newMode, ","+toRemove, "", -1)
+	newMode = strings.Replace(newMode, toRemove, "", -1)
+
+	return
 }
 
 // SetSafeMode make the MysqlSyncer to use safe mode or not

--- a/drainer/sync/util.go
+++ b/drainer/sync/util.go
@@ -23,6 +23,7 @@ type DBConfig struct {
 	Host          string           `toml:"host" json:"host"`
 	User          string           `toml:"user" json:"user"`
 	Password      string           `toml:"password" json:"password"`
+	SyncMode      int              `toml:"sync-mode" json:"sync-mode"`
 	Port          int              `toml:"port" json:"port"`
 	Checkpoint    CheckpointConfig `toml:"checkpoint" json:"checkpoint"`
 	BinlogFileDir string           `toml:"dir" json:"dir"`

--- a/pkg/loader/load.go
+++ b/pkg/loader/load.go
@@ -69,6 +69,7 @@ type loaderImpl struct {
 
 	batchSize   int
 	workerCount int
+	syncMode    SyncMode
 
 	input      chan *Txn
 	successTxn chan *Txn
@@ -99,11 +100,21 @@ type MetricsGroup struct {
 	QueryHistogramVec *prometheus.HistogramVec
 }
 
+// SyncMode represents the sync mode of DML.
+type SyncMode int
+
+// SyncMode values.
+const (
+	SyncFullColumn SyncMode = 1 + iota
+	SyncPartialColumn
+)
+
 type options struct {
 	workerCount   int
 	batchSize     int
 	metrics       *MetricsGroup
 	saveAppliedTS bool
+	syncMode      SyncMode
 }
 
 var defaultLoaderOptions = options{
@@ -111,10 +122,18 @@ var defaultLoaderOptions = options{
 	batchSize:     20,
 	metrics:       nil,
 	saveAppliedTS: false,
+	syncMode:      SyncFullColumn,
 }
 
 // A Option sets options such batch size, worker count etc.
 type Option func(*options)
+
+// SyncModeOption set sync mode of loader.
+func SyncModeOption(n SyncMode) Option {
+	return func(o *options) {
+		o.syncMode = n
+	}
+}
 
 // WorkerCount set worker count of loader
 func WorkerCount(n int) Option {
@@ -398,6 +417,20 @@ func (s *loaderImpl) singleExec(executor *executor, dmls []*DML) error {
 	return errors.Trace(err)
 }
 
+func removeOrphanCols(info *tableInfo, dml *DML) {
+	mp := make(map[string]struct{}, len(info.columns))
+	for _, name := range info.columns {
+		mp[name] = struct{}{}
+	}
+
+	for name := range dml.Values {
+		if _, ok := mp[name]; !ok {
+			delete(dml.Values, name)
+			delete(dml.OldValues, name)
+		}
+	}
+}
+
 func (s *loaderImpl) execDMLs(dmls []*DML) error {
 	if len(dmls) == 0 {
 		return nil
@@ -408,6 +441,9 @@ func (s *loaderImpl) execDMLs(dmls []*DML) error {
 			return errors.Trace(err)
 		}
 		filterGeneratedCols(dml)
+		if s.syncMode == SyncPartialColumn {
+			removeOrphanCols(dml.info, dml)
+		}
 	}
 
 	batchTables, singleDMLs := s.groupDMLs(dmls)

--- a/pkg/loader/load_test.go
+++ b/pkg/loader/load_test.go
@@ -37,6 +37,37 @@ func (cs *LoadSuite) SetUpTest(c *check.C) {
 func (cs *LoadSuite) TearDownTest(c *check.C) {
 }
 
+func (cs *LoadSuite) TestRemoveOrphanCols(c *check.C) {
+	dml := &DML{
+		Values: map[string]interface{}{
+			"exist1":  11,
+			"exist2":  22,
+			"orhpan1": 11,
+			"orhpan2": 22,
+		},
+		OldValues: map[string]interface{}{
+			"exist1":  1,
+			"exist2":  2,
+			"orhpan1": 1,
+			"orhpan2": 2,
+		},
+	}
+
+	info := &tableInfo{
+		columns: []string{"exist1", "exist2"},
+	}
+
+	removeOrphanCols(info, dml)
+	c.Assert(dml.Values, check.DeepEquals, map[string]interface{}{
+		"exist1": 11,
+		"exist2": 22,
+	})
+	c.Assert(dml.OldValues, check.DeepEquals, map[string]interface{}{
+		"exist1": 1,
+		"exist2": 2,
+	})
+}
+
 func (cs *LoadSuite) TestOptions(c *check.C) {
 	var o options
 	WorkerCount(42)(&o)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
allow when the column number of downstream table mismatch with current schema.

For the case bidirectional replication, we will execute the DDL at one side, for add or drop column
the column number will mismatch.

cluster A <-> cluster B
- drop column of table `t` at cluster A
- some DML of table `t` at cluster B will miss the column dropped compared to cluster A



### What is changed and how it works?
Add a config item `sync-mode`
when setting SyncPartialColumn will allow mismatch column number
and relax sql mode by removing STRICT_TRANS_TABLES.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test


Code changes



Side effects


Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to be included in the release note           