### PR TITLE
feed downstream by relay log at startup if need

### DIFF
--- a/cmd/drainer/drainer.toml
+++ b/cmd/drainer/drainer.toml
@@ -68,7 +68,7 @@ ignore-schemas = "INFORMATION_SCHEMA,PERFORMANCE_SCHEMA,mysql"
 # relay log works only if the downstream is TiDB/MySQL.
 # log-dir = ""
 # max file size of each relay log
-# log-size = 10485760
+# max-file-size = 10485760
 
 #[[syncer.replicate-do-table]]
 #db-name ="test"

--- a/cmd/drainer/drainer.toml
+++ b/cmd/drainer/drainer.toml
@@ -63,7 +63,7 @@ ignore-schemas = "INFORMATION_SCHEMA,PERFORMANCE_SCHEMA,mysql"
 #
 #replicate-do-db = ["~^b.*","s1"]
 
-[relay]
+[syncer.relay]
 # directory of relay logs. Empty string indicates disabling relay log.
 # relay log works only if the downstream is TiDB/MySQL.
 # log-dir = ""

--- a/cmd/drainer/drainer.toml
+++ b/cmd/drainer/drainer.toml
@@ -63,13 +63,12 @@ ignore-schemas = "INFORMATION_SCHEMA,PERFORMANCE_SCHEMA,mysql"
 #
 #replicate-do-db = ["~^b.*","s1"]
 
+[relay]
 # directory of relay logs. Empty string indicates disabling relay log.
 # relay log works only if the downstream is TiDB/MySQL.
-relay-log-dir = ""
+# log-dir = ""
 # max file size of each relay log
-relay-log-size = 10485760
-# read buffer size of relay log
-relay-read-buf-size = 8
+# log-size = 10485760
 
 #[[syncer.replicate-do-table]]
 #db-name ="test"

--- a/drainer/checkpoint/checkpoint.go
+++ b/drainer/checkpoint/checkpoint.go
@@ -61,7 +61,7 @@ func NewCheckPoint(cfg *Config) (CheckPoint, error) {
 	case "mysql", "tidb":
 		cp, err = newMysql(cfg)
 	case "file":
-		cp, err = NewFile(cfg)
+		cp, err = NewFile(cfg.InitialCommitTS, cfg.CheckPointFile)
 	default:
 		err = errors.Errorf("unsupported checkpoint type %s", cfg.CheckpointType)
 	}

--- a/drainer/checkpoint/checkpoint.go
+++ b/drainer/checkpoint/checkpoint.go
@@ -20,8 +20,8 @@ import (
 )
 
 const (
-	// StatusNormal means server quit normally, data <= ts is synced to downstream
-	StatusNormal int = 0
+	// StatusConsistent means server quit normally, data <= ts is synced to downstream
+	StatusConsistent int = 0
 
 	// StatusRunning means server running or quit abnormally, part of data may or may not been synced to downstream
 	StatusRunning int = 1

--- a/drainer/checkpoint/checkpoint.go
+++ b/drainer/checkpoint/checkpoint.go
@@ -19,6 +19,14 @@ import (
 	"go.uber.org/zap"
 )
 
+const (
+	// StatusNormal means server quit normally, data <= ts is synced to downstream
+	StatusNormal int = 0
+
+	// StatusRunning means server running or quit abnormally, part of data may or may not been synced to downstream
+	StatusRunning int = 1
+)
+
 var (
 	// ErrCheckPointClosed indicates the CheckPoint already closed.
 	ErrCheckPointClosed = errors.New("CheckPoint already closed")
@@ -31,10 +39,13 @@ type CheckPoint interface {
 	Load() error
 
 	// Save saves checkpoint information.
-	Save(int64, int64) error
+	Save(commitTS int64, slaveTS int64, status int) error
 
-	// Pos gets position information.
+	// TS gets checkpoint commit timestamp.
 	TS() int64
+
+	// Status return the status saved.
+	Status() int
 
 	// Close closes the CheckPoint and release resources, after closed other methods should not be called again.
 	Close() error

--- a/drainer/checkpoint/file.go
+++ b/drainer/checkpoint/file.go
@@ -36,10 +36,10 @@ type FileCheckPoint struct {
 }
 
 // NewFile creates a new FileCheckpoint.
-func NewFile(cfg *Config) (CheckPoint, error) {
+func NewFile(initialCommitTS int64, filePath string) (CheckPoint, error) {
 	pb := &FileCheckPoint{
-		initialCommitTS: cfg.InitialCommitTS,
-		name:            cfg.CheckPointFile,
+		initialCommitTS: initialCommitTS,
+		name:            filePath,
 	}
 	err := pb.Load()
 	if err != nil {

--- a/drainer/checkpoint/file.go
+++ b/drainer/checkpoint/file.go
@@ -31,7 +31,8 @@ type FileCheckPoint struct {
 
 	name string
 
-	CommitTS int64 `toml:"commitTS" json:"commitTS"`
+	StatusSaved int   `toml:"status" json:"status"`
+	CommitTS    int64 `toml:"commitTS" json:"commitTS"`
 }
 
 // NewFile creates a new FileCheckpoint.
@@ -81,7 +82,7 @@ func (sp *FileCheckPoint) Load() error {
 }
 
 // Save implements CheckPoint.Save interface
-func (sp *FileCheckPoint) Save(ts, slaveTS int64) error {
+func (sp *FileCheckPoint) Save(ts, slaveTS int64, status int) error {
 	sp.Lock()
 	defer sp.Unlock()
 
@@ -90,6 +91,7 @@ func (sp *FileCheckPoint) Save(ts, slaveTS int64) error {
 	}
 
 	sp.CommitTS = ts
+	sp.StatusSaved = status
 
 	var buf bytes.Buffer
 	e := toml.NewEncoder(&buf)
@@ -112,6 +114,14 @@ func (sp *FileCheckPoint) TS() int64 {
 	defer sp.RUnlock()
 
 	return sp.CommitTS
+}
+
+// Status implements CheckPoint.Status interface
+func (sp *FileCheckPoint) Status() int {
+	sp.RLock()
+	defer sp.RUnlock()
+
+	return sp.StatusSaved
 }
 
 // Close implements CheckPoint.Close interface

--- a/drainer/checkpoint/file_test.go
+++ b/drainer/checkpoint/file_test.go
@@ -23,9 +23,7 @@ import (
 func (t *testCheckPointSuite) TestFile(c *C) {
 	fileName := "/tmp/test"
 	notExistFileName := "test_not_exist"
-	cfg := new(Config)
-	cfg.CheckPointFile = fileName
-	meta, err := NewFile(cfg)
+	meta, err := NewFile(0, fileName)
 	c.Assert(err, IsNil)
 	defer os.RemoveAll(fileName)
 
@@ -49,18 +47,17 @@ func (t *testCheckPointSuite) TestFile(c *C) {
 	c.Assert(ts, Equals, testTs)
 
 	// check not exist meta file
-	cfg.CheckPointFile = notExistFileName
-	meta, err = NewFile(cfg)
+	meta, err = NewFile(0, notExistFileName)
 	c.Assert(err, IsNil)
 	err = meta.Load()
 	c.Assert(err, IsNil)
 	c.Assert(meta.TS(), Equals, int64(0))
 
 	// check not exist meta file, but with initialCommitTs
-	cfg.InitialCommitTS = 123
-	meta, err = NewFile(cfg)
+	var initialCommitTS int64 = 123
+	meta, err = NewFile(initialCommitTS, notExistFileName)
 	c.Assert(err, IsNil)
-	c.Assert(meta.TS(), Equals, cfg.InitialCommitTS)
+	c.Assert(meta.TS(), Equals, initialCommitTS)
 
 	// close the checkpoint
 	err = meta.Close()

--- a/drainer/checkpoint/file_test.go
+++ b/drainer/checkpoint/file_test.go
@@ -31,14 +31,16 @@ func (t *testCheckPointSuite) TestFile(c *C) {
 
 	// zero (initial) CommitTs
 	c.Assert(meta.TS(), Equals, int64(0))
+	c.Assert(meta.Status(), Equals, StatusNormal)
 
 	testTs := int64(1)
 	// save ts
-	err = meta.Save(testTs, 0)
+	err = meta.Save(testTs, 0, StatusRunning)
 	c.Assert(err, IsNil)
 	// check ts
 	ts := meta.TS()
 	c.Assert(ts, Equals, testTs)
+	c.Assert(meta.Status(), Equals, StatusRunning)
 
 	// check load ts
 	err = meta.Load()
@@ -64,6 +66,6 @@ func (t *testCheckPointSuite) TestFile(c *C) {
 	err = meta.Close()
 	c.Assert(err, IsNil)
 	c.Assert(errors.Cause(meta.Load()), Equals, ErrCheckPointClosed)
-	c.Assert(errors.Cause(meta.Save(0, 0)), Equals, ErrCheckPointClosed)
+	c.Assert(errors.Cause(meta.Save(0, 0, StatusNormal)), Equals, ErrCheckPointClosed)
 	c.Assert(errors.Cause(meta.Close()), Equals, ErrCheckPointClosed)
 }

--- a/drainer/checkpoint/mysql_test.go
+++ b/drainer/checkpoint/mysql_test.go
@@ -49,7 +49,7 @@ func (s *saveSuite) TestShouldSaveCheckpoint(c *C) {
 	c.Assert(err, IsNil)
 	mock.ExpectExec("replace into db.tbl.*").WillReturnResult(sqlmock.NewResult(0, 0))
 	cp := MysqlCheckPoint{db: db, schema: "db", table: "tbl"}
-	err = cp.Save(1111, 0)
+	err = cp.Save(1111, 0, StatusRunning)
 	c.Assert(err, IsNil)
 }
 
@@ -63,7 +63,7 @@ func (s *saveSuite) TestShouldUpdateTsMap(c *C) {
 		table:  "tbl",
 		TsMap:  make(map[string]int64),
 	}
-	err = cp.Save(65536, 3333)
+	err = cp.Save(65536, 3333, StatusRunning)
 	c.Assert(err, IsNil)
 	c.Assert(cp.TsMap["master-ts"], Equals, int64(65536))
 	c.Assert(cp.TsMap["slave-ts"], Equals, int64(3333))
@@ -83,12 +83,13 @@ func (s *loadSuite) TestShouldLoadFromDB(c *C) {
 		TsMap:  make(map[string]int64),
 	}
 	rows := sqlmock.NewRows([]string{"checkPoint"}).
-		AddRow(`{"commitTS": 1024, "ts-map": {"master-ts": 2000, "slave-ts": 1999}}`)
+		AddRow(`{"commitTS": 1024, "status": 1, "ts-map": {"master-ts": 2000, "slave-ts": 1999}}`)
 	mock.ExpectQuery("select checkPoint from db.tbl.*").WillReturnRows(rows)
 
 	err = cp.Load()
 	c.Assert(err, IsNil)
 	c.Assert(cp.CommitTS, Equals, int64(1024))
+	c.Assert(cp.StatusSaved, Equals, 1)
 	c.Assert(cp.TsMap["master-ts"], Equals, int64(2000))
 	c.Assert(cp.TsMap["slave-ts"], Equals, int64(1999))
 }

--- a/drainer/checkpoint/util.go
+++ b/drainer/checkpoint/util.go
@@ -15,6 +15,7 @@ package checkpoint
 
 import (
 	"database/sql"
+	stderrors "errors"
 	"fmt"
 
 	// mysql driver
@@ -24,7 +25,7 @@ import (
 
 // ErrNoCheckpointItem represents there's no any checkpoint item and the cluster id must be specified
 // for the mysql checkpoint type.
-var ErrNoCheckpointItem = errors.New("no any checkpoint item")
+var ErrNoCheckpointItem = stderrors.New("no any checkpoint item")
 
 // DBConfig is the DB configuration.
 type DBConfig struct {

--- a/drainer/checkpoint/util_test.go
+++ b/drainer/checkpoint/util_test.go
@@ -1,0 +1,58 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checkpoint
+
+import (
+	"github.com/DATA-DOG/go-sqlmock"
+	. "github.com/pingcap/check"
+)
+
+var _ = Suite(&testUtil{})
+
+type testUtil struct{}
+
+func (t *testUtil) TestG(c *C) {
+	tests := []struct {
+		name string
+		rows []uint64
+		id   uint64
+		err  bool
+	}{
+		{"no row", nil, 0, true},
+		{"on row", []uint64{1}, 1, false},
+		{"multi row", []uint64{1, 2}, 0, true},
+	}
+
+	for _, test := range tests {
+		db, mock, err := sqlmock.New()
+		c.Assert(err, IsNil)
+
+		rows := sqlmock.NewRows([]string{"clusterID"})
+		for _, row := range test.rows {
+			rows.AddRow(row)
+		}
+
+		mock.ExpectQuery("select clusterID from .*").WillReturnRows(rows)
+
+		c.Log("test: ", test.name)
+		id, err := getClusterID(db, "schema", "table")
+		if test.err {
+			c.Assert(err, NotNil)
+			c.Assert(id, Equals, test.id)
+		} else {
+			c.Assert(err, IsNil)
+			c.Assert(id, Equals, test.id)
+		}
+	}
+}

--- a/drainer/checkpoint/util_test.go
+++ b/drainer/checkpoint/util_test.go
@@ -16,6 +16,7 @@ package checkpoint
 import (
 	"github.com/DATA-DOG/go-sqlmock"
 	. "github.com/pingcap/check"
+	"github.com/pingcap/errors"
 )
 
 var _ = Suite(&testUtil{})
@@ -24,14 +25,15 @@ type testUtil struct{}
 
 func (t *testUtil) TestG(c *C) {
 	tests := []struct {
-		name string
-		rows []uint64
-		id   uint64
-		err  bool
+		name              string
+		rows              []uint64
+		id                uint64
+		err               bool
+		checkSpecifiedErr error
 	}{
-		{"no row", nil, 0, true},
-		{"on row", []uint64{1}, 1, false},
-		{"multi row", []uint64{1, 2}, 0, true},
+		{"no row", nil, 0, true, ErrNoCheckpointItem},
+		{"on row", []uint64{1}, 1, false, nil},
+		{"multi row", []uint64{1, 2}, 0, true, nil},
 	}
 
 	for _, test := range tests {
@@ -50,6 +52,9 @@ func (t *testUtil) TestG(c *C) {
 		if test.err {
 			c.Assert(err, NotNil)
 			c.Assert(id, Equals, test.id)
+			if test.checkSpecifiedErr != nil {
+				c.Assert(errors.Cause(err), Equals, test.checkSpecifiedErr)
+			}
 		} else {
 			c.Assert(err, IsNil)
 			c.Assert(id, Equals, test.id)

--- a/drainer/config.go
+++ b/drainer/config.go
@@ -79,8 +79,8 @@ type SyncerConfig struct {
 
 // RelayConfig is the Relay log's configuration.
 type RelayConfig struct {
-	LogDir  string `toml:"log-dir" json:"log-dir"`
-	LogSize int64  `toml:"log-size" json:"log-size"`
+	LogDir      string `toml:"log-dir" json:"log-dir"`
+	MaxFileSize int64  `toml:"max-file-size" json:"max-file-size"`
 }
 
 // SwitchOn return true if we need to handle relay log.

--- a/drainer/config.go
+++ b/drainer/config.go
@@ -83,6 +83,11 @@ type RelayConfig struct {
 	LogSize int64  `toml:"log-size" json:"log-size"`
 }
 
+// SwitchOn return true if we need to handle relay log.
+func (rc RelayConfig) SwitchOn() bool {
+	return len(rc.LogDir) > 0
+}
+
 // Config holds the configuration of drainer
 type Config struct {
 	*flag.FlagSet   `json:"-"`

--- a/drainer/config.go
+++ b/drainer/config.go
@@ -71,12 +71,16 @@ type SyncerConfig struct {
 	DoTables          []filter.TableName `toml:"replicate-do-table" json:"replicate-do-table"`
 	DoDBs             []string           `toml:"replicate-do-db" json:"replicate-do-db"`
 	DestDBType        string             `toml:"db-type" json:"db-type"`
-	RelayLogDir       string             `toml:"relay-log-dir" json:"relay-log-dir"`
-	RelayLogSize      int64              `toml:"relay-log-size" json:"relay-log-size"`
-	RelayReadBufSize  int                `toml:"relay-read-buf-size" json:"relay-read-buf-size"`
+	Relay             RelayConfig        `toml:"relay" json:"relay"`
 	EnableDispatch    bool               `toml:"enable-dispatch" json:"enable-dispatch"`
 	SafeMode          bool               `toml:"safe-mode" json:"safe-mode"`
 	EnableCausality   bool               `toml:"enable-detect" json:"enable-detect"`
+}
+
+// RelayConfig is the Relay log's configuration.
+type RelayConfig struct {
+	LogDir  string `toml:"log-dir" json:"log-dir"`
+	LogSize int64  `toml:"log-size" json:"log-size"`
 }
 
 // Config holds the configuration of drainer
@@ -133,9 +137,6 @@ func NewConfig() *Config {
 	fs.StringVar(&cfg.SyncerCfg.IgnoreSchemas, "ignore-schemas", "INFORMATION_SCHEMA,PERFORMANCE_SCHEMA,mysql", "disable sync those schemas")
 	fs.IntVar(&cfg.SyncerCfg.WorkerCount, "c", 16, "parallel worker count")
 	fs.StringVar(&cfg.SyncerCfg.DestDBType, "dest-db-type", "mysql", "target db type: mysql or tidb or file or kafka; see syncer section in conf/drainer.toml")
-	fs.StringVar(&cfg.SyncerCfg.RelayLogDir, "relay-log-dir", "", "path to relay log of syncer")
-	fs.Int64Var(&cfg.SyncerCfg.RelayLogSize, "relay-log-size", 10*1024*1024, "max file size of each relay log")
-	fs.IntVar(&cfg.SyncerCfg.RelayReadBufSize, "relay-read-buf-size", 8, "read buffer size of relay log")
 	fs.BoolVar(&cfg.SyncerCfg.EnableDispatch, "enable-dispatch", true, "enable dispatching sqls that in one same binlog; if set true, work-count and txn-batch would be useless")
 	fs.BoolVar(&cfg.SyncerCfg.SafeMode, "safe-mode", false, "enable safe mode to make syncer reentrant")
 	fs.BoolVar(&cfg.SyncerCfg.EnableCausality, "enable-detect", false, "enable detect causality")

--- a/drainer/config.go
+++ b/drainer/config.go
@@ -86,8 +86,8 @@ type RelayConfig struct {
 	MaxFileSize int64  `toml:"max-file-size" json:"max-file-size"`
 }
 
-// SwitchOn return true if we need to handle relay log.
-func (rc RelayConfig) SwitchOn() bool {
+// IsEnabled return true if we need to handle relay log.
+func (rc RelayConfig) IsEnabled() bool {
 	return len(rc.LogDir) > 0
 }
 
@@ -148,6 +148,9 @@ func NewConfig() *Config {
 	fs.StringVar(&cfg.SyncerCfg.IgnoreSchemas, "ignore-schemas", "INFORMATION_SCHEMA,PERFORMANCE_SCHEMA,mysql", "disable sync those schemas")
 	fs.IntVar(&cfg.SyncerCfg.WorkerCount, "c", 16, "parallel worker count")
 	fs.StringVar(&cfg.SyncerCfg.DestDBType, "dest-db-type", "mysql", "target db type: mysql or tidb or file or kafka; see syncer section in conf/drainer.toml")
+	fs.StringVar(&cfg.SyncerCfg.Relay.LogDir, "relay-log-dir", "", "path to relay log of syncer")
+	fs.Int64Var(&cfg.SyncerCfg.Relay.MaxFileSize, "relay-max-file-size", 10485760, "max file size of each relay log")
+
 	fs.BoolVar(&cfg.SyncerCfg.EnableDispatch, "enable-dispatch", true, "enable dispatching sqls that in one same binlog; if set true, work-count and txn-batch would be useless")
 	fs.BoolVar(&cfg.SyncerCfg.SafeMode, "safe-mode", false, "enable safe mode to make syncer reentrant")
 	fs.BoolVar(&cfg.SyncerCfg.EnableCausality, "enable-detect", false, "enable detect causality")

--- a/drainer/relay.go
+++ b/drainer/relay.go
@@ -34,7 +34,7 @@ func feedByRelayLogIfNeed(cfg *Config) error {
 
 	defer cp.Close()
 
-	if cp.Status() == checkpoint.StatusNormal {
+	if cp.Status() == checkpoint.StatusConsistent {
 		return nil
 	}
 
@@ -149,7 +149,7 @@ func feedByRelayLog(r relay.Reader, ld loader.Loader, cp checkpoint.CheckPoint) 
 		return errors.Trace(readerErr)
 	}
 
-	err := cp.Save(lastSuccessTS, 0 /* slaveTS */, checkpoint.StatusNormal)
+	err := cp.Save(lastSuccessTS, 0 /* slaveTS */, checkpoint.StatusConsistent)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/drainer/relay.go
+++ b/drainer/relay.go
@@ -81,7 +81,7 @@ func feedByRelayLog(r relay.Reader, ld loader.Loader, cp checkpoint.CheckPoint) 
 	readerTxns = r.Txns()
 
 	loaderClosed := false
-loop:
+
 	for {
 		if readerTxns == nil && loaderInput == nil && !loaderClosed {
 			ld.Close()
@@ -118,7 +118,7 @@ loop:
 			if !ok {
 				successTxnC = nil
 				log.Info("success closed")
-				break loop
+				continue
 			}
 			lastSuccessTS = success.Metadata.(int64)
 		case <-loaderQuit:

--- a/drainer/relay.go
+++ b/drainer/relay.go
@@ -1,0 +1,155 @@
+package drainer
+
+import (
+	"github.com/pingcap/errors"
+	"github.com/pingcap/log"
+	"github.com/pingcap/tidb-binlog/drainer/checkpoint"
+	"github.com/pingcap/tidb-binlog/drainer/relay"
+	"github.com/pingcap/tidb-binlog/drainer/sync"
+	"github.com/pingcap/tidb-binlog/pkg/loader"
+	obinlog "github.com/pingcap/tidb-tools/tidb-binlog/slave_binlog_proto/go-binlog"
+	"go.uber.org/zap"
+)
+
+func feedByRelayLogIfNeed(cfg *Config) error {
+	if !cfg.SyncerCfg.Relay.SwitchOn() {
+		return nil
+	}
+
+	// for the mysql type checkpoint
+	// clusterID will be use as the key
+	// we can't get the cluster id from pd so we just set 0
+	// and the checkpoint will use the clusterID exist at the checkpoint table.
+	cpCfg, err := GenCheckPointCfg(cfg, 0 /* clusterID */)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	scfg := cfg.SyncerCfg
+
+	cp, err := checkpoint.NewCheckPoint(cpCfg)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	defer cp.Close()
+
+	if cp.Status() == checkpoint.StatusNormal {
+		return nil
+	}
+
+	reader, err := relay.NewReader(scfg.Relay.LogDir, 1 /* readBufferSize */)
+	if err != nil {
+		return errors.Annotate(err, "failed to create reader")
+	}
+
+	db, ld, err := sync.CreateLoader(scfg.To, scfg.WorkerCount, scfg.TxnBatch, nil, scfg.StrSQLMode, scfg.DestDBType)
+	if err != nil {
+		return errors.Annotate(err, "faild to create loader")
+	}
+
+	defer db.Close()
+
+	err = feedByRelayLog(reader, ld, cp)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	return nil
+}
+
+// feedByRelayLog will take over the `ld loader.Loader`.
+func feedByRelayLog(r relay.Reader, ld loader.Loader, cp checkpoint.CheckPoint) error {
+	checkpointTS := cp.TS()
+	var lastSuccessTS int64
+	r.Run()
+
+	loaderQuit := make(chan struct{})
+	var loaderErr error
+	go func() {
+		ld.SetSafeMode(true)
+		loaderErr = ld.Run()
+		close(loaderQuit)
+	}()
+
+	var readerTxns <-chan *obinlog.Binlog
+	// var readerInputClosed bool
+	var toPushLoaderTxn *loader.Txn
+	var loaderInput chan<- *loader.Txn
+	successTxnC := ld.Successes()
+
+	readerTxns = r.Txns()
+
+	loaderClosed := false
+loop:
+	for {
+		if readerTxns == nil && loaderInput == nil && !loaderClosed {
+			ld.Close()
+			loaderClosed = true
+		}
+
+		if loaderClosed && successTxnC == nil {
+			break
+		}
+
+		select {
+		case sbinlog, ok := <-readerTxns:
+			if !ok {
+				log.Info("readerTxns closed")
+				readerTxns = nil
+				continue
+			}
+			txn, err := loader.SlaveBinlogToTxn(sbinlog)
+			if err != nil {
+				return errors.Trace(err)
+			}
+
+			if sbinlog.CommitTs <= checkpointTS {
+				continue
+			}
+
+			txn.Metadata = sbinlog.CommitTs
+			toPushLoaderTxn = txn
+			loaderInput = ld.Input()
+		case loaderInput <- toPushLoaderTxn:
+			loaderInput = nil
+			toPushLoaderTxn = nil
+		case success, ok := <-successTxnC:
+			if !ok {
+				successTxnC = nil
+				log.Info("success closed")
+				break loop
+			}
+			lastSuccessTS = success.Metadata.(int64)
+		case <-loaderQuit:
+			if loaderErr != nil {
+				return errors.Trace(loaderErr)
+			}
+			loaderQuit = nil
+		}
+	}
+
+	log.Info("finish feed by relay log")
+
+	readerErr := <-r.Error()
+	<-loaderQuit
+
+	if readerErr != nil {
+		return errors.Trace(readerErr)
+	}
+
+	if loaderErr != nil {
+		return errors.Trace(loaderErr)
+	}
+
+	if lastSuccessTS > checkpointTS {
+		err := cp.Save(lastSuccessTS, 0 /* slaveTS */, checkpoint.StatusNormal)
+		if err != nil {
+			return errors.Trace(err)
+		}
+
+		log.Info("update status as normal", zap.Int64("ts", lastSuccessTS))
+	}
+
+	return nil
+}

--- a/drainer/relay.go
+++ b/drainer/relay.go
@@ -61,7 +61,7 @@ func feedByRelayLogIfNeed(cfg *Config) error {
 // feedByRelayLog will take over the `ld loader.Loader`.
 func feedByRelayLog(r relay.Reader, ld loader.Loader, cp checkpoint.CheckPoint) error {
 	checkpointTS := cp.TS()
-	var lastSuccessTS int64
+	lastSuccessTS := checkpointTS
 	r.Run()
 
 	loaderQuit := make(chan struct{})
@@ -142,14 +142,12 @@ loop:
 		return errors.Trace(loaderErr)
 	}
 
-	if lastSuccessTS > checkpointTS {
-		err := cp.Save(lastSuccessTS, 0 /* slaveTS */, checkpoint.StatusNormal)
-		if err != nil {
-			return errors.Trace(err)
-		}
-
-		log.Info("update status as normal", zap.Int64("ts", lastSuccessTS))
+	err := cp.Save(lastSuccessTS, 0 /* slaveTS */, checkpoint.StatusNormal)
+	if err != nil {
+		return errors.Trace(err)
 	}
+
+	log.Info("update status as normal", zap.Int64("ts", lastSuccessTS))
 
 	return nil
 }

--- a/drainer/relay.go
+++ b/drainer/relay.go
@@ -43,7 +43,7 @@ func feedByRelayLogIfNeed(cfg *Config) error {
 		return errors.Annotate(err, "failed to create reader")
 	}
 
-	db, ld, err := sync.CreateLoader(scfg.To, scfg.WorkerCount, scfg.TxnBatch, nil, scfg.StrSQLMode, scfg.DestDBType)
+	db, ld, err := sync.CreateLoader(scfg.To, scfg.WorkerCount, scfg.TxnBatch, nil, scfg.StrSQLMode, scfg.DestDBType, scfg.To.SyncMode)
 	if err != nil {
 		return errors.Annotate(err, "faild to create loader")
 	}

--- a/drainer/relay/reader.go
+++ b/drainer/relay/reader.go
@@ -19,7 +19,6 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
 	"github.com/pingcap/tidb-binlog/pkg/binlogfile"
-	"github.com/pingcap/tidb-binlog/pkg/loader"
 	obinlog "github.com/pingcap/tidb-tools/tidb-binlog/slave_binlog_proto/go-binlog"
 	"github.com/pingcap/tipb/go-binlog"
 )
@@ -32,7 +31,7 @@ type Reader interface {
 	Run() context.CancelFunc
 
 	// Txns returns parsed transactions.
-	Txns() <-chan *loader.Txn
+	Txns() <-chan *obinlog.Binlog
 
 	// Close releases resources.
 	Close() error
@@ -43,7 +42,7 @@ type Reader interface {
 
 type reader struct {
 	binlogger binlogfile.Binlogger
-	txns      chan *loader.Txn
+	txns      chan *obinlog.Binlog
 	err       chan error
 }
 
@@ -56,7 +55,7 @@ func NewReader(dir string, readBufferSize int) (Reader, error) {
 
 	return &reader{
 		binlogger: binlogger,
-		txns:      make(chan *loader.Txn, readBufferSize),
+		txns:      make(chan *obinlog.Binlog, readBufferSize),
 	}, nil
 }
 
@@ -85,16 +84,11 @@ func (r *reader) Run() context.CancelFunc {
 				break
 			}
 
-			var txn *loader.Txn
-			txn, err = loader.SlaveBinlogToTxn(slaveBinlog)
-			if err != nil {
-				break
-			}
 			select {
 			case <-ctx.Done():
 				err = ctx.Err()
 				log.Warn("Producing transaction is interrupted")
-			case r.txns <- txn:
+			case r.txns <- slaveBinlog:
 			}
 		}
 		// If binlogger is not done, notify it to stop.
@@ -114,7 +108,7 @@ func (r *reader) Run() context.CancelFunc {
 }
 
 // Txns implements Reader interface.
-func (r *reader) Txns() <-chan *loader.Txn {
+func (r *reader) Txns() <-chan *obinlog.Binlog {
 	return r.txns
 }
 

--- a/drainer/relay/reader_test.go
+++ b/drainer/relay/reader_test.go
@@ -88,7 +88,7 @@ func (r *testReaderSuite) readBinlogAndCheck(c *C, dir string, expectedNumber in
 
 	var lastTxn *loader.Txn
 	number := 0
-	for txn := range relayReader.Txns() {
+	for txn := range relayReader.Binlogs() {
 		number++
 		loaderTxn, err := loader.SlaveBinlogToTxn(txn)
 		c.Assert(err, IsNil)

--- a/drainer/relay/reader_test.go
+++ b/drainer/relay/reader_test.go
@@ -90,7 +90,9 @@ func (r *testReaderSuite) readBinlogAndCheck(c *C, dir string, expectedNumber in
 	number := 0
 	for txn := range relayReader.Txns() {
 		number++
-		lastTxn = txn
+		loaderTxn, err := loader.SlaveBinlogToTxn(txn)
+		c.Assert(err, IsNil)
+		lastTxn = loaderTxn
 	}
 	c.Assert(<-relayReader.Error(), IsNil)
 	c.Assert(number, Equals, expectedNumber)

--- a/drainer/relay/relayer.go
+++ b/drainer/relay/relayer.go
@@ -22,6 +22,8 @@ import (
 
 var _ Relayer = &relayer{}
 
+const defaultMaxFileSize = 10 * 1024 * 1024
+
 // Relayer is the interface for writing relay log.
 type Relayer interface {
 	// WriteBinlog writes binlog to relay log file.
@@ -43,6 +45,10 @@ type relayer struct {
 
 // NewRelayer creates a relayer.
 func NewRelayer(dir string, maxFileSize int64, tableInfoGetter translator.TableInfoGetter) (Relayer, error) {
+	if maxFileSize <= 0 {
+		maxFileSize = defaultMaxFileSize
+	}
+
 	binlogger, err := binlogfile.OpenBinlogger(dir, maxFileSize)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/drainer/relay_test.go
+++ b/drainer/relay_test.go
@@ -1,0 +1,104 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package drainer
+
+import (
+	"github.com/pingcap/check"
+	"github.com/pingcap/tidb-binlog/drainer/checkpoint"
+	"github.com/pingcap/tidb-binlog/drainer/relay"
+	"github.com/pingcap/tidb-binlog/drainer/translator"
+	"github.com/pingcap/tidb-binlog/pkg/binlogfile"
+	"github.com/pingcap/tidb-binlog/pkg/loader"
+)
+
+type relaySuite struct{}
+
+var _ = check.Suite(&relaySuite{})
+
+type noOpLoader struct {
+	input   chan *loader.Txn
+	success chan *loader.Txn
+}
+
+func newNoOpLoader() *noOpLoader {
+	return &noOpLoader{
+		input:   make(chan *loader.Txn, 1),
+		success: make(chan *loader.Txn, 1),
+	}
+}
+
+func (ld *noOpLoader) Run() error {
+	for txn := range ld.input {
+		ld.success <- txn
+	}
+
+	close(ld.success)
+	return nil
+}
+
+func (ld *noOpLoader) Close() {
+	close(ld.input)
+}
+
+func (ld *noOpLoader) Input() chan<- *loader.Txn {
+	return ld.input
+}
+
+func (ld *noOpLoader) Successes() <-chan *loader.Txn {
+	return ld.success
+}
+
+func (ld *noOpLoader) SetSafeMode(bool) {
+	return
+}
+
+func (ld *noOpLoader) GetSafeMode() bool {
+	return false
+}
+
+var _ loader.Loader = &noOpLoader{}
+
+func (s *relaySuite) TestFeedByRealyLog(c *check.C) {
+	cp, err := checkpoint.NewFile(0 /* initialCommitTS */, c.MkDir()+"/cp")
+	c.Assert(err, check.IsNil)
+	cp.Save(0, 0, checkpoint.StatusRunning)
+
+	ld := newNoOpLoader()
+
+	// write some relay log
+	gen := &translator.BinlogGenerator{}
+	relayDir := c.MkDir()
+	relayer, err := relay.NewRelayer(relayDir, binlogfile.SegmentSizeBytes, gen)
+	c.Assert(err, check.IsNil)
+
+	for i := 0; i < 10; i++ {
+		gen.SetInsert(c)
+		gen.TiBinlog.StartTs = int64(i)
+		gen.TiBinlog.CommitTs = int64(i) * 10
+		relayer.WriteBinlog(gen.Schema, gen.Table, gen.TiBinlog, gen.PV)
+	}
+
+	relayer.Close()
+	c.Assert(err, check.IsNil)
+
+	reader, err := relay.NewReader(relayDir, 1)
+	c.Assert(err, check.IsNil)
+
+	err = feedByRelayLog(reader, ld, cp)
+	c.Assert(err, check.IsNil)
+
+	ts := cp.TS()
+	c.Assert(ts, check.Equals, int64(90) /* latest commit ts */)
+	c.Assert(cp.Status(), check.Equals, checkpoint.StatusNormal)
+}

--- a/drainer/relay_test.go
+++ b/drainer/relay_test.go
@@ -31,6 +31,9 @@ type noOpLoader struct {
 	success chan *loader.Txn
 }
 
+// noOpLoader just return success for every input txn.
+var _ loader.Loader = &noOpLoader{}
+
 func newNoOpLoader() *noOpLoader {
 	return &noOpLoader{
 		input:   make(chan *loader.Txn, 1),
@@ -69,10 +72,11 @@ func (ld *noOpLoader) GetSafeMode() bool {
 var _ loader.Loader = &noOpLoader{}
 
 func (s *relaySuite) TestFeedByRealyLog(c *check.C) {
-	cp, err := checkpoint.NewFile(0 /* initialCommitTS */, c.MkDir()+"/cp")
+	cp, err := checkpoint.NewFile(0 /* initialCommitTS */, c.MkDir()+"/checkpoint")
 	c.Assert(err, check.IsNil)
 	err = cp.Save(0, 0, checkpoint.StatusRunning)
 	c.Assert(err, check.IsNil)
+	c.Assert(cp.Status(), check.Equals, checkpoint.StatusRunning)
 
 	ld := newNoOpLoader()
 

--- a/drainer/relay_test.go
+++ b/drainer/relay_test.go
@@ -60,7 +60,6 @@ func (ld *noOpLoader) Successes() <-chan *loader.Txn {
 }
 
 func (ld *noOpLoader) SetSafeMode(bool) {
-	return
 }
 
 func (ld *noOpLoader) GetSafeMode() bool {
@@ -72,7 +71,8 @@ var _ loader.Loader = &noOpLoader{}
 func (s *relaySuite) TestFeedByRealyLog(c *check.C) {
 	cp, err := checkpoint.NewFile(0 /* initialCommitTS */, c.MkDir()+"/cp")
 	c.Assert(err, check.IsNil)
-	cp.Save(0, 0, checkpoint.StatusRunning)
+	err = cp.Save(0, 0, checkpoint.StatusRunning)
+	c.Assert(err, check.IsNil)
 
 	ld := newNoOpLoader()
 
@@ -86,7 +86,8 @@ func (s *relaySuite) TestFeedByRealyLog(c *check.C) {
 		gen.SetInsert(c)
 		gen.TiBinlog.StartTs = int64(i)
 		gen.TiBinlog.CommitTs = int64(i) * 10
-		relayer.WriteBinlog(gen.Schema, gen.Table, gen.TiBinlog, gen.PV)
+		_, err = relayer.WriteBinlog(gen.Schema, gen.Table, gen.TiBinlog, gen.PV)
+		c.Assert(err, check.IsNil)
 	}
 
 	relayer.Close()

--- a/drainer/server.go
+++ b/drainer/server.go
@@ -101,6 +101,10 @@ func NewServer(cfg *Config) (*Server, error) {
 	// get pd client and cluster ID
 	pdCli, err := getPdClient(cfg.EtcdURLs, cfg.Security)
 	if err != nil {
+		err := feedByRelayLogIfNeed(cfg)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
 		return nil, errors.Trace(err)
 	}
 

--- a/drainer/server.go
+++ b/drainer/server.go
@@ -101,9 +101,9 @@ func NewServer(cfg *Config) (*Server, error) {
 	// get pd client and cluster ID
 	pdCli, err := getPdClient(cfg.EtcdURLs, cfg.Security)
 	if err != nil {
-		err := feedByRelayLogIfNeed(cfg)
-		if err != nil {
-			return nil, errors.Trace(err)
+		ferr := feedByRelayLogIfNeed(cfg)
+		if ferr != nil {
+			return nil, errors.Trace(ferr)
 		}
 		return nil, errors.Trace(err)
 	}

--- a/drainer/server.go
+++ b/drainer/server.go
@@ -102,7 +102,7 @@ func NewServer(cfg *Config) (*Server, error) {
 	pdCli, err := getPdClient(cfg.EtcdURLs, cfg.Security)
 	if err != nil {
 		ferr := feedByRelayLogIfNeed(cfg)
-		if ferr != nil {
+		if ferr != nil && errors.Cause(ferr) != checkpoint.ErrNoCheckpointItem {
 			return nil, errors.Trace(ferr)
 		}
 		return nil, errors.Trace(err)

--- a/drainer/sync/mysql.go
+++ b/drainer/sync/mysql.go
@@ -48,7 +48,6 @@ func CreateLoader(
 	queryHistogramVec *prometheus.HistogramVec,
 	sqlMode *string,
 	destDBType string,
-	syncMode int,
 ) (db *sql.DB, ld loader.Loader, err error) {
 	db, err = createDB(cfg.User, cfg.Password, cfg.Host, cfg.Port, sqlMode)
 	if err != nil {
@@ -64,7 +63,7 @@ func CreateLoader(
 		}))
 	}
 
-	if syncMode != 0 {
+	if cfg.SyncMode != 0 {
 		mode := loader.SyncMode(cfg.SyncMode)
 		opts = append(opts, loader.SyncModeOption(mode))
 
@@ -105,7 +104,7 @@ func NewMysqlSyncer(
 	destDBType string,
 	relayer relay.Relayer,
 ) (*MysqlSyncer, error) {
-	db, loader, err := CreateLoader(cfg, worker, batchSize, queryHistogramVec, sqlMode, destDBType, cfg.SyncMode)
+	db, loader, err := CreateLoader(cfg, worker, batchSize, queryHistogramVec, sqlMode, destDBType)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/drainer/sync/syncer.go
+++ b/drainer/sync/syncer.go
@@ -39,6 +39,7 @@ type Syncer interface {
 	// Return not nil if fail to sync data to downstream or nil if closed normally
 	Error() <-chan error
 	// Close the Syncer, no more item can be added by `Sync`
+	// will drain all items and return nil if all successfully sync into downstream
 	Close() error
 }
 

--- a/drainer/syncer.go
+++ b/drainer/syncer.go
@@ -436,10 +436,11 @@ ForLoop:
 		return err
 	}
 
-	if cerr == nil {
-		s.cp.Save(s.cp.TS(), 0, checkpoint.StatusNormal)
+	if cerr != nil {
+		return cerr
 	}
-	return cerr
+
+	return s.cp.Save(s.cp.TS(), 0, checkpoint.StatusNormal)
 }
 
 // filterTable may drop some table mutation in `PrewriteValue`

--- a/drainer/syncer.go
+++ b/drainer/syncer.go
@@ -461,7 +461,7 @@ ForLoop:
 		return cerr
 	}
 
-	return s.cp.Save(s.cp.TS(), 0, checkpoint.StatusNormal)
+	return s.cp.Save(s.cp.TS(), 0, checkpoint.StatusConsistent)
 }
 
 func findLoopBackMark(dmls []*loader.DML, info *loopbacksync.LoopBackSync) (bool, error) {

--- a/drainer/syncer.go
+++ b/drainer/syncer.go
@@ -252,7 +252,7 @@ func (s *Syncer) savePoint(ts, slaveTS int64) {
 	}
 
 	log.Info("write save point", zap.Int64("ts", ts))
-	err := s.cp.Save(ts, slaveTS)
+	err := s.cp.Save(ts, slaveTS, checkpoint.StatusRunning)
 	if err != nil {
 		log.Fatal("save checkpoint failed", zap.Int64("ts", ts), zap.Error(err))
 	}
@@ -435,6 +435,10 @@ ForLoop:
 	// return the origin error if has, or the close error
 	if err != nil {
 		return err
+	}
+
+	if cerr == nil {
+		s.cp.Save(s.cp.TS(), 0, checkpoint.StatusNormal)
 	}
 	return cerr
 }

--- a/drainer/syncer.go
+++ b/drainer/syncer.go
@@ -102,7 +102,7 @@ func createDSyncer(cfg *SyncerConfig, schema *Schema) (dsyncer dsync.Syncer, err
 	case "mysql", "tidb":
 		var relayer relay.Relayer
 		if cfg.Relay.SwitchOn() {
-			if relayer, err = relay.NewRelayer(cfg.Relay.LogDir, cfg.Relay.LogSize, schema); err != nil {
+			if relayer, err = relay.NewRelayer(cfg.Relay.LogDir, cfg.Relay.MaxFileSize, schema); err != nil {
 				return nil, errors.Annotate(err, "fail to create relayer")
 			}
 		}

--- a/drainer/syncer.go
+++ b/drainer/syncer.go
@@ -102,8 +102,8 @@ func createDSyncer(cfg *SyncerConfig, schema *Schema) (dsyncer dsync.Syncer, err
 	case "mysql", "tidb":
 		var relayer relay.Relayer
 		// If the dir is empty, it means relayer is disabled.
-		if len(cfg.RelayLogDir) > 0 {
-			if relayer, err = relay.NewRelayer(cfg.RelayLogDir, cfg.RelayLogSize, schema); err != nil {
+		if len(cfg.Relay.LogDir) > 0 {
+			if relayer, err = relay.NewRelayer(cfg.Relay.LogDir, cfg.Relay.LogSize, schema); err != nil {
 				return nil, errors.Annotate(err, "fail to create relayer")
 			}
 		}

--- a/drainer/syncer.go
+++ b/drainer/syncer.go
@@ -101,8 +101,7 @@ func createDSyncer(cfg *SyncerConfig, schema *Schema) (dsyncer dsync.Syncer, err
 		}
 	case "mysql", "tidb":
 		var relayer relay.Relayer
-		// If the dir is empty, it means relayer is disabled.
-		if len(cfg.Relay.LogDir) > 0 {
+		if cfg.Relay.SwitchOn() {
 			if relayer, err = relay.NewRelayer(cfg.Relay.LogDir, cfg.Relay.LogSize, schema); err != nil {
 				return nil, errors.Annotate(err, "fail to create relayer")
 			}

--- a/drainer/syncer.go
+++ b/drainer/syncer.go
@@ -108,7 +108,7 @@ func createDSyncer(cfg *SyncerConfig, schema *Schema, info *loopbacksync.LoopBac
 		}
 	case "mysql", "tidb":
 		var relayer relay.Relayer
-		if cfg.Relay.SwitchOn() {
+		if cfg.Relay.IsEnabled() {
 			if relayer, err = relay.NewRelayer(cfg.Relay.LogDir, cfg.Relay.MaxFileSize, schema); err != nil {
 				return nil, errors.Annotate(err, "fail to create relayer")
 			}

--- a/drainer/syncer_test.go
+++ b/drainer/syncer_test.go
@@ -64,7 +64,7 @@ func (s *syncerSuite) TestNewSyncer(c *check.C) {
 	}
 
 	cpFile := c.MkDir() + "/checkpoint"
-	cp, err := checkpoint.NewFile(&checkpoint.Config{CheckPointFile: cpFile})
+	cp, err := checkpoint.NewFile(0, cpFile)
 	c.Assert(err, check.IsNil)
 
 	syncer, err := NewSyncer(cp, cfg, nil)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
support to recover at startup by relay log. 
follows #847 #849 
### What is changed and how it works?
- add a status in checkpoint
    - we can learn from the status that there are dirty data written into downstream behind commit ts or not.
- group the config items about relay
    - remove the `relay-read-buf-size`
    - rename `relay-log-size` to `max-file-size`
- make relay.Reader return the origin format  directly
    - this will be more flexible by the user of the reader
- feed downstream by relay log at startup if need.
    - mainly implement in `drainer/relay.go`
    - only fails to init the pd client will try this or just assume the upstream cluster is normal and works like before.

   

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)
- kill -9 drainer & pd while insert data into upstream
- check status is Running
- startup drainer
- check recover and status updated to be Normal



Side effects



Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note