### PR TITLE
Refine log when enable tls

### DIFF
--- a/drainer/config.go
+++ b/drainer/config.go
@@ -413,8 +413,13 @@ func (cfg *Config) adjustConfig() error {
 	// adjust configuration
 	util.AdjustString(&cfg.ListenAddr, util.DefaultListenAddr(8249))
 	util.AdjustString(&cfg.AdvertiseAddr, cfg.ListenAddr)
-	cfg.ListenAddr = "http://" + cfg.ListenAddr       // add 'http:' scheme to facilitate parsing
-	cfg.AdvertiseAddr = "http://" + cfg.AdvertiseAddr // add 'http:' scheme to facilitate parsing
+	if cfg.tls != nil {
+		cfg.ListenAddr = "https://" + cfg.ListenAddr       // add 'https:' scheme to facilitate parsing
+		cfg.AdvertiseAddr = "https://" + cfg.AdvertiseAddr // add 'https:' scheme to facilitate parsing
+	} else {
+		cfg.ListenAddr = "http://" + cfg.ListenAddr       // add 'http:' scheme to facilitate parsing
+		cfg.AdvertiseAddr = "http://" + cfg.AdvertiseAddr // add 'http:' scheme to facilitate parsing
+	}
 	util.AdjustString(&cfg.DataDir, defaultDataDir)
 	util.AdjustInt(&cfg.DetectInterval, defaultDetectInterval)
 

--- a/pump/config.go
+++ b/pump/config.go
@@ -164,8 +164,13 @@ func (cfg *Config) Parse(arguments []string) error {
 
 	util.AdjustString(&cfg.ListenAddr, defaultListenAddr)
 	util.AdjustString(&cfg.AdvertiseAddr, cfg.ListenAddr)
-	cfg.ListenAddr = "http://" + cfg.ListenAddr       // add 'http:' scheme to facilitate parsing
-	cfg.AdvertiseAddr = "http://" + cfg.AdvertiseAddr // add 'http:' scheme to facilitate parsing
+	if cfg.tls != nil {
+		cfg.ListenAddr = "https://" + cfg.ListenAddr       // add 'https:' scheme to facilitate parsing
+		cfg.AdvertiseAddr = "https://" + cfg.AdvertiseAddr // add 'https:' scheme to facilitate parsing
+	} else {
+		cfg.ListenAddr = "http://" + cfg.ListenAddr       // add 'http:' scheme to facilitate parsing
+		cfg.AdvertiseAddr = "http://" + cfg.AdvertiseAddr // add 'http:' scheme to facilitate parsing
+	}
 	util.AdjustDuration(&cfg.EtcdDialTimeout, defaultEtcdDialTimeout)
 	util.AdjustString(&cfg.DataDir, defaultDataDir)
 	util.AdjustInt(&cfg.HeartbeatInterval, defaultHeartbeatInterval)

--- a/pump/server.go
+++ b/pump/server.go
@@ -73,16 +73,17 @@ type Server struct {
 	// node maintains the status of this pump and interact with etcd registry
 	node node.Node
 
-	tcpAddr    string
-	unixAddr   string
-	gs         *grpc.Server
-	ctx        context.Context
-	cancel     context.CancelFunc
-	wg         sync.WaitGroup
-	gcDuration time.Duration
-	triggerGC  chan time.Time
-	pullClose  chan struct{}
-	metrics    *util.MetricClient
+	tcpAddr       string
+	advertiseAddr string
+	unixAddr      string
+	gs            *grpc.Server
+	ctx           context.Context
+	cancel        context.CancelFunc
+	wg            sync.WaitGroup
+	gcDuration    time.Duration
+	triggerGC     chan time.Time
+	pullClose     chan struct{}
+	metrics       *util.MetricClient
 	// save the last time we write binlog to Storage
 	// if long time not write, we can write a fake binlog
 	lastWriteBinlogUnixNano int64
@@ -165,22 +166,23 @@ func NewServer(cfg *Config) (*Server, error) {
 	}
 
 	return &Server{
-		dataDir:    cfg.DataDir,
-		storage:    storage,
-		clusterID:  clusterID,
-		node:       n,
-		unixAddr:   cfg.Socket,
-		tcpAddr:    cfg.ListenAddr,
-		gs:         grpc.NewServer(grpcOpts...),
-		ctx:        ctx,
-		cancel:     cancel,
-		metrics:    metrics,
-		tiStore:    tiStore,
-		gcDuration: time.Duration(cfg.GC) * 24 * time.Hour,
-		pdCli:      pdCli,
-		cfg:        cfg,
-		triggerGC:  make(chan time.Time),
-		pullClose:  make(chan struct{}),
+		dataDir:       cfg.DataDir,
+		storage:       storage,
+		clusterID:     clusterID,
+		node:          n,
+		unixAddr:      cfg.Socket,
+		tcpAddr:       cfg.ListenAddr,
+		advertiseAddr: cfg.AdvertiseAddr,
+		gs:            grpc.NewServer(grpcOpts...),
+		ctx:           ctx,
+		cancel:        cancel,
+		metrics:       metrics,
+		tiStore:       tiStore,
+		gcDuration:    time.Duration(cfg.GC) * 24 * time.Hour,
+		pdCli:         pdCli,
+		cfg:           cfg,
+		triggerGC:     make(chan time.Time),
+		pullClose:     make(chan struct{}),
 	}, nil
 }
 
@@ -446,7 +448,7 @@ func (s *Server) Start() error {
 
 	s.startHeartbeat()
 
-	log.Info("start to server request", zap.String("addr", s.tcpAddr))
+	log.Info("start to server request", zap.String("addr", s.advertiseAddr))
 	err = m.Serve()
 	if strings.Contains(err.Error(), "use of closed network connection") {
 		err = nil


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix #936
When TLS is enabled, the logs of drainer contains http:

### What is changed and how it works?
log https instead of HTTP when enabling TLS.
Also, log advertise addr instead of listen addr

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->


 - Manual test (add detailed scripts or steps below)
start and check the log

Code changes



Side effects



Related changes

