### PR TITLE
drainer: Fix #724, Enable drainer to purge old incremental backup data on disk

### DIFF
--- a/cmd/drainer/drainer.toml
+++ b/cmd/drainer/drainer.toml
@@ -129,6 +129,8 @@ port = 3306
 #[syncer.to]
 # directory to save binlog file, default same as data-dir(save checkpoint file) if this is not configured.
 # dir = "data.drainer"
+#
+# retention-time = 7
 
 
 # when db-type is kafka, you can uncomment this to config the down stream kafka, it will be the globle config kafka default
@@ -138,8 +140,6 @@ port = 3306
 # kafka-addrs = "127.0.0.1:9092"
 # kafka-version = "0.8.2.0"
 # kafka-max-messages = 1024
-#
-# retention-time = 7
 #
 # the topic name drainer will push msg, the default name is <cluster-id>_obinlog
 # be careful don't use the same name if run multi drainer instances

--- a/cmd/drainer/drainer.toml
+++ b/cmd/drainer/drainer.toml
@@ -139,6 +139,7 @@ port = 3306
 # kafka-version = "0.8.2.0"
 # kafka-max-messages = 1024
 #
+# retention-time = 7
 #
 # the topic name drainer will push msg, the default name is <cluster-id>_obinlog
 # be careful don't use the same name if run multi drainer instances

--- a/drainer/relay/relayer.go
+++ b/drainer/relay/relayer.go
@@ -79,7 +79,7 @@ func (r *relayer) WriteBinlog(schema string, table string, tiBinlog *tb.Binlog, 
 func (r *relayer) GCBinlog(pos tb.Pos) {
 	// If the file suffix increases, it means previous files are useless.
 	if pos.Suffix > r.nextGCFileSuffix {
-		r.binlogger.GC(0, pos)
+		r.binlogger.GCByPos(pos)
 		r.nextGCFileSuffix = pos.Suffix
 	}
 }

--- a/drainer/sync/pb.go
+++ b/drainer/sync/pb.go
@@ -14,7 +14,11 @@
 package sync
 
 import (
+	"context"
+	"time"
+
 	"github.com/pingcap/errors"
+	"github.com/pingcap/log"
 	"github.com/pingcap/tidb-binlog/drainer/translator"
 	"github.com/pingcap/tidb-binlog/pkg/binlogfile"
 	pb "github.com/pingcap/tidb-binlog/proto/binlog"
@@ -24,21 +28,44 @@ import (
 var _ Syncer = &pbSyncer{}
 
 type pbSyncer struct {
-	binlogger binlogfile.Binlogger
-
 	*baseSyncer
+
+	binlogger binlogfile.Binlogger
+	cancel    func()
 }
 
 // NewPBSyncer sync binlog to files
-func NewPBSyncer(dir string, tableInfoGetter translator.TableInfoGetter) (*pbSyncer, error) {
-	binlogger, err := binlogfile.OpenBinlogger(dir, binlogfile.SegmentSizeBytes)
+func NewPBSyncer(cfg *DBConfig, tableInfoGetter translator.TableInfoGetter) (*pbSyncer, error) {
+	binlogger, err := binlogfile.OpenBinlogger(cfg.BinlogFileDir, binlogfile.SegmentSizeBytes)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
+	ctx, cancel := context.WithCancel(context.TODO())
+
 	s := &pbSyncer{
 		binlogger:  binlogger,
 		baseSyncer: newBaseSyncer(tableInfoGetter),
+		cancel:     cancel,
+	}
+
+	if cfg.BinlogFileRetentionTime > 0 {
+		// TODO: Add support for human readable format input of times like "7d", "12h"
+		retentionTime := time.Duration(cfg.BinlogFileRetentionTime) * 24 * time.Hour
+		ticker := time.NewTicker(time.Hour)
+		go func() {
+			defer ticker.Stop()
+			for {
+				select {
+				case <-ctx.Done():
+					log.Info("Binlog GC loop stopped")
+					return
+				case <-ticker.C:
+					log.Info("Trying to GC binlog files")
+					binlogger.GCByTime(retentionTime)
+				}
+			}
+		}()
 	}
 
 	return s, nil
@@ -71,6 +98,8 @@ func (p *pbSyncer) saveBinlog(binlog *pb.Binlog) error {
 }
 
 func (p *pbSyncer) Close() error {
+	p.cancel()
+
 	err := p.binlogger.Close()
 	p.setErr(err)
 	close(p.success)

--- a/drainer/sync/pb.go
+++ b/drainer/sync/pb.go
@@ -35,8 +35,8 @@ type pbSyncer struct {
 }
 
 // NewPBSyncer sync binlog to files
-func NewPBSyncer(cfg *DBConfig, tableInfoGetter translator.TableInfoGetter) (Syncer, error) {
-	binlogger, err := binlogfile.OpenBinlogger(cfg.BinlogFileDir, binlogfile.SegmentSizeBytes)
+func NewPBSyncer(dir string, retentionDays int, tableInfoGetter translator.TableInfoGetter) (*pbSyncer, error) {
+	binlogger, err := binlogfile.OpenBinlogger(dir, binlogfile.SegmentSizeBytes)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -49,9 +49,9 @@ func NewPBSyncer(cfg *DBConfig, tableInfoGetter translator.TableInfoGetter) (Syn
 		cancel:     cancel,
 	}
 
-	if cfg.BinlogFileRetentionTime > 0 {
+	if retentionDays > 0 {
 		// TODO: Add support for human readable format input of times like "7d", "12h"
-		retentionTime := time.Duration(cfg.BinlogFileRetentionTime) * 24 * time.Hour
+		retentionTime := time.Duration(retentionDays) * 24 * time.Hour
 		ticker := time.NewTicker(time.Hour)
 		go func() {
 			defer ticker.Stop()

--- a/drainer/sync/pb.go
+++ b/drainer/sync/pb.go
@@ -35,7 +35,7 @@ type pbSyncer struct {
 }
 
 // NewPBSyncer sync binlog to files
-func NewPBSyncer(cfg *DBConfig, tableInfoGetter translator.TableInfoGetter) (*pbSyncer, error) {
+func NewPBSyncer(cfg *DBConfig, tableInfoGetter translator.TableInfoGetter) (Syncer, error) {
 	binlogger, err := binlogfile.OpenBinlogger(cfg.BinlogFileDir, binlogfile.SegmentSizeBytes)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/drainer/sync/syncer_test.go
+++ b/drainer/sync/syncer_test.go
@@ -42,15 +42,16 @@ type syncerSuite struct {
 func (s *syncerSuite) SetUpTest(c *check.C) {
 	var infoGetter translator.TableInfoGetter
 	cfg := &DBConfig{
-		Host:         "localhost",
-		User:         "root",
-		Password:     "",
-		Port:         3306,
-		KafkaVersion: "0.8.2.0",
+		Host:          "localhost",
+		User:          "root",
+		Password:      "",
+		Port:          3306,
+		KafkaVersion:  "0.8.2.0",
+		BinlogFileDir: c.MkDir(),
 	}
 
 	// create pb syncer
-	pb, err := NewPBSyncer(c.MkDir(), infoGetter)
+	pb, err := NewPBSyncer(cfg, infoGetter)
 	c.Assert(err, check.IsNil)
 
 	s.syncers = append(s.syncers, pb)

--- a/drainer/sync/syncer_test.go
+++ b/drainer/sync/syncer_test.go
@@ -51,7 +51,7 @@ func (s *syncerSuite) SetUpTest(c *check.C) {
 	}
 
 	// create pb syncer
-	pb, err := NewPBSyncer(cfg, infoGetter)
+	pb, err := NewPBSyncer(cfg.BinlogFileDir, cfg.BinlogFileRetentionTime, infoGetter)
 	c.Assert(err, check.IsNil)
 
 	s.syncers = append(s.syncers, pb)

--- a/drainer/sync/util.go
+++ b/drainer/sync/util.go
@@ -24,11 +24,12 @@ type DBConfig struct {
 	User     string `toml:"user" json:"user"`
 	Password string `toml:"password" json:"password"`
 	// if EncryptedPassword is not empty, Password will be ignore.
-	EncryptedPassword string           `toml:"encrypted_password" json:"encrypted_password"`
-	SyncMode          int              `toml:"sync-mode" json:"sync-mode"`
-	Port              int              `toml:"port" json:"port"`
-	Checkpoint        CheckpointConfig `toml:"checkpoint" json:"checkpoint"`
-	BinlogFileDir     string           `toml:"dir" json:"dir"`
+	EncryptedPassword       string           `toml:"encrypted_password" json:"encrypted_password"`
+	SyncMode                int              `toml:"sync-mode" json:"sync-mode"`
+	Port                    int              `toml:"port" json:"port"`
+	Checkpoint              CheckpointConfig `toml:"checkpoint" json:"checkpoint"`
+	BinlogFileDir           string           `toml:"dir" json:"dir"`
+	BinlogFileRetentionTime int              `toml:"retention-time" json:"retention-time"`
 
 	ZKAddrs          string `toml:"zookeeper-addrs" json:"zookeeper-addrs"`
 	KafkaAddrs       string `toml:"kafka-addrs" json:"kafka-addrs"`

--- a/drainer/syncer.go
+++ b/drainer/syncer.go
@@ -102,7 +102,7 @@ func createDSyncer(cfg *SyncerConfig, schema *Schema, info *loopbacksync.LoopBac
 			return nil, errors.Annotate(err, "fail to create kafka dsyncer")
 		}
 	case "file":
-		dsyncer, err = dsync.NewPBSyncer(cfg.To, schema)
+		dsyncer, err = dsync.NewPBSyncer(cfg.To.BinlogFileDir, cfg.To.BinlogFileRetentionTime, schema)
 		if err != nil {
 			return nil, errors.Annotate(err, "fail to create pb dsyncer")
 		}

--- a/drainer/syncer.go
+++ b/drainer/syncer.go
@@ -102,7 +102,7 @@ func createDSyncer(cfg *SyncerConfig, schema *Schema, info *loopbacksync.LoopBac
 			return nil, errors.Annotate(err, "fail to create kafka dsyncer")
 		}
 	case "file":
-		dsyncer, err = dsync.NewPBSyncer(cfg.To.BinlogFileDir, schema)
+		dsyncer, err = dsync.NewPBSyncer(cfg.To, schema)
 		if err != nil {
 			return nil, errors.Annotate(err, "fail to create pb dsyncer")
 		}

--- a/pkg/binlogfile/binlogger.go
+++ b/pkg/binlogfile/binlogger.go
@@ -372,7 +372,7 @@ func (b *binlogger) GCByPos(pos binlog.Pos) {
 		if curSuffix < pos.Suffix {
 			fileName := path.Join(b.dir, name)
 			if err := os.Remove(fileName); err != nil {
-				log.Error("remove old binlog file err", zap.Error(err), zap.String("file name", fileName))
+				log.Error("fail to remove old binlog file ", zap.Error(err), zap.String("file name", fileName))
 				continue
 			}
 			log.Info("GC binlog file", zap.String("file name", fileName))

--- a/pkg/binlogfile/binlogger.go
+++ b/pkg/binlogfile/binlogger.go
@@ -403,7 +403,7 @@ func (b *binlogger) GCByTime(retentionTime time.Duration) {
 
 		if time.Since(fi.ModTime()) > retentionTime {
 			if err := os.Remove(fileName); err != nil {
-				log.Error("remove old binlog file err", zap.Error(err), zap.String("file name", fileName))
+				log.Error("fail to remove old binlog file", zap.Error(err), zap.String("file name", fileName))
 				continue
 			}
 			log.Info("GC binlog file", zap.String("file name", fileName))


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Enable drainer to purge old incremental backup data on disk.

### What is changed and how it works?


1. Add a `retention-time` config to specify how long binlog files should be kept in drainer. Backward-compatibility is maintained by treating non-positive values of `retention-time` as *no GC*.
1. Currently `retention-time` is of type `int`, which is consistent with the pump `GC` configuration. We may later introduce `p8s` style time format for both `GC` and `retention-time` and use days as the default unit to maintain backward-compatibility.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change

      The `GC` method is changed to two new methods `GCByTIme` and `GCByPos`.

Related changes

- Need to cherry-pick to the release branch
- Need to update the documentation
- Need to be included in the release note