### PR TITLE
fix initMarkTable failed case not quit normally and refactor

### DIFF
--- a/drainer/loopbacksync/loopbacksync.go
+++ b/drainer/loopbacksync/loopbacksync.go
@@ -13,6 +13,16 @@
 
 package loopbacksync
 
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"github.com/pingcap/errors"
+	"github.com/pingcap/log"
+	"go.uber.org/zap"
+)
+
 const (
 	//MarkTableName mark table name
 	MarkTableName = "retl._drainer_repl_mark"
@@ -25,6 +35,12 @@ const (
 	//ChannelInfo channel info
 	ChannelInfo = "channel_info"
 )
+
+// CreateMarkTableDDL is the DDL to create the mark table.
+var CreateMarkTableDDL string = fmt.Sprintf("CREATE TABLE If Not Exists %s (%s bigint not null,%s bigint not null DEFAULT 0, %s bigint DEFAULT 0, %s varchar(64) ,PRIMARY KEY (%s,%s));", MarkTableName, ID, ChannelID, Val, ChannelInfo, ID, ChannelID)
+
+// CreateMarkDBDDL is DDL to create the database of mark table.
+var CreateMarkDBDDL = "create database IF NOT EXISTS retl;"
 
 //LoopBackSync loopback sync info
 type LoopBackSync struct {
@@ -41,4 +57,66 @@ func NewLoopBackSyncInfo(ChannelID int64, LoopbackControl, SyncDDL bool) *LoopBa
 		SyncDDL:         SyncDDL,
 	}
 	return l
+}
+
+// CreateMarkTable create the db and table if need.
+func CreateMarkTable(db *sql.DB) error {
+	_, err := db.Exec(CreateMarkDBDDL)
+	if err != nil {
+		return errors.Annotate(err, "failed to create mark db")
+	}
+
+	_, err = db.Exec(CreateMarkTableDDL)
+	if err != nil {
+		return errors.Annotate(err, "failed to create mark table")
+	}
+
+	return nil
+}
+
+// InitMarkTableData init rowNum rows in the mark table for channelID.
+func InitMarkTableData(db *sql.DB, rowNum int, channelID int64) error {
+	var builder strings.Builder
+	holder := "(?,?,?,?)"
+	columns := fmt.Sprintf("(%s,%s,%s,%s) ", ID, ChannelID, Val, ChannelInfo)
+	builder.WriteString("REPLACE INTO " + MarkTableName + columns + " VALUES ")
+	for i := 0; i < rowNum; i++ {
+		if i > 0 {
+			builder.WriteByte(',')
+		}
+		builder.WriteString(holder)
+	}
+
+	var args []interface{}
+	for id := 0; id < rowNum; id++ {
+		args = append(args, id, channelID, 1 /* value */, "" /*channel_info*/)
+	}
+
+	query := builder.String()
+	if _, err := db.Exec(query, args...); err != nil {
+		log.Error("Exec fail", zap.String("query", query), zap.Reflect("args", args), zap.Error(err))
+		return errors.Trace(err)
+	}
+
+	return nil
+}
+
+// CleanMarkTableData clean up the data in mark table.
+func CleanMarkTableData(db *sql.DB, channelID int64) error {
+	sql := fmt.Sprintf("delete from %s where %s = ? ", MarkTableName, ChannelID)
+	_, err := db.Exec(sql, channelID)
+
+	if err != nil {
+		return errors.Annotate(err, "failed t clean mark table data")
+	}
+
+	return nil
+}
+
+// UpdateMark update the mark table.
+func UpdateMark(tx *sql.Tx, id int64, channelID int64) error {
+	sql := fmt.Sprintf("update %s set %s=%s+1 where %s=? and %s=? limit 1;", MarkTableName, Val, Val, ID, ChannelID)
+	_, err := tx.Exec(sql, id, channelID)
+
+	return errors.Trace(err)
 }

--- a/drainer/loopbacksync/loopbacksync_test.go
+++ b/drainer/loopbacksync/loopbacksync_test.go
@@ -13,15 +13,101 @@
 
 package loopbacksync
 
-import "testing"
+import (
+	"database/sql/driver"
+	"regexp"
+	"testing"
 
-//TestNewLoopBackSyncInfo test loopBackSyncInfo alloc
-func TestNewLoopBackSyncInfo(t *testing.T) {
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/pingcap/check"
+)
+
+func Test(t *testing.T) { check.TestingT(t) }
+
+type loopbackSuite struct{}
+
+var _ = check.Suite(&loopbackSuite{})
+
+func (s *loopbackSuite) TestNewLoopBackSyncInfo(c *check.C) {
 	var ChannelID int64 = 1
 	var LoopbackControl = true
 	var SyncDDL = false
 	l := NewLoopBackSyncInfo(ChannelID, LoopbackControl, SyncDDL)
-	if l == nil {
-		t.Error("alloc loopBackSyncInfo objec failed ")
+
+	c.Assert(l, check.DeepEquals, &LoopBackSync{
+		ChannelID:       ChannelID,
+		LoopbackControl: LoopbackControl,
+		SyncDDL:         SyncDDL,
+	})
+}
+
+func (s *loopbackSuite) TestCreateMarkTable(c *check.C) {
+	db, mk, err := sqlmock.New()
+	c.Assert(err, check.IsNil)
+
+	mk.ExpectExec(regexp.QuoteMeta(CreateMarkDBDDL)).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mk.ExpectExec(regexp.QuoteMeta(CreateMarkTableDDL)).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	err = CreateMarkTable(db)
+	c.Assert(err, check.IsNil)
+
+	err = mk.ExpectationsWereMet()
+	c.Assert(err, check.IsNil)
+}
+
+func (s *loopbackSuite) TestInitMarkTableData(c *check.C) {
+	db, mk, err := sqlmock.New()
+	c.Assert(err, check.IsNil)
+
+	var cid int64 = 1
+	rowNum := 16
+
+	var args []driver.Value
+	for i := 0; i < rowNum; i++ {
+		args = append(args, i, cid, 1 /*value*/, "" /*channel_info*/)
 	}
+	mk.ExpectExec("REPLACE INTO .*").WithArgs(args...).
+		WillReturnResult(sqlmock.NewResult(0, int64(rowNum)))
+
+	err = InitMarkTableData(db, rowNum, cid)
+	c.Assert(err, check.IsNil)
+
+	err = mk.ExpectationsWereMet()
+	c.Assert(err, check.IsNil)
+}
+
+func (s *loopbackSuite) TestCleanMarkTableData(c *check.C) {
+	db, mk, err := sqlmock.New()
+	c.Assert(err, check.IsNil)
+
+	var cid int64 = 1
+	mk.ExpectExec("delete from .*").WithArgs(cid).WillReturnResult(sqlmock.NewResult(0, 1))
+
+	err = CleanMarkTableData(db, cid)
+	c.Assert(err, check.IsNil)
+
+	err = mk.ExpectationsWereMet()
+	c.Assert(err, check.IsNil)
+}
+
+func (s *loopbackSuite) TestUpdateMark(c *check.C) {
+	db, mk, err := sqlmock.New()
+	c.Assert(err, check.IsNil)
+
+	mk.ExpectBegin()
+	tx, err := db.Begin()
+	c.Assert(err, check.IsNil)
+
+	var id int64 = 1
+	var cid int64 = 1
+	mk.ExpectExec("update .*").WithArgs(id, cid).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	err = UpdateMark(tx, id, cid)
+	c.Assert(err, check.IsNil)
+
+	err = mk.ExpectationsWereMet()
+	c.Assert(err, check.IsNil)
 }

--- a/pkg/loader/executor.go
+++ b/pkg/loader/executor.go
@@ -160,6 +160,7 @@ func (e *executor) cleanChannelInfo() error {
 	err2 := tx.commit()
 	return errors.Trace(err2)
 }
+
 func (e *executor) addIndex() int64 {
 	return atomic.AddInt64(&index, 1) % ((int64)(e.workerCount))
 }

--- a/pkg/loader/model.go
+++ b/pkg/loader/model.go
@@ -19,8 +19,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/pingcap/tidb-binlog/drainer/loopbacksync"
-
 	"github.com/pingcap/log"
 	"go.uber.org/zap"
 )
@@ -188,11 +186,6 @@ func (dml *DML) updateSQL() (sql string, args []interface{}) {
 	builder.WriteString(" LIMIT 1")
 	sql = builder.String()
 	return
-}
-
-func createMarkTableDDL() string {
-	sql := fmt.Sprintf("CREATE TABLE If Not Exists %s (%s bigint not null,%s bigint not null DEFAULT 0, %s bigint DEFAULT 0, %s varchar(64) ,PRIMARY KEY (%s,%s));", loopbacksync.MarkTableName, loopbacksync.ID, loopbacksync.ChannelID, loopbacksync.Val, loopbacksync.ChannelInfo, loopbacksync.ID, loopbacksync.ChannelID)
-	return sql
 }
 
 func (dml *DML) buildWhere(builder *strings.Builder) (args []interface{}) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
first commit: fix https://github.com/pingcap/tidb-binlog/issues/910
second commit: Refactor loopback sync

### What is changed and how it works?
put the main logic together in drainer/loopbacksync. this should look more clear, also simplify some func. and distinct the metrics of time need to update mark table from other replicate sql, this can help us know whether it's too slow to update mark table and that will be a bottle net.

a metrics example:
![Screen Shot 2020-02-26 at 2 51 39 PM](https://user-images.githubusercontent.com/1681864/75319423-99b85a80-58a7-11ea-8774-8984beece634.png)


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)
 sett https://github.com/july2993/bitest#bitest-dml test  bi-replicate clusters.

Code changes



Side effects



Related changes

