### PR TITLE
scripts: release pod resource after CI test

### DIFF
--- a/scripts/groovy/binlog_ghpr_integration.groovy
+++ b/scripts/groovy/binlog_ghpr_integration.groovy
@@ -94,7 +94,7 @@ try {
 
         tests["Integration Test"] = {
             podTemplate(label: label, 
-            idleMinutes: 60,
+            idleMinutes: 0,
             containers: [
                 containerTemplate(name: 'golang',alwaysPullImage: false, image: "${GO_DOCKER_IMAGE}", 
                 resourceRequestCpu: '2000m', resourceRequestMemory: '4Gi',


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

in https://github.com/pingcap/tidb-binlog/pull/857/commits/32ee5e88ff3a4d2ddc74da293a5f862718b4d803, we add a 60min idle to investigate CI problem, but for normal CI situation we should release resource quickly.

### What is changed and how it works?

set idle back to 0

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - n/a

Side effects

 - n/a

Related changes

 - n/a

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb-binlog/869)
<!-- Reviewable:end -->
