### PR TITLE
Reload cert/key for every new conn

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -176,7 +176,6 @@ github.com/klauspost/compress v1.8.2 h1:Bx0qjetmNjdFXASH02NSAREKpiaDwkO1DRZ3dV2K
 github.com/klauspost/compress v1.8.2/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/cpuid v0.0.0-20170728055534-ae7887de9fa5 h1:2U0HzY8BJ8hVwDKIzp7y4voR9CX/nvcfymLmg2UiOio=
 github.com/klauspost/cpuid v0.0.0-20170728055534-ae7887de9fa5/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
-github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2 h1:DB17ag19krx9CFsz4o3enTrPXyIXCl+2iCXH/aMAp9s=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
@@ -381,7 +380,6 @@ golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
-golang.org/x/lint v0.0.0-20190930215403-16217165b5de h1:5hukYrvBGR8/eNkX5mdUezrA6JiaEZDtJb9Ei+1LlBs=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20200130185559-910be7a94367 h1:0IiAsCRByjO2QjX7ZPkw5oU9x+n1YqRL802rjC0c3Aw=
 golang.org/x/lint v0.0.0-20200130185559-910be7a94367/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
@@ -495,7 +493,6 @@ gopkg.in/yaml.v2 v2.2.3 h1:fvjTMHxHEw/mxHbtzPi3JCcKXQRAnQTBRo6YCJSVHKI=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
-honnef.co/go/tools v0.0.1-2019.2.3 h1:3JgtbtFHMiCmsznwGVTUWbgGov+pVqnlf1dEJTNAXeM=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3 h1:sXmLre5bzIR6ypkjXCDI3jHPssRhc8KD/Ome589sc3U=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=

--- a/pkg/security/security.go
+++ b/pkg/security/security.go
@@ -30,38 +30,52 @@ type Config struct {
 }
 
 // ToTLSConfig generates tls's config based on security section of the config.
-func (c *Config) ToTLSConfig() (*tls.Config, error) {
-	var tlsConfig *tls.Config
-	if len(c.SSLCA) != 0 {
-		var certificates = make([]tls.Certificate, 0)
-		if len(c.SSLCert) != 0 && len(c.SSLKey) != 0 {
+func (c *Config) ToTLSConfig() (tlsConfig *tls.Config, err error) {
+	if c.SSLCA == "" {
+		return
+	}
+
+	// Create a certificate pool from the certificate authority
+	certPool := x509.NewCertPool()
+	var ca []byte
+	ca, err = ioutil.ReadFile(c.SSLCA)
+	if err != nil {
+		return nil, errors.Errorf("could not read ca certificate: %s", err)
+	}
+
+	// Append the certificates from the CA
+	if !certPool.AppendCertsFromPEM(ca) {
+		return nil, errors.New("failed to append ca certs")
+	}
+
+	tlsConfig = &tls.Config{
+		RootCAs: certPool,
+	}
+
+	if len(c.SSLCert) != 0 && len(c.SSLKey) != 0 {
+		getCert := func() (*tls.Certificate, error) {
 			// Load the client certificates from disk
-			certificate, err := tls.LoadX509KeyPair(c.SSLCert, c.SSLKey)
+			cert, err := tls.LoadX509KeyPair(c.SSLCert, c.SSLKey)
 			if err != nil {
 				return nil, errors.Errorf("could not load client key pair: %s", err)
 			}
-			certificates = append(certificates, certificate)
+			return &cert, nil
 		}
 
-		// Create a certificate pool from the certificate authority
-		certPool := x509.NewCertPool()
-		ca, err := ioutil.ReadFile(c.SSLCA)
-		if err != nil {
-			return nil, errors.Errorf("could not read ca certificate: %s", err)
+		// pre-test cert's loading.
+		if _, err = getCert(); err != nil {
+			return
 		}
 
-		// Append the certificates from the CA
-		if !certPool.AppendCertsFromPEM(ca) {
-			return nil, errors.New("failed to append ca certs")
+		tlsConfig.GetClientCertificate = func(info *tls.CertificateRequestInfo) (certificate *tls.Certificate, err error) {
+			return getCert()
 		}
-
-		tlsConfig = &tls.Config{
-			Certificates: certificates,
-			RootCAs:      certPool,
+		tlsConfig.GetCertificate = func(info *tls.ClientHelloInfo) (certificate *tls.Certificate, err error) {
+			return getCert()
 		}
 	}
 
-	return tlsConfig, nil
+	return
 }
 
 // ToTiDBSecurityConfig generates tidb security config

--- a/pkg/security/security_test.go
+++ b/pkg/security/security_test.go
@@ -16,6 +16,7 @@ package security_test
 import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
+	"crypto/tls"
 	"io/ioutil"
 	"path/filepath"
 	"testing"
@@ -28,6 +29,46 @@ import (
 func TestClient(t *testing.T) {
 	TestingT(t)
 }
+
+// These certs are generated with:
+//
+// ```sh
+// # generate CA keys
+// openssl ecparam -name secp224r1 -genkey -noout -out ca.key
+// openssl req -x509 -new -nodes -key ca.key -days 999999 -out ca.crt -subj '/CN=localhost'
+//
+// # generate SSL keys
+// openssl ecparam -name secp224r1 -genkey -noout -out ssl.key
+// openssl req -new -key ssl.key -out ssl.csr -subj '/CN=localhost'
+// openssl x509 -req -in ssl.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out ssl.crt -days 999999
+// ```
+var testCa = `
+-----BEGIN CERTIFICATE-----
+MIIBBjCBtQIJAMLMVjQw2v1pMAoGCCqGSM49BAMCMBQxEjAQBgNVBAMMCWxvY2Fs
+aG9zdDAgFw0xOTA0MTcxODEyNDNaGA80NzU3MDMxMzE4MTI0M1owFDESMBAGA1UE
+AwwJbG9jYWxob3N0ME4wEAYHKoZIzj0CAQYFK4EEACEDOgAELwEHdmAcDtBYK9BH
+72q0dKbBBqIG7MZ5+qc+LTcz0OSdhuWkWUZkNN6MqKAPuP7nSo1+21Vb8YswCgYI
+KoZIzj0EAwIDQAAwPQIcbNvV16rOOzwotH65cJY6cCdf0h3IODjlWMf1qAIdAIBB
+Fma6g8iW5zdQPqDR9BGqugNPjtI/SMK6tfQ=
+-----END CERTIFICATE-----
+`
+var testCert = `
+-----BEGIN CERTIFICATE-----
+MIIBBTCBtAIJAP8wfS+6tJ3LMAkGByqGSM49BAEwFDESMBAGA1UEAwwJbG9jYWxo
+b3N0MCAXDTE5MDQxNzE4MTI0NFoYDzQ3NTcwMzEzMTgxMjQ0WjAUMRIwEAYDVQQD
+DAlsb2NhbGhvc3QwTjAQBgcqhkjOPQIBBgUrgQQAIQM6AAQJaXEnDhG2tPxD4wl1
+ycaZwqWm9JeQZFuUPgxekGwCMM22sKpYLvhdKroSBoKWwXIC6vZMWeIj/zAJBgcq
+hkjOPQQBA0EAMD4CHQC05dXi9zFLjYjQGhpJNx+Nc/5vC6E7j/MU+xsTAh0A6SUn
+g916djuFWv8djdDq+0NEFD9OzgPdSb8rZw==
+-----END CERTIFICATE-----
+`
+var testKey = `
+-----BEGIN EC PRIVATE KEY-----
+MGgCAQEEHCsPBVueZ3YX3yp1tn15YXj0cTKGCo1SO1EWO92gBwYFK4EEACGhPAM6
+AAQJaXEnDhG2tPxD4wl1ycaZwqWm9JeQZFuUPgxekGwCMM22sKpYLvhdKroSBoKW
+wXIC6vZMWeIj/w==
+-----END EC PRIVATE KEY-----
+`
 
 var _ = Suite(&testSecuritySuite{})
 
@@ -62,60 +103,31 @@ func (s *testSecuritySuite) TestToTLSConfig(c *C) {
 		SSLKey:  filepath.Join(temp, "ssl.key"),
 	}
 
-	// These certs are generated with:
-	//
-	// ```sh
-	// # generate CA keys
-	// openssl ecparam -name secp224r1 -genkey -noout -out ca.key
-	// openssl req -x509 -new -nodes -key ca.key -days 999999 -out ca.crt -subj '/CN=localhost'
-	//
-	// # generate SSL keys
-	// openssl ecparam -name secp224r1 -genkey -noout -out ssl.key
-	// openssl req -new -key ssl.key -out ssl.csr -subj '/CN=localhost'
-	// openssl x509 -req -in ssl.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out ssl.crt -days 999999
-	// ```
-
-	err := ioutil.WriteFile(dummyConfig.SSLCA, []byte(`
------BEGIN CERTIFICATE-----
-MIIBBjCBtQIJAMLMVjQw2v1pMAoGCCqGSM49BAMCMBQxEjAQBgNVBAMMCWxvY2Fs
-aG9zdDAgFw0xOTA0MTcxODEyNDNaGA80NzU3MDMxMzE4MTI0M1owFDESMBAGA1UE
-AwwJbG9jYWxob3N0ME4wEAYHKoZIzj0CAQYFK4EEACEDOgAELwEHdmAcDtBYK9BH
-72q0dKbBBqIG7MZ5+qc+LTcz0OSdhuWkWUZkNN6MqKAPuP7nSo1+21Vb8YswCgYI
-KoZIzj0EAwIDQAAwPQIcbNvV16rOOzwotH65cJY6cCdf0h3IODjlWMf1qAIdAIBB
-Fma6g8iW5zdQPqDR9BGqugNPjtI/SMK6tfQ=
------END CERTIFICATE-----
-	`), 0644)
+	err := ioutil.WriteFile(dummyConfig.SSLCA, []byte(testCa), 0644)
 	c.Assert(err, IsNil)
 
-	err = ioutil.WriteFile(dummyConfig.SSLCert, []byte(`
------BEGIN CERTIFICATE-----
-MIIBBTCBtAIJAP8wfS+6tJ3LMAkGByqGSM49BAEwFDESMBAGA1UEAwwJbG9jYWxo
-b3N0MCAXDTE5MDQxNzE4MTI0NFoYDzQ3NTcwMzEzMTgxMjQ0WjAUMRIwEAYDVQQD
-DAlsb2NhbGhvc3QwTjAQBgcqhkjOPQIBBgUrgQQAIQM6AAQJaXEnDhG2tPxD4wl1
-ycaZwqWm9JeQZFuUPgxekGwCMM22sKpYLvhdKroSBoKWwXIC6vZMWeIj/zAJBgcq
-hkjOPQQBA0EAMD4CHQC05dXi9zFLjYjQGhpJNx+Nc/5vC6E7j/MU+xsTAh0A6SUn
-g916djuFWv8djdDq+0NEFD9OzgPdSb8rZw==
------END CERTIFICATE-----
-	`), 0644)
+	err = ioutil.WriteFile(dummyConfig.SSLCert, []byte(testCert), 0644)
 	c.Assert(err, IsNil)
 
-	err = ioutil.WriteFile(dummyConfig.SSLKey, []byte(`
------BEGIN EC PRIVATE KEY-----
-MGgCAQEEHCsPBVueZ3YX3yp1tn15YXj0cTKGCo1SO1EWO92gBwYFK4EEACGhPAM6
-AAQJaXEnDhG2tPxD4wl1ycaZwqWm9JeQZFuUPgxekGwCMM22sKpYLvhdKroSBoKW
-wXIC6vZMWeIj/w==
------END EC PRIVATE KEY-----
-	`), 0600)
+	err = ioutil.WriteFile(dummyConfig.SSLKey, []byte(testKey), 0600)
 	c.Assert(err, IsNil)
 
 	config, err := dummyConfig.ToTLSConfig()
 	c.Assert(err, IsNil)
 	c.Assert(config, NotNil)
 	c.Assert(config.RootCAs.Subjects(), HasLen, 1)
-	c.Assert(config.Certificates, HasLen, 1)
-	sslKey, ok := config.Certificates[0].PrivateKey.(*ecdsa.PrivateKey)
-	c.Assert(ok, IsTrue)
-	c.Assert(sslKey.Curve, Equals, elliptic.P224())
+	for i := 0; i < 2; i++ {
+		var cert *tls.Certificate
+		if i == 0 {
+			cert, err = config.GetCertificate(nil)
+		} else {
+			cert, err = config.GetClientCertificate(nil)
+		}
+		c.Assert(err, IsNil)
+		sslKey, ok := cert.PrivateKey.(*ecdsa.PrivateKey)
+		c.Assert(ok, IsTrue)
+		c.Assert(sslKey.Curve, Equals, elliptic.P224())
+	}
 }
 
 func (s *testSecuritySuite) TestEmptyTLSConfig(c *C) {
@@ -148,7 +160,17 @@ func (s *testSecuritySuite) TestInvalidTLSConfig(c *C) {
 	err = ioutil.WriteFile(dummyConfig.SSLKey, []byte("invalid key"), 0600)
 	c.Assert(err, IsNil)
 
+	// make ca valid.
+	err = ioutil.WriteFile(dummyConfig.SSLCA, []byte(testCa), 0644)
+	c.Assert(err, IsNil)
 	_, err = dummyConfig.ToTLSConfig()
 	c.Assert(err, ErrorMatches, "could not load client key pair.*")
 
+	// make cert/key valid can check again.
+	err = ioutil.WriteFile(dummyConfig.SSLCert, []byte(testCert), 0644)
+	c.Assert(err, IsNil)
+	err = ioutil.WriteFile(dummyConfig.SSLKey, []byte(testKey), 0600)
+	c.Assert(err, IsNil)
+	_, err = dummyConfig.ToTLSConfig()
+	c.Assert(err, IsNil)
 }

--- a/pkg/security/security_test.go
+++ b/pkg/security/security_test.go
@@ -16,7 +16,6 @@ package security_test
 import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
-	"crypto/tls"
 	"io/ioutil"
 	"path/filepath"
 	"testing"
@@ -116,18 +115,19 @@ func (s *testSecuritySuite) TestToTLSConfig(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(config, NotNil)
 	c.Assert(config.RootCAs.Subjects(), HasLen, 1)
-	for i := 0; i < 2; i++ {
-		var cert *tls.Certificate
-		if i == 0 {
-			cert, err = config.GetCertificate(nil)
-		} else {
-			cert, err = config.GetClientCertificate(nil)
-		}
-		c.Assert(err, IsNil)
-		sslKey, ok := cert.PrivateKey.(*ecdsa.PrivateKey)
-		c.Assert(ok, IsTrue)
-		c.Assert(sslKey.Curve, Equals, elliptic.P224())
-	}
+
+	cert, err := config.GetCertificate(nil)
+	c.Assert(err, IsNil)
+	sslKey, ok := cert.PrivateKey.(*ecdsa.PrivateKey)
+	c.Assert(ok, IsTrue)
+	c.Assert(sslKey.Curve, Equals, elliptic.P224())
+
+	cert, err = config.GetClientCertificate(nil)
+	c.Assert(err, IsNil)
+	sslKey, ok = cert.PrivateKey.(*ecdsa.PrivateKey)
+	c.Assert(ok, IsTrue)
+	c.Assert(sslKey.Curve, Equals, elliptic.P224())
+
 }
 
 func (s *testSecuritySuite) TestEmptyTLSConfig(c *C) {


### PR DESCRIPTION
support reload cluster/downstream  TLS cert/key.
CA still can not be hot-reload now

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
preliminary of #891 
Reload cert/key of tls for new connection

for the pd client and kv client need to update dep version of pd/db, it will be handle by the client.
but this pr enough for reload certification used to connecting downstream db.
### What is changed and how it works?
- support reload cluster/downstream TLS cert/key, CA still can not be hot-reload now

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test


Code changes



Side effects



Related changes
 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to be included in the release note