### PR TITLE
Add some reserved db for tools as ignore schema default.

### DIFF
--- a/cmd/drainer/drainer.toml
+++ b/cmd/drainer/drainer.toml
@@ -69,7 +69,7 @@ db-type = "mysql"
 ignore-txn-commit-ts = []
 
 # disable sync these schema
-ignore-schemas = "INFORMATION_SCHEMA,PERFORMANCE_SCHEMA,mysql"
+ignore-schemas = "INFORMATION_SCHEMA,PERFORMANCE_SCHEMA,mysql,tidb_binlog,sync_diff_inspector,dm_meta,tidb_loader,tidb_tool"
 
 ##replicate-do-db priority over replicate-do-table if have same db name
 ##and we support regex expression , start with '~' declare use regex expression.

--- a/drainer/config.go
+++ b/drainer/config.go
@@ -145,7 +145,7 @@ func NewConfig() *Config {
 	fs.BoolVar(&cfg.SyncerCfg.LoopbackControl, "loopback-control", false, "set mark or not ")
 	fs.BoolVar(&cfg.SyncerCfg.SyncDDL, "sync-ddl", true, "sync ddl or not")
 	fs.Int64Var(&cfg.SyncerCfg.ChannelID, "channel-id", 0, "sync channel id ")
-	fs.StringVar(&cfg.SyncerCfg.IgnoreSchemas, "ignore-schemas", "INFORMATION_SCHEMA,PERFORMANCE_SCHEMA,mysql", "disable sync those schemas")
+	fs.StringVar(&cfg.SyncerCfg.IgnoreSchemas, "ignore-schemas", "INFORMATION_SCHEMA,PERFORMANCE_SCHEMA,mysql,tidb_binlog,sync_diff_inspector,dm_meta,tidb_loader,tidb_tool", "disable sync those schemas")
 	fs.IntVar(&cfg.SyncerCfg.WorkerCount, "c", 16, "parallel worker count")
 	fs.StringVar(&cfg.SyncerCfg.DestDBType, "dest-db-type", "mysql", "target db type: mysql or tidb or file or kafka; see syncer section in conf/drainer.toml")
 	fs.StringVar(&cfg.SyncerCfg.Relay.LogDir, "relay-log-dir", "", "path to relay log of syncer")


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fix #905 

this also helps the bi-replication deploy, we don't need to add the `tidb_binlog` mannually.
and using `sync_diff` will break the replication.

### What is changed and how it works?
 Add some reserved db for tools as ignore schema default.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->



Code changes



Side effects


 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to be included in the release note