### PR TITLE
Fix current DML&DDL corner case for bidirectional replication 

### DIFF
--- a/drainer/sync/mysql.go
+++ b/drainer/sync/mysql.go
@@ -123,7 +123,7 @@ func (m *MysqlSyncer) SetSafeMode(mode bool) {
 
 // Sync implements Syncer interface
 func (m *MysqlSyncer) Sync(item *Item) error {
-	txn, err := translator.TiBinlogToTxn(m.tableInfoGetter, item.Schema, item.Table, item.Binlog, item.PrewriteValue)
+	txn, err := translator.TiBinlogToTxn(m.tableInfoGetter, item.Schema, item.Table, item.Binlog, item.PrewriteValue, item.ShouldSkip)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/drainer/sync/syncer.go
+++ b/drainer/sync/syncer.go
@@ -27,6 +27,10 @@ type Item struct {
 
 	// the applied TS executed in downstream, only for tidb
 	AppliedTS int64
+	// should skip to replicate this item at downstream
+	// currently only used for signal the syncer to learn that the downstream schema is changed
+	// when we don't replicate DDL.
+	ShouldSkip bool
 }
 
 // Syncer sync binlog item to downstream

--- a/drainer/translator/mysql.go
+++ b/drainer/translator/mysql.go
@@ -102,14 +102,15 @@ func genMysqlDelete(schema string, table *model.TableInfo, row []byte) (names []
 }
 
 // TiBinlogToTxn translate the format to loader.Txn
-func TiBinlogToTxn(infoGetter TableInfoGetter, schema string, table string, tiBinlog *tipb.Binlog, pv *tipb.PrewriteValue) (txn *loader.Txn, err error) {
+func TiBinlogToTxn(infoGetter TableInfoGetter, schema string, table string, tiBinlog *tipb.Binlog, pv *tipb.PrewriteValue, shouldSkip bool) (txn *loader.Txn, err error) {
 	txn = new(loader.Txn)
 
 	if tiBinlog.DdlJobId > 0 {
 		txn.DDL = &loader.DDL{
-			Database: schema,
-			Table:    table,
-			SQL:      string(tiBinlog.GetDdlQuery()),
+			Database:   schema,
+			Table:      table,
+			SQL:        string(tiBinlog.GetDdlQuery()),
+			ShouldSkip: shouldSkip,
 		}
 	} else {
 		for _, mut := range pv.GetMutations() {

--- a/drainer/translator/mysql_test.go
+++ b/drainer/translator/mysql_test.go
@@ -37,20 +37,21 @@ func (t *testMysqlSuite) TestGenColumnList(c *check.C) {
 func (t *testMysqlSuite) TestDDL(c *check.C) {
 	t.SetDDL()
 
-	txn, err := TiBinlogToTxn(t, t.Schema, t.Table, t.TiBinlog, nil)
+	txn, err := TiBinlogToTxn(t, t.Schema, t.Table, t.TiBinlog, nil, true)
 	c.Assert(err, check.IsNil)
 
 	c.Assert(txn, check.DeepEquals, &loader.Txn{
 		DDL: &loader.DDL{
-			Database: t.Schema,
-			Table:    t.Table,
-			SQL:      string(t.TiBinlog.GetDdlQuery()),
+			Database:   t.Schema,
+			Table:      t.Table,
+			SQL:        string(t.TiBinlog.GetDdlQuery()),
+			ShouldSkip: true,
 		},
 	})
 }
 
 func (t *testMysqlSuite) testDML(c *check.C, tp loader.DMLType) {
-	txn, err := TiBinlogToTxn(t, t.Schema, t.Table, t.TiBinlog, t.PV)
+	txn, err := TiBinlogToTxn(t, t.Schema, t.Table, t.TiBinlog, t.PV, false)
 	c.Assert(err, check.IsNil)
 
 	c.Assert(txn.DMLs, check.HasLen, 1)

--- a/pkg/loader/executor_test.go
+++ b/pkg/loader/executor_test.go
@@ -114,12 +114,12 @@ func (s *singleExecSuite) TestInsert(c *C) {
 			columns: []string{"name", "age"},
 		},
 	}
-	insertSQL := "INSERT INTO `unicorn`.`users`(`name`,`age`) VALUES(?,?)"
-	replaceSQL := "REPLACE INTO `unicorn`.`users`(`name`,`age`) VALUES(?,?)"
+	insertSQL := "INSERT INTO `unicorn`.`users`(`age`,`name`) VALUES(?,?)"
+	replaceSQL := "REPLACE INTO `unicorn`.`users`(`age`,`name`) VALUES(?,?)"
 
 	s.dbMock.ExpectBegin()
 	s.dbMock.ExpectExec(regexp.QuoteMeta(insertSQL)).
-		WithArgs("tester", 2019).WillReturnResult(sqlmock.NewResult(1, 1))
+		WithArgs(2019, "tester").WillReturnResult(sqlmock.NewResult(1, 1))
 	s.dbMock.ExpectCommit()
 
 	e := newExecutor(s.db)
@@ -131,7 +131,7 @@ func (s *singleExecSuite) TestInsert(c *C) {
 
 	s.dbMock.ExpectBegin()
 	s.dbMock.ExpectExec(regexp.QuoteMeta(replaceSQL)).
-		WithArgs("tester", 2019).WillReturnResult(sqlmock.NewResult(1, 1))
+		WithArgs(2019, "tester").WillReturnResult(sqlmock.NewResult(1, 1))
 	s.dbMock.ExpectCommit()
 
 	e = newExecutor(s.db)
@@ -180,7 +180,7 @@ func (s *singleExecSuite) TestSafeUpdate(c *C) {
 	s.dbMock.ExpectExec(delSQL).
 		WithArgs("tester").WillReturnResult(sqlmock.NewResult(1, 1))
 	s.dbMock.ExpectExec(replaceSQL).
-		WithArgs("tester", 2019).WillReturnError(errors.New("replace"))
+		WithArgs(2019, "tester").WillReturnError(errors.New("replace"))
 
 	e = newExecutor(s.db)
 	err = e.singleExec([]*DML{&dml}, true)
@@ -193,7 +193,7 @@ func (s *singleExecSuite) TestSafeUpdate(c *C) {
 	s.dbMock.ExpectExec(delSQL).
 		WithArgs("tester").WillReturnResult(sqlmock.NewResult(1, 1))
 	s.dbMock.ExpectExec(replaceSQL).
-		WithArgs("tester", 2019).WillReturnResult(sqlmock.NewResult(1, 1))
+		WithArgs(2019, "tester").WillReturnResult(sqlmock.NewResult(1, 1))
 	s.dbMock.ExpectCommit()
 
 	e = newExecutor(s.db)

--- a/pkg/loader/load.go
+++ b/pkg/loader/load.go
@@ -187,6 +187,7 @@ func NewLoader(db *gosql.DB, opt ...Option) (Loader, error) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 
+	// TODO just save opts in loaderImpl instead of copy every field.
 	s := &loaderImpl{
 		db:               db,
 		workerCount:      opts.workerCount,

--- a/pkg/loader/load.go
+++ b/pkg/loader/load.go
@@ -617,7 +617,7 @@ func filterGeneratedCols(dml *DML) {
 }
 
 func (s *loaderImpl) getExecutor() *executor {
-	e := newExecutor(s.db, s.refreshTableInfo).withBatchSize(s.batchSize)
+	e := newExecutor(s.db).withBatchSize(s.batchSize).withRefreshTableInfo(s.refreshTableInfo)
 	e.setSyncInfo(s.loopBackSyncInfo)
 	if s.metrics != nil && s.metrics.QueryHistogramVec != nil {
 		e = e.withQueryHistogramVec(s.metrics.QueryHistogramVec)

--- a/pkg/loader/load.go
+++ b/pkg/loader/load.go
@@ -346,7 +346,7 @@ func isCreateDatabaseDDL(sql string) bool {
 
 func (s *loaderImpl) execDDL(ddl *DDL) error {
 	log.Debug("exec ddl", zap.Reflect("ddl", ddl))
-	if ddl.SQL == "" {
+	if ddl.ShouldSkip {
 		return nil
 	}
 
@@ -638,7 +638,7 @@ func newBatchManager(s *loaderImpl) *batchManager {
 		fExecDDL:             s.execDDL,
 		fDDLSuccessCallback: func(txn *Txn) {
 			s.markSuccess(txn)
-			if txn.DDL.SQL == "" {
+			if txn.DDL.ShouldSkip {
 				s.evitTableInfo(txn.DDL.Database, txn.DDL.Table)
 				return
 			}

--- a/pkg/loader/load_test.go
+++ b/pkg/loader/load_test.go
@@ -151,8 +151,9 @@ func (cs *LoadSuite) TestNewClose(c *check.C) {
 	db, _, err := sqlmock.New()
 	c.Assert(err, check.IsNil)
 
-	loader, err := NewLoader(db)
+	loader, err := NewLoader(db, SyncModeOption(SyncPartialColumn))
 	c.Assert(err, check.IsNil)
+	c.Assert(loader.(*loaderImpl).syncMode, check.Equals, SyncPartialColumn)
 
 	loader.Close()
 }

--- a/pkg/loader/model.go
+++ b/pkg/loader/model.go
@@ -140,8 +140,8 @@ func (dml *DML) updateKey() bool {
 }
 
 func (dml *DML) String() string {
-	return fmt.Sprintf("{db: %s, table: %s,tp: %v values: %v old_values: %v}",
-		dml.Database, dml.Table, dml.Tp, dml.Values, dml.OldValues)
+	return fmt.Sprintf("{db: %s, table: %s,tp: %v values: %d old_values: %d}",
+		dml.Database, dml.Table, dml.Tp, len(dml.Values), len(dml.OldValues))
 }
 
 func (dml *DML) oldPrimaryKeyValues() []interface{} {

--- a/pkg/loader/model.go
+++ b/pkg/loader/model.go
@@ -50,11 +50,13 @@ type DML struct {
 }
 
 // DDL holds the ddl info
-// A empty SQL will force loader to evict table info and return success directly.
 type DDL struct {
 	Database string
 	Table    string
 	SQL      string
+	// should skip to execute this DDL at downstream and just refresh the downstream table info.
+	// one case for this usage is for bidirectional replication and only execute DDL at one side.
+	ShouldSkip bool
 }
 
 // Txn holds transaction info, an DDL or DML sequences

--- a/pkg/loader/model.go
+++ b/pkg/loader/model.go
@@ -140,8 +140,8 @@ func (dml *DML) updateKey() bool {
 }
 
 func (dml *DML) String() string {
-	return fmt.Sprintf("{db: %s, table: %s,tp: %v values: %d old_values: %d}",
-		dml.Database, dml.Table, dml.Tp, len(dml.Values), len(dml.OldValues))
+	return fmt.Sprintf("{db: %s, table: %s,tp: %v values: %v old_values: %v}",
+		dml.Database, dml.Table, dml.Tp, dml.Values, dml.OldValues)
 }
 
 func (dml *DML) oldPrimaryKeyValues() []interface{} {

--- a/pkg/loader/model_test.go
+++ b/pkg/loader/model_test.go
@@ -62,6 +62,7 @@ func (d *dmlSuite) testWhere(c *check.C, tp DMLType) {
 
 	if tp == UpdateDMLType {
 		dml.OldValues = values
+		dml.Values = values
 	} else {
 		dml.Values = values
 	}
@@ -79,12 +80,13 @@ func (d *dmlSuite) testWhere(c *check.C, tp DMLType) {
 	dml = getDML(false, tp)
 	if tp == UpdateDMLType {
 		dml.OldValues = values
+		dml.Values = values
 	} else {
 		dml.Values = values
 	}
 
 	names, args = dml.whereSlice()
-	c.Assert(names, check.DeepEquals, []string{"id", "a1"})
+	c.Assert(names, check.DeepEquals, []string{"a1", "id"})
 	c.Assert(args, check.DeepEquals, []interface{}{1, 1})
 
 	builder.Reset()
@@ -184,10 +186,10 @@ func (s *SQLSuite) TestInsertSQL(c *check.C) {
 		},
 	}
 	sql, args := dml.sql()
-	c.Assert(sql, check.Equals, "INSERT INTO `test`.`hello`(`name`,`age`) VALUES(?,?)")
+	c.Assert(sql, check.Equals, "INSERT INTO `test`.`hello`(`age`,`name`) VALUES(?,?)")
 	c.Assert(args, check.HasLen, 2)
-	c.Assert(args[0], check.Equals, "pc")
-	c.Assert(args[1], check.Equals, 42)
+	c.Assert(args[0], check.Equals, 42)
+	c.Assert(args[1], check.Equals, "pc")
 }
 
 func (s *SQLSuite) TestDeleteSQL(c *check.C) {
@@ -197,6 +199,7 @@ func (s *SQLSuite) TestDeleteSQL(c *check.C) {
 		Table:    "hello",
 		Values: map[string]interface{}{
 			"name": "pc",
+			"age":  10,
 		},
 		info: &tableInfo{
 			columns: []string{"name", "age"},
@@ -205,9 +208,10 @@ func (s *SQLSuite) TestDeleteSQL(c *check.C) {
 	sql, args := dml.sql()
 	c.Assert(
 		sql, check.Equals,
-		"DELETE FROM `test`.`hello` WHERE `name` = ? AND `age` IS NULL LIMIT 1")
-	c.Assert(args, check.HasLen, 1)
-	c.Assert(args[0], check.Equals, "pc")
+		"DELETE FROM `test`.`hello` WHERE `age` = ? AND `name` = ? LIMIT 1")
+	c.Assert(args, check.HasLen, 2)
+	c.Assert(args[0], check.Equals, 10)
+	c.Assert(args[1], check.Equals, "pc")
 }
 
 func (s *SQLSuite) TestUpdateSQL(c *check.C) {

--- a/reparo/syncer/mysql_test.go
+++ b/reparo/syncer/mysql_test.go
@@ -51,17 +51,17 @@ func (s *testMysqlSuite) testMysqlSyncer(c *check.C, safemode bool) {
 	if safemode {
 		insertPattern = "REPLACE INTO"
 	}
-	mock.ExpectExec(insertPattern).WithArgs(1, "test", nil).WillReturnResult(sqlmock.NewResult(0, 1))
-	mock.ExpectExec("DELETE FROM").WithArgs(1, "test").WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(insertPattern).WithArgs(1, "test", "test").WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("DELETE FROM").WithArgs(1, "test", "test").WillReturnResult(sqlmock.NewResult(0, 1))
 	if safemode {
 		mock.ExpectExec("DELETE FROM").WithArgs().WillReturnResult(sqlmock.NewResult(0, 1))
-		mock.ExpectExec(insertPattern).WithArgs(nil, nil, "abc").WillReturnResult(sqlmock.NewResult(0, 1))
+		mock.ExpectExec(insertPattern).WithArgs(1, "test", "abc").WillReturnResult(sqlmock.NewResult(0, 1))
 	} else {
-		mock.ExpectExec("UPDATE").WithArgs("abc", "test").WillReturnResult(sqlmock.NewResult(0, 1))
+		mock.ExpectExec("UPDATE").WithArgs(1, "test", "abc", 1, "test", "test").WillReturnResult(sqlmock.NewResult(0, 1))
 	}
 	mock.ExpectCommit()
 
-	syncTest(c, Syncer(syncer))
+	syncTest(c, syncer)
 
 	err = syncer.Close()
 	c.Assert(err, check.IsNil)

--- a/reparo/syncer/print_test.go
+++ b/reparo/syncer/print_test.go
@@ -25,10 +25,14 @@ func (s *testPrintSuite) TestPrintSyncer(c *check.C) {
 			"schema: test; table: t1; type: Insert\n"+
 			"a(int): 1\n"+
 			"b(varchar): test\n"+
+			"c(varchar): test\n"+
 			"schema: test; table: t1; type: Delete\n"+
 			"a(int): 1\n"+
 			"b(varchar): test\n"+
+			"c(varchar): test\n"+
 			"schema: test; table: t1; type: Update\n"+
+			"a(int): 1 => 1\n"+
+			"b(varchar): test => test\n"+
 			"c(varchar): test => abc\n")
 
 	err = syncer.Close()

--- a/reparo/syncer/translate_test.go
+++ b/reparo/syncer/translate_test.go
@@ -165,20 +165,10 @@ func (s *testTranslateSuite) TestPBBinlogToTxn(c *check.C) {
 	}
 
 	for binlog, txn := range tests {
-		c.Log("test: ", txn)
 		getTxn, err := pbBinlogToTxn(binlog)
 		c.Assert(err, check.IsNil)
 		c.Assert(getTxn.DDL, check.DeepEquals, txn.DDL)
-
-		// for _, dml := range getTxn.DMLs {
-		// 	c.Logf("get dml: %+v", dml)
-		// }
-		// for _, dml := range txn.DMLs {
-		// 	c.Logf("expect dml: %+v", dml)
-		// }
-
-		c.Assert(getTxn.DMLs, check.DeepEquals, txn.DMLs, check.Commentf("get: %+v, expect: %+v", getTxn.DMLs, txn.DMLs))
-
+		c.Assert(getTxn.DMLs, check.DeepEquals, txn.DMLs)
 	}
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
In bidirectional replication
cluster A <-> cluster B
only do and replicate DDL in A

- in B will filter all DDL and will never refresh the table info in pkg/Loader
- we will not know the schema is changed while replicating data from B to A if a DDL is applied on A and not having replicated to B. A sample case:
    * drop a column `c81` on table `auto1` (apply on A)
    * apply some DML on B and replicate to cluster A will failed for we specified the column `c81` to insert cause we have not learned that the Shema is changed on A.
   
### What is changed and how it works?
- refresh table info even if we filter the ddl on B(make an empty query force loader to refresh now)
- try refresh table info if failed to exec the dml for some error (column mismatch now)
- always  use the values pass into Loader to construct the SQL(compared to the downstream table info we will specified a `NULL` value as the column value if we have not specified the value in `Values` pass into `Loader`) an example before:
   * A   auto(a int primary key, c int default 10)
   * B  auto(a int primary key)
   * while replicate data from B to A we will   `insert into auto(a,c) (11, NULL)` (set a NULL for the column c)
  * the column c will not consistent between A and B even later apply the add column on B


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)
use tool https://github.com/july2993/bitest


Related changes

 - Need to cherry-pick to the release branch
port back to master