### PR TITLE
drainer: add KafkaClientID in DBConfig

### DIFF
--- a/cmd/drainer/drainer.toml
+++ b/cmd/drainer/drainer.toml
@@ -149,6 +149,7 @@ port = 3306
 # kafka-addrs = "127.0.0.1:9092"
 # kafka-version = "0.8.2.0"
 # kafka-max-messages = 1024
+# kafka-client-id = "tidb_binlog"
 #
 # the topic name drainer will push msg, the default name is <cluster-id>_obinlog
 # be careful don't use the same name if run multi drainer instances

--- a/drainer/sync/kafka.go
+++ b/drainer/sync/kafka.go
@@ -77,6 +77,10 @@ func NewKafka(cfg *DBConfig, tableInfoGetter translator.TableInfoGetter) (*Kafka
 		return nil, errors.Trace(err)
 	}
 
+	if len(cfg.KafkaClientID) > 0 {
+		config.ClientID = cfg.KafkaClientID
+	}
+
 	config.Producer.Flush.MaxMessages = cfg.KafkaMaxMessages
 
 	// maintain minimal set that has been necessary so far

--- a/drainer/sync/util.go
+++ b/drainer/sync/util.go
@@ -40,6 +40,7 @@ type DBConfig struct {
 	KafkaAddrs       string `toml:"kafka-addrs" json:"kafka-addrs"`
 	KafkaVersion     string `toml:"kafka-version" json:"kafka-version"`
 	KafkaMaxMessages int    `toml:"kafka-max-messages" json:"kafka-max-messages"`
+	KafkaClientID    string `toml:"kafka-client-id" json:"kafka-client-id"`
 	TopicName        string `toml:"topic-name" json:"topic-name"`
 	// get it from pd
 	ClusterID uint64 `toml:"-" json:"-"`

--- a/tests/binlog/drainer.toml
+++ b/tests/binlog/drainer.toml
@@ -73,6 +73,7 @@ port = 3306
 # kafka-addrs = "127.0.0.1:9092"
 # kafka-version = "0.8.2.0"
 # kafka-max-messages = 1024
+# kafka-client-id = "tidb_binlog"
 #
 #
 # the topic name drainer will push msg, the default name is <cluster-id>_obinlog


### PR DESCRIPTION
Improve configuration for kafka syncer:
Add kafka-client-id in drainer.toml to config kafka client.id property.

### What problem does this PR solve? 
Drainer should support kafka clientID property https://github.com/pingcap/tidb-binlog/issues/900