### PR TITLE
binlog loop back sync

### DIFF
--- a/cmd/drainer/drainer.toml
+++ b/cmd/drainer/drainer.toml
@@ -84,6 +84,10 @@ password = ""
 # if encrypted_password is not empty, password will be ignored.
 encrypted_password = ""
 port = 3306
+# 1: SyncFullColumn, 2: SyncPartialColumn
+# when setting SyncPartialColumn drainer will allow the downstream schema
+# having more or less column numbers and relax sql mode by removing STRICT_TRANS_TABLES.
+# sync-mode = 1
 
 [syncer.to.checkpoint]
 # only support mysql or tidb now, you can uncomment this to control where the checkpoint is saved.

--- a/cmd/drainer/drainer.toml
+++ b/cmd/drainer/drainer.toml
@@ -38,6 +38,19 @@ compressor = ""
 # number of binlog events in a transaction batch
 txn-batch = 20
 
+# sync ddl to downstream db or not
+sync-ddl = true
+
+# This variable works in dual-a. if it is false, the upstream data will all be synchronized to the downstream, except for the filtered table.
+# If it is true, the channel value is set at the same time, and the upstream starts with the mark table ID updated, and the channel ID is the same as its channel ID.
+# this part of data will not be synchronized to the downstream. Therefore, in dual-a scenario,both sides Channel id also needs to be set to the same value
+loopback-control = false
+
+# When loopback control is turned on, the channel ID will work.
+# In the dual-a scenario, the channel ID synchronized from the downstream to the upstream and the channel ID synchronized from
+# the upstream to the downstream need to be set to the same value to avoid loopback synchronization
+channel-id = 1
+
 # work count to execute binlogs
 # if the latency between drainer and downstream(mysql or tidb) are too high, you might want to increase this
 # to get higher throughput by higher concurrent write to the downstream

--- a/drainer/config.go
+++ b/drainer/config.go
@@ -66,6 +66,9 @@ type SyncerConfig struct {
 	IgnoreSchemas     string             `toml:"ignore-schemas" json:"ignore-schemas"`
 	IgnoreTables      []filter.TableName `toml:"ignore-table" json:"ignore-table"`
 	TxnBatch          int                `toml:"txn-batch" json:"txn-batch"`
+	LoopbackControl   bool               `toml:"loopback-control" json:"loopback-control"`
+	SyncDDL           bool               `toml:"sync-ddl" json:"sync-ddl"`
+	ChannelID         int64              `toml:"channel-id" json:"channel-id"`
 	WorkerCount       int                `toml:"worker-count" json:"worker-count"`
 	To                *dsync.DBConfig    `toml:"to" json:"to"`
 	DoTables          []filter.TableName `toml:"replicate-do-table" json:"replicate-do-table"`
@@ -127,6 +130,9 @@ func NewConfig() *Config {
 	fs.Int64Var(&cfg.InitialCommitTS, "initial-commit-ts", -1, "if drainer donesn't have checkpoint, use initial commitTS to initial checkpoint, will get a latest timestamp from pd if setting to be -1")
 	fs.StringVar(&cfg.Compressor, "compressor", "", "use the specified compressor to compress payload between pump and drainer, only 'gzip' is supported now (default \"\", ie. compression disabled.)")
 	fs.IntVar(&cfg.SyncerCfg.TxnBatch, "txn-batch", 20, "number of binlog events in a transaction batch")
+	fs.BoolVar(&cfg.SyncerCfg.LoopbackControl, "loopback-control", false, "set mark or not ")
+	fs.BoolVar(&cfg.SyncerCfg.SyncDDL, "sync-ddl", true, "sync ddl or not")
+	fs.Int64Var(&cfg.SyncerCfg.ChannelID, "channel-id", 0, "sync channel id ")
 	fs.StringVar(&cfg.SyncerCfg.IgnoreSchemas, "ignore-schemas", "INFORMATION_SCHEMA,PERFORMANCE_SCHEMA,mysql", "disable sync those schemas")
 	fs.IntVar(&cfg.SyncerCfg.WorkerCount, "c", 16, "parallel worker count")
 	fs.StringVar(&cfg.SyncerCfg.DestDBType, "dest-db-type", "mysql", "target db type: mysql or tidb or file or kafka; see syncer section in conf/drainer.toml")

--- a/drainer/loopbacksync/loopbacksync.go
+++ b/drainer/loopbacksync/loopbacksync.go
@@ -1,0 +1,42 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package loopbacksync
+
+const (
+	//MarkTableName mark table name
+	MarkTableName = "retl._drainer_repl_mark"
+	//ChannelID channel id
+	ChannelID = "channel_id"
+	//Val val
+	Val = "val"
+	//ChannelInfo channel info
+	ChannelInfo = "channel_info"
+)
+
+//LoopBackSync loopback sync info
+type LoopBackSync struct {
+	ChannelID       int64
+	LoopbackControl bool
+	SyncDDL         bool
+}
+
+//NewLoopBackSyncInfo return LoopBackSyncInfo objec
+func NewLoopBackSyncInfo(ChannelID int64, LoopbackControl, SyncDDL bool) *LoopBackSync {
+	l := &LoopBackSync{
+		ChannelID:       ChannelID,
+		LoopbackControl: LoopbackControl,
+		SyncDDL:         SyncDDL,
+	}
+	return l
+}

--- a/drainer/loopbacksync/loopbacksync_test.go
+++ b/drainer/loopbacksync/loopbacksync_test.go
@@ -1,0 +1,27 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package loopbacksync
+
+import "testing"
+
+//TestNewLoopBackSyncInfo test loopBackSyncInfo alloc
+func TestNewLoopBackSyncInfo(t *testing.T) {
+	var ChannelID int64 = 1
+	var LoopbackControl = true
+	var SyncDDL = false
+	l := NewLoopBackSyncInfo(ChannelID, LoopbackControl, SyncDDL)
+	if l == nil {
+		t.Error("alloc loopBackSyncInfo objec failed ")
+	}
+}

--- a/drainer/sync/mysql.go
+++ b/drainer/sync/mysql.go
@@ -15,6 +15,7 @@ package sync
 
 import (
 	"database/sql"
+	"strings"
 	"sync"
 
 	"github.com/pingcap/errors"
@@ -53,6 +54,27 @@ func NewMysqlSyncer(cfg *DBConfig, tableInfoGetter translator.TableInfoGetter, w
 		}))
 	}
 
+	if cfg.SyncMode != 0 {
+		mode := loader.SyncMode(cfg.SyncMode)
+		opts = append(opts, loader.SyncModeOption(mode))
+
+		if mode == loader.SyncPartialColumn {
+			var oldMode, newMode string
+			oldMode, newMode, err = relaxSQLMode(db)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+
+			if newMode != oldMode {
+				db.Close()
+				db, err = createDB(cfg.User, cfg.Password, cfg.Host, cfg.Port, &newMode)
+				if err != nil {
+					return nil, errors.Trace(err)
+				}
+			}
+		}
+	}
+
 	loader, err := loader.NewLoader(db, opts...)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -67,6 +89,29 @@ func NewMysqlSyncer(cfg *DBConfig, tableInfoGetter translator.TableInfoGetter, w
 	go s.run()
 
 	return s, nil
+}
+
+// set newMode as the oldMode query from db by removing "STRICT_TRANS_TABLES".
+func relaxSQLMode(db *sql.DB) (oldMode string, newMode string, err error) {
+	row := db.QueryRow("SELECT @@SESSION.sql_mode;")
+	err = row.Scan(&oldMode)
+	if err != nil {
+		return "", "", errors.Trace(err)
+	}
+
+	toRemove := "STRICT_TRANS_TABLES"
+	newMode = oldMode
+
+	if !strings.Contains(oldMode, toRemove) {
+		return
+	}
+
+	// concatenated by "," like: mode1,mode2
+	newMode = strings.Replace(newMode, toRemove+",", "", -1)
+	newMode = strings.Replace(newMode, ","+toRemove, "", -1)
+	newMode = strings.Replace(newMode, toRemove, "", -1)
+
+	return
 }
 
 // SetSafeMode make the MysqlSyncer to use safe mode or not

--- a/drainer/sync/syncer_test.go
+++ b/drainer/sync/syncer_test.go
@@ -69,7 +69,7 @@ func (s *syncerSuite) SetUpTest(c *check.C) {
 		createDB = oldCreateDB
 	}()
 
-	mysql, err := NewMysqlSyncer(cfg, infoGetter, 1, 1, nil, nil, "mysql")
+	mysql, err := NewMysqlSyncer(cfg, infoGetter, 1, 1, nil, nil, "mysql", nil)
 	c.Assert(err, check.IsNil)
 	s.syncers = append(s.syncers, mysql)
 

--- a/drainer/sync/util.go
+++ b/drainer/sync/util.go
@@ -25,6 +25,7 @@ type DBConfig struct {
 	Password string `toml:"password" json:"password"`
 	// if EncryptedPassword is not empty, Password will be ignore.
 	EncryptedPassword string           `toml:"encrypted_password" json:"encrypted_password"`
+	SyncMode          int              `toml:"sync-mode" json:"sync-mode"`
 	Port              int              `toml:"port" json:"port"`
 	Checkpoint        CheckpointConfig `toml:"checkpoint" json:"checkpoint"`
 	BinlogFileDir     string           `toml:"dir" json:"dir"`

--- a/drainer/syncer_test.go
+++ b/drainer/syncer_test.go
@@ -16,6 +16,9 @@ package drainer
 import (
 	"time"
 
+	"github.com/pingcap/tidb-binlog/drainer/loopbacksync"
+	"github.com/pingcap/tidb-binlog/pkg/loader"
+
 	"github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"
@@ -58,9 +61,38 @@ func (s *syncerSuite) TestFilterTable(c *check.C) {
 	c.Assert(len(pv.Mutations), check.Equals, 1)
 }
 
+func (s *syncerSuite) TestFilterMarkDatas(c *check.C) {
+	var dmls []*loader.DML
+	dml := loader.DML{
+		Database: "retl",
+		Table:    "_drainer_repl_mark",
+		Tp:       1,
+		Values:   make(map[string]interface{}),
+	}
+	dml.Values["channel_id"] = int64(100)
+	dmls = append(dmls, &dml)
+	dml1 := loader.DML{
+		Database: "retl",
+		Table:    "retl_mark9",
+		Tp:       1,
+		Values:   make(map[string]interface{}),
+	}
+	dml1.Values["status"] = 100
+	dmls = append(dmls, &dml1)
+	loopBackSyncInfo := loopbacksync.LoopBackSync{
+		ChannelID:       100,
+		SyncDDL:         true,
+		LoopbackControl: false,
+	}
+	status, err := findLoopBackMark(dmls, &loopBackSyncInfo)
+	c.Assert(status, check.IsTrue)
+	c.Assert(err, check.IsNil)
+}
+
 func (s *syncerSuite) TestNewSyncer(c *check.C) {
 	cfg := &SyncerConfig{
 		DestDBType: "_intercept",
+		SyncDDL:    true,
 	}
 
 	cpFile := c.MkDir() + "/checkpoint"

--- a/pkg/loader/load.go
+++ b/pkg/loader/load.go
@@ -17,9 +17,12 @@ import (
 	"context"
 	gosql "database/sql"
 	"fmt"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/pingcap/tidb-binlog/drainer/loopbacksync"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
@@ -71,6 +74,8 @@ type loaderImpl struct {
 	workerCount int
 	syncMode    SyncMode
 
+	loopBackSyncInfo *loopbacksync.LoopBackSync
+
 	input      chan *Txn
 	successTxn chan *Txn
 
@@ -110,19 +115,21 @@ const (
 )
 
 type options struct {
-	workerCount   int
-	batchSize     int
-	metrics       *MetricsGroup
-	saveAppliedTS bool
-	syncMode      SyncMode
+	workerCount      int
+	batchSize        int
+	loopBackSyncInfo *loopbacksync.LoopBackSync
+	metrics          *MetricsGroup
+	saveAppliedTS    bool
+	syncMode         SyncMode
 }
 
 var defaultLoaderOptions = options{
-	workerCount:   16,
-	batchSize:     20,
-	metrics:       nil,
-	saveAppliedTS: false,
-	syncMode:      SyncFullColumn,
+	workerCount:      16,
+	batchSize:        20,
+	loopBackSyncInfo: nil,
+	metrics:          nil,
+	saveAppliedTS:    false,
+	syncMode:         SyncFullColumn,
 }
 
 // A Option sets options such batch size, worker count etc.
@@ -146,6 +153,13 @@ func WorkerCount(n int) Option {
 func BatchSize(n int) Option {
 	return func(o *options) {
 		o.batchSize = n
+	}
+}
+
+//SetloopBackSyncInfo set loop back sync info of loader
+func SetloopBackSyncInfo(loopBackSyncInfo *loopbacksync.LoopBackSync) Option {
+	return func(o *options) {
+		o.loopBackSyncInfo = loopBackSyncInfo
 	}
 }
 
@@ -174,14 +188,15 @@ func NewLoader(db *gosql.DB, opt ...Option) (Loader, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	s := &loaderImpl{
-		db:            db,
-		workerCount:   opts.workerCount,
-		batchSize:     opts.batchSize,
-		metrics:       opts.metrics,
-		input:         make(chan *Txn),
-		successTxn:    make(chan *Txn),
-		merge:         true,
-		saveAppliedTS: opts.saveAppliedTS,
+		db:               db,
+		workerCount:      opts.workerCount,
+		batchSize:        opts.batchSize,
+		metrics:          opts.metrics,
+		loopBackSyncInfo: opts.loopBackSyncInfo,
+		input:            make(chan *Txn),
+		successTxn:       make(chan *Txn),
+		merge:            true,
+		saveAppliedTS:    opts.saveAppliedTS,
 
 		ctx:    ctx,
 		cancel: cancel,
@@ -325,7 +340,6 @@ func isCreateDatabaseDDL(sql string) bool {
 
 func (s *loaderImpl) execDDL(ddl *DDL) error {
 	log.Debug("exec ddl", zap.Reflect("ddl", ddl))
-
 	err := util.RetryContext(s.ctx, maxDDLRetryCount, execDDLRetryWait, 1, func(context.Context) error {
 		tx, err := s.db.Begin()
 		if err != nil {
@@ -464,8 +478,30 @@ func (s *loaderImpl) execDMLs(dmls []*DML) error {
 	return errors.Trace(err)
 }
 
+func (s *loaderImpl) createMarkTable() error {
+	markTableDataBase := loopbacksync.MarkTableName[:strings.Index(loopbacksync.MarkTableName, ".")]
+	createDatabaseSQL := fmt.Sprintf("create database IF NOT EXISTS %s;", markTableDataBase)
+	createDatabase := DDL{SQL: createDatabaseSQL}
+	if err1 := s.execDDL(&createDatabase); err1 != nil {
+		log.Error("exec failed", zap.String("sql", createDatabase.SQL), zap.Error(err1))
+		return errors.Trace(err1)
+	}
+	sql := createMarkTableDDL()
+	createMarkTableInfo := DDL{Database: markTableDataBase, Table: loopbacksync.MarkTableName, SQL: sql}
+	if err := s.execDDL(&createMarkTableInfo); err != nil {
+		log.Error("exec failed", zap.String("sql", createMarkTableInfo.SQL), zap.Error(err))
+		return errors.Trace(err)
+	}
+	return nil
+}
+
 // Run will quit when meet any error, or all the txn are drained
 func (s *loaderImpl) Run() error {
+	if s.loopBackSyncInfo != nil && s.loopBackSyncInfo.LoopbackControl {
+		if err := s.createMarkTable(); err != nil {
+			return errors.Trace(err)
+		}
+	}
 	txnManager := newTxnManager(1024, s.input)
 	defer func() {
 		log.Info("Run()... in Loader quit")
@@ -574,6 +610,7 @@ func filterGeneratedCols(dml *DML) {
 
 func (s *loaderImpl) getExecutor() *executor {
 	e := newExecutor(s.db).withBatchSize(s.batchSize)
+	e.setSyncInfo(s.loopBackSyncInfo)
 	if s.metrics != nil && s.metrics.QueryHistogramVec != nil {
 		e = e.withQueryHistogramVec(s.metrics.QueryHistogramVec)
 	}

--- a/pkg/loader/load.go
+++ b/pkg/loader/load.go
@@ -69,6 +69,7 @@ type loaderImpl struct {
 
 	batchSize   int
 	workerCount int
+	syncMode    SyncMode
 
 	input      chan *Txn
 	successTxn chan *Txn
@@ -99,11 +100,21 @@ type MetricsGroup struct {
 	QueryHistogramVec *prometheus.HistogramVec
 }
 
+// SyncMode represents the sync mode of DML.
+type SyncMode int
+
+// SyncMode values.
+const (
+	SyncFullColumn SyncMode = 1 + iota
+	SyncPartialColumn
+)
+
 type options struct {
 	workerCount   int
 	batchSize     int
 	metrics       *MetricsGroup
 	saveAppliedTS bool
+	syncMode      SyncMode
 }
 
 var defaultLoaderOptions = options{
@@ -111,10 +122,18 @@ var defaultLoaderOptions = options{
 	batchSize:     20,
 	metrics:       nil,
 	saveAppliedTS: false,
+	syncMode:      SyncFullColumn,
 }
 
 // A Option sets options such batch size, worker count etc.
 type Option func(*options)
+
+// SyncModeOption set sync mode of loader.
+func SyncModeOption(n SyncMode) Option {
+	return func(o *options) {
+		o.syncMode = n
+	}
+}
 
 // WorkerCount set worker count of loader
 func WorkerCount(n int) Option {
@@ -392,6 +411,20 @@ func (s *loaderImpl) singleExec(executor *executor, dmls []*DML) error {
 	return errors.Trace(err)
 }
 
+func removeOrphanCols(info *tableInfo, dml *DML) {
+	mp := make(map[string]struct{}, len(info.columns))
+	for _, name := range info.columns {
+		mp[name] = struct{}{}
+	}
+
+	for name := range dml.Values {
+		if _, ok := mp[name]; !ok {
+			delete(dml.Values, name)
+			delete(dml.OldValues, name)
+		}
+	}
+}
+
 func (s *loaderImpl) execDMLs(dmls []*DML) error {
 	if len(dmls) == 0 {
 		return nil
@@ -402,6 +435,9 @@ func (s *loaderImpl) execDMLs(dmls []*DML) error {
 			return errors.Trace(err)
 		}
 		filterGeneratedCols(dml)
+		if s.syncMode == SyncPartialColumn {
+			removeOrphanCols(dml.info, dml)
+		}
 	}
 
 	batchTables, singleDMLs := s.groupDMLs(dmls)

--- a/pkg/loader/load_test.go
+++ b/pkg/loader/load_test.go
@@ -21,7 +21,7 @@ import (
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/go-sql-driver/mysql"
-	check "github.com/pingcap/check"
+	"github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/prometheus/client_golang/prometheus"
 )

--- a/pkg/loader/load_test.go
+++ b/pkg/loader/load_test.go
@@ -37,6 +37,37 @@ func (cs *LoadSuite) SetUpTest(c *check.C) {
 func (cs *LoadSuite) TearDownTest(c *check.C) {
 }
 
+func (cs *LoadSuite) TestRemoveOrphanCols(c *check.C) {
+	dml := &DML{
+		Values: map[string]interface{}{
+			"exist1":  11,
+			"exist2":  22,
+			"orhpan1": 11,
+			"orhpan2": 22,
+		},
+		OldValues: map[string]interface{}{
+			"exist1":  1,
+			"exist2":  2,
+			"orhpan1": 1,
+			"orhpan2": 2,
+		},
+	}
+
+	info := &tableInfo{
+		columns: []string{"exist1", "exist2"},
+	}
+
+	removeOrphanCols(info, dml)
+	c.Assert(dml.Values, check.DeepEquals, map[string]interface{}{
+		"exist1": 11,
+		"exist2": 22,
+	})
+	c.Assert(dml.OldValues, check.DeepEquals, map[string]interface{}{
+		"exist1": 1,
+		"exist2": 2,
+	})
+}
+
 func (cs *LoadSuite) TestOptions(c *check.C) {
 	var o options
 	WorkerCount(42)(&o)

--- a/pkg/loader/model.go
+++ b/pkg/loader/model.go
@@ -18,6 +18,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/pingcap/tidb-binlog/drainer/loopbacksync"
+
 	"github.com/pingcap/log"
 	"go.uber.org/zap"
 )
@@ -182,6 +184,11 @@ func (dml *DML) updateSQL() (sql string, args []interface{}) {
 	builder.WriteString(" LIMIT 1")
 	sql = builder.String()
 	return
+}
+
+func createMarkTableDDL() string {
+	sql := fmt.Sprintf("CREATE TABLE If Not Exists %s ( %s bigint primary key, %s bigint DEFAULT 0, %s varchar(64));", loopbacksync.MarkTableName, loopbacksync.ChannelID, loopbacksync.Val, loopbacksync.ChannelInfo)
+	return sql
 }
 
 func (dml *DML) buildWhere(builder *strings.Builder) (args []interface{}) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
cherry pick #879 #867 

### What is changed and how it works?
cherry pick #879 #867 

    Add sync mode config (#867)

    allow when the column number of downstream table mismatch with current schema.

    For the case bidirectional replication, we will execute the DDL at one side, for add or drop column
    the column number will mismatch.

    cluster A <-> cluster B

    drop column of table t at cluster A
    some DML of table t at cluster B will miss the column dropped compared to cluster A

    binlog loop back sync (#879)

    In the AA dual activity scenario, there is data write (DML) on both sides. The data of tidb cluster on both sides needs to be synchronized with each other，but avoid loopback synchronization，and ddl is only writed one side.

    add three variables in drainer.toml as identification to confirm need sync ddl or not and need set sync mark identification or not and sync identification id to Avoid loopback synchronization
    add configuration item
    loopback-control (true/false) set mark table identification or not and filter txn by mark table
    ddl-sync (true/false) sync ddl to downstream DB or not
    channel-id (integer) sync identification id，avoid loopback synchronization

### Check List <!--REMOVE the items that are not applicable-->



Code changes
