### PR TITLE
Fix multi rows of same table split into multi table in the downstream format

### DIFF
--- a/drainer/translator/kafka.go
+++ b/drainer/translator/kafka.go
@@ -52,6 +52,7 @@ func TiBinlogToSlaveBinlog(
 		}
 		return slaveBinlog, nil
 	}
+
 	slaveBinlog := &obinlog.Binlog{
 		Type:     obinlog.BinlogType_DML,
 		CommitTs: tiBinlog.GetCommitTs(),
@@ -71,15 +72,18 @@ func TiBinlogToSlaveBinlog(
 		}
 
 		iter := newSequenceIterator(&mut)
+		table := genTable(schema, info)
+		slaveBinlog.DmlData.Tables = append(slaveBinlog.DmlData.Tables, table)
+
 		for {
-			table, err := nextRow(schema, info, isTblDroppingCol, iter)
+			tableMutation, err := nextRow(schema, info, isTblDroppingCol, iter)
 			if err != nil {
 				if errors.Cause(err) == io.EOF {
 					break
 				}
 				return nil, errors.Trace(err)
 			}
-			slaveBinlog.DmlData.Tables = append(slaveBinlog.DmlData.Tables, table)
+			table.Mutations = append(table.Mutations, tableMutation)
 		}
 	}
 	return slaveBinlog, nil
@@ -310,7 +314,7 @@ func createTableMutation(tp pb.MutationType, info *model.TableInfo, isTblDroppin
 	return mut, nil
 }
 
-func nextRow(schema string, info *model.TableInfo, isTblDroppingCol bool, iter *sequenceIterator) (*obinlog.Table, error) {
+func nextRow(schema string, info *model.TableInfo, isTblDroppingCol bool, iter *sequenceIterator) (*obinlog.TableMutation, error) {
 	mutType, row, err := iter.next()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -320,7 +324,6 @@ func nextRow(schema string, info *model.TableInfo, isTblDroppingCol bool, iter *
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	table := genTable(schema, info)
-	table.Mutations = append(table.Mutations, tableMutation)
-	return table, nil
+
+	return tableMutation, nil
 }

--- a/drainer/translator/testing.go
+++ b/drainer/translator/testing.go
@@ -148,6 +148,33 @@ func (g *BinlogGenerator) SetInsert(c *check.C) {
 	})
 }
 
+// SetAllDML one insert/update/delete/update in one txn.
+func (g *BinlogGenerator) SetAllDML(c *check.C) {
+	g.reset()
+	info := g.setEvent(c)
+
+	mut := ti.TableMutation{
+		TableId: info.ID,
+	}
+
+	// insert
+	row := testGenInsertBinlog(c, info, g.datums)
+	mut.InsertedRows = append(mut.InsertedRows, row)
+	mut.Sequence = append(mut.Sequence, ti.MutationType_Insert)
+
+	// update
+	row = testGenUpdateBinlog(c, info, g.oldDatums, g.datums)
+	mut.UpdatedRows = append(mut.UpdatedRows, row)
+	mut.Sequence = append(mut.Sequence, ti.MutationType_Update)
+
+	// delete
+	row = testGenDeleteBinlog(c, info, g.datums)
+	mut.DeletedRows = append(mut.DeletedRows, row)
+	mut.Sequence = append(mut.Sequence, ti.MutationType_DeleteRow)
+
+	g.PV.Mutations = append(g.PV.Mutations, mut)
+}
+
 // SetUpdate set up a update event binlog.
 func (g *BinlogGenerator) SetUpdate(c *check.C) {
 	g.reset()


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fix #932

### What is changed and how it works?
put the mutations of the same table in one `Table` struct

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test


Code changes



Side effects



Related changes
 - Need to cherry-pick to the release branch
 - Need to be included in the release note

### Release note
- Fix multi rows of the same table split into multi-table structure in the downstream format