### PR TITLE
skip wrongly write ActionUpdateTiFlashReplicaStatus job

### DIFF
--- a/drainer/schema.go
+++ b/drainer/schema.go
@@ -251,6 +251,11 @@ func (s *Schema) handlePreviousDDLJobIfNeed(version int64) error {
 			log.Info("Got DeleteOnly Job", zap.Stringer("job", job))
 			continue
 		}
+
+		if skipFlash(job) {
+			continue
+		}
+
 		_, _, _, err := s.handleDDL(job)
 		if err != nil {
 			return errors.Annotatef(err, "handle ddl job %v failed, the schema info: %s", s.jobs[i], s)

--- a/tests/filter/run.sh
+++ b/tests/filter/run.sh
@@ -25,6 +25,9 @@ run_sql "CREATE DATABASE do_name;"
 run_sql "CREATE DATABASE do_not_start1;"
 run_sql "CREATE DATABASE do_not_name;"
 
+# Test this DDL about tiflash will not abort the replication.
+run_sql "ALTER TABLE do_start1 SET TIFLASH REPLICA 3 LOCATION LABELS \"rack\", \"host\", \"abc\"";
+
 run_sql "CREATE TABLE test.do_start1(id int);"
 run_sql "CREATE TABLE test.do_name(id int);"
 run_sql "CREATE TABLE test.do_not_start1(id int);"

--- a/tests/filter/run.sh
+++ b/tests/filter/run.sh
@@ -25,14 +25,15 @@ run_sql "CREATE DATABASE do_name;"
 run_sql "CREATE DATABASE do_not_start1;"
 run_sql "CREATE DATABASE do_not_name;"
 
-# Test this DDL about tiflash will not abort the replication.
-run_sql "ALTER TABLE do_start1 SET TIFLASH REPLICA 3 LOCATION LABELS \"rack\", \"host\", \"abc\"";
 
 run_sql "CREATE TABLE test.do_start1(id int);"
 run_sql "CREATE TABLE test.do_name(id int);"
 run_sql "CREATE TABLE test.do_not_start1(id int);"
 run_sql "CREATE TABLE test.do_not_name(id int);"
 run_sql "CREATE TABLE test.do_ignore_name(id int);"
+
+# Test this DDL about tiflash will not abort the replication.
+run_sql "ALTER TABLE test.do_start1 SET TIFLASH REPLICA 3 LOCATION LABELS \"rack\", \"host\", \"abc\"";
 
 run_sql "INSERT INTO test.do_start1(id) VALUES (1);"
 run_sql "INSERT INTO test.do_name(id) VALUES (1);"


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
ref https://github.com/pingcap/tidb-binlog/pull/941


### What is changed and how it works?
skip wrongly write ActionUpdateTiFlashReplicaStatus job

after https://github.com/pingcap/tidb/pull/16049 there's no any ActionUpdateTiFlashReplicaStatus job that will be written.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test
 - Manual test (add detailed scripts or steps below)
create table t(id int);
ALTER TABLE t SET TIFLASH REPLICA 3 LOCATION LABELS "rack", "host", "abc"; // model.ActionSetTiFlashReplica
curl -X POST -d '{"id":45,"region_count":3,"flash_region_count":3}' https://127.0.0.1:10080/tiflash/replica // model.ActionUpdateTiFlashReplicaStatus
performance write on table t and check can still replicate. - No code

Code changes



Side effects



Related changes

