### PR TITLE
Make the column order deterministic

### DIFF
--- a/pkg/loader/model.go
+++ b/pkg/loader/model.go
@@ -170,10 +170,11 @@ func (dml *DML) updateSQL() (sql string, args []interface{}) {
 
 	fmt.Fprintf(builder, "UPDATE %s SET ", dml.TableName())
 
-	for name, arg := range dml.Values {
+	for _, name := range dml.columnNames() {
 		if len(args) > 0 {
 			builder.WriteByte(',')
 		}
+		arg := dml.Values[name]
 		fmt.Fprintf(builder, "%s = ?", quoteName(name))
 		args = append(args, arg)
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fix unstable test:
the column order in the update sql in the indeterministic order and the test code may fail sometimes.
```

[2020-03-02T10:02:48.916Z] [2020/03/02 18:02:48.034 +08:00] [ERROR] [executor.go:111] ["Exec fail, will rollback"] [query="UPDATE `test`.`t1` SET `b` = ?,`c` = ?,`a` = ? WHERE `a` = ? AND `b` = ? AND `c` = ? LIMIT 1"] [args="[\"test\",\"abc\",1,1,\"test\",\"test\"]"] [error="ExecQuery 'UPDATE `test`.`t1` SET `b` = ?,`c` = ?,`a` = ? WHERE `a` = ? AND `b` = ? AND `c` = ? LIMIT 1', arguments do not match: argument 0 expected [int64 - 1] does not match actual [string - test]"] [stack="github.com/pingcap/log.Error\n\t/go/pkg/mod/github.com/pingcap/log@v0.0.0-20191012051959-b742a5d432e9/global.go:42\ngithub.com/pingcap/tidb-binlog/pkg/loader.(*tx).autoRollbackExec\n\t/home/jenkins/agent/workspace/binlog_ghpr_unit_test/go/src/github.com/pingcap/tidb-binlog/pkg/loader/executor.go:111\ngithub.com/pingcap/tidb-binlog/pkg/loader.(*executor).singleExec\n\t/home/jenkins/agent/workspace/binlog_ghpr_unit_test/go/src/github.com/pingcap/tidb-binlog/pkg/loader/executor.go:375\ngithub.com/pingcap/tidb-binlog/pkg/loader.(*executor).singleExecRetry.func1\n\t/home/jenkins/agent/workspace/binlog_ghpr_unit_test/go/src/github.com/pingcap/tidb-binlog/pkg/loader/executor.go:308\ngithub.com/pingcap/tidb-binlog/pkg/util.RetryContext\n\t/home/jenkins/agent/workspace/binlog_ghpr_unit_test/go/src/github.com/pingcap/tidb-binlog/pkg/util/util.go:177\ngithub.com/pingcap/tidb-binlog/pkg/loader.(*executor).singleExecRetry\n\t/home/jenkins/agent/workspace/binlog_ghpr_unit_test/go/src/github.com/pingcap/tidb-binlog/pkg/loader/executor.go:307\ngithub.com/pingcap/tidb-binlog/pkg/loader.(*loaderImpl).execByHash.func1\n\t/home/jenkins/agent/workspace/binlog_ghpr_unit_test/go/src/github.com/pingcap/tidb-binlog/pkg/loader/load.go:428\ngolang.org/x/sync/errgroup.(*Group).Go.func1\n\t/go/pkg/mod/golang.org/x/sync@v0.0.0-20190423024810-112230192c58/errgroup/errgroup.go:57"]

[2020-03-02T10:02:48.917Z] [2020/03/02 18:02:48.035 +08:00] [ERROR] [executor.go:113] ["Auto rollback"] [error="call to Rollback transaction, was not expected, next expectation is: ExpectedExec => expecting Exec or ExecContext which:\n  - matches sql: 'UPDATE'\n  - is with arguments:\n    0 - 1\n    1 - test\n    2 - abc\n    3 - 1\n    4 - test\n    5 - test\n  - should return Result having:\n      LastInsertId: 0\n      RowsAffected: 1"] [stack="github.com/pingcap/log.Error\n\t/go/pkg/mod/github.com/pingcap/log@v0.0.0-20191012051959-b742a5d432e9/global.go:42\ngithub.com/pingcap/tidb-binlog/pkg/loader.(*tx).autoRollbackExec\n\t/home/jenkins/agent/workspace/binlog_ghpr_unit_test/go/src/github.com/pingcap/tidb-binlog/pkg/loader/executor.go:113\ngithub.com/pingcap/tidb-binlog/pkg/loader.(*executor).singleExec\n\t/home/jenkins/agent/workspace/binlog_ghpr_unit_test/go/src/github.com/pingcap/tidb-binlog/pkg/loader/executor.go:375\ngithub.com/pingcap/tidb-binlog/pkg/loader.(*executor).singleExecRetry.func1\n\t/home/jenkins/agent/workspace/binlog_ghpr_unit_test/go/src/github.com/pingcap/tidb-binlog/pkg/loader/executor.go:308\ngithub.com/pingcap/tidb-binlog/pkg/util.RetryContext\n\t/home/jenkins/agent/workspace/binlog_ghpr_unit_test/go/src/github.com/pingcap/tidb-binlog/pkg/util/util.go:177\ngithub.com/pingcap/tidb-binlog/pkg/loader.(*executor).singleExecRetry\n\t/home/jenkins/agent/workspace/binlog_ghpr_unit_test/go/src/github.com/pingcap/tidb-binlog/pkg/loader/executor.go:307\ngithub.com/pingcap/tidb-binlog/pkg/loader.(*loaderImpl).execByHash.func1\n\t/home/jenkins/agent/workspace/binlog_ghpr_unit_test/go/src/github.com/pingcap/tidb-binlog/pkg/loader/load.go:428\ngolang.org/x/sync/errgroup.(*Group).Go.func1\n\t/go/pkg/mod/golang.org/x/sync@v0.0.0-20190423024810-112230192c58/errgroup/errgroup.go:57"]

[2020-03-02T10:02:48.917Z] 

[2020-03-02T10:02:48.917Z] ----------------------------------------------------------------------

[2020-03-02T10:02:48.917Z] FAIL: mysql_test.go:17: testMysqlSuite.TestMysqlSyncer
```

### What is changed and how it works?
Make the column order deterministic

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test


Code changes



Side effects



Related changes

