### PR TITLE
.*: update max message size for grpc

### DIFF
--- a/drainer/config.go
+++ b/drainer/config.go
@@ -434,6 +434,8 @@ func (cfg *Config) adjustConfig() error {
 	}
 
 	if cfg.SyncerCfg.DestDBType == "kafka" {
+		maxMsgSize = maxKafkaMsgSize
+
 		// get KafkaAddrs from zookeeper if ZkAddrs is setted
 		if cfg.SyncerCfg.To.ZKAddrs != "" {
 			zkClient, err := newZKFromConnectionString(cfg.SyncerCfg.To.ZKAddrs, time.Second*5, time.Second*60)

--- a/drainer/config_test.go
+++ b/drainer/config_test.go
@@ -206,6 +206,7 @@ func (t *testDrainerSuite) TestAdjustConfig(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(cfg.SyncerCfg.DestDBType, Equals, "file")
 	c.Assert(cfg.SyncerCfg.WorkerCount, Equals, 1)
+	c.Assert(maxMsgSize, Equals, maxGrpcMsgSize)
 
 	cfg = NewConfig()
 	err = cfg.adjustConfig()
@@ -334,6 +335,7 @@ func (t *testKafkaSuite) TestConfigDestDBTypeKafka(c *C) {
 	c.Assert(cfg.SyncerCfg.To.KafkaAddrs, Matches, defaultKafkaAddrs)
 	c.Assert(cfg.SyncerCfg.To.KafkaVersion, Equals, defaultKafkaVersion)
 	c.Assert(cfg.SyncerCfg.To.KafkaMaxMessages, Equals, 1024)
+	c.Assert(maxMsgSize, Equals, maxKafkaMsgSize)
 
 	// With Zookeeper address
 	cfg = NewConfig()

--- a/drainer/util.go
+++ b/drainer/util.go
@@ -35,11 +35,11 @@ import (
 
 const (
 	maxKafkaMsgSize = 1024 * 1024 * 1024
+	maxGrpcMsgSize  = math.MaxInt32
 )
 
 var (
-	maxGrpcMsgSize = math.MaxInt32
-	maxMsgSize     = maxGrpcMsgSize
+	maxMsgSize = maxGrpcMsgSize
 )
 
 // taskGroup is a wrapper of `sync.WaitGroup`.

--- a/drainer/util.go
+++ b/drainer/util.go
@@ -15,6 +15,7 @@ package drainer
 
 import (
 	"fmt"
+	"math"
 	"net"
 	"net/url"
 	"os"
@@ -33,7 +34,12 @@ import (
 )
 
 const (
-	maxMsgSize = 1024 * 1024 * 1024
+	maxKafkaMsgSize = 1024 * 1024 * 1024
+)
+
+var (
+	maxGrpcMsgSize = math.MaxInt32
+	maxMsgSize     = maxGrpcMsgSize
 )
 
 // taskGroup is a wrapper of `sync.WaitGroup`.
@@ -125,9 +131,9 @@ func GenCheckPointCfg(cfg *Config, id uint64) (*checkpoint.Config, error) {
 }
 
 func initializeSaramaGlobalConfig() {
-	sarama.MaxResponseSize = int32(maxMsgSize)
+	sarama.MaxResponseSize = int32(maxKafkaMsgSize)
 	// add 1 to avoid confused log: Producer.MaxMessageBytes must be smaller than MaxRequestSize; it will be ignored
-	sarama.MaxRequestSize = int32(maxMsgSize) + 1
+	sarama.MaxRequestSize = int32(maxKafkaMsgSize) + 1
 }
 
 func getDDLJob(tiStore kv.Storage, id int64) (*model.Job, error) {

--- a/pump/config.go
+++ b/pump/config.go
@@ -17,6 +17,7 @@ import (
 	"crypto/tls"
 	"flag"
 	"fmt"
+	"math"
 	"net"
 	"net/url"
 	"os"
@@ -35,7 +36,7 @@ const (
 	defaultEtcdDialTimeout   = 5 * time.Second
 	defaultEtcdURLs          = "http://127.0.0.1:2379"
 	defaultListenAddr        = "127.0.0.1:8250"
-	defautMaxKafkaSize       = 1024 * 1024 * 1024
+	defautMaxMsgSize         = math.MaxInt32 // max grpc message size
 	defaultHeartbeatInterval = 2
 	defaultGC                = 7
 	defaultDataDir           = "data.pump"
@@ -110,7 +111,7 @@ func NewConfig() *Config {
 
 	// global config
 	fs.BoolVar(&GlobalConfig.enableDebug, "enable-debug", false, "enable print debug log")
-	fs.IntVar(&GlobalConfig.maxMsgSize, "max-message-size", defautMaxKafkaSize, "max msg size producer produce into kafka")
+	fs.IntVar(&GlobalConfig.maxMsgSize, "max-message-size", defautMaxMsgSize, "max message size tidb produce into pump")
 	fs.Int64Var(new(int64), "binlog-file-size", 0, "DEPRECATED")
 	fs.BoolVar(new(bool), "enable-binlog-slice", false, "DEPRECATED")
 	fs.IntVar(new(int), "binlog-slice-size", 0, "DEPRECATED")

--- a/pump/server.go
+++ b/pump/server.go
@@ -102,7 +102,7 @@ func init() {
 	// it must be set before any real grpc operation.
 	grpc.EnableTracing = false
 	GlobalConfig = &globalConfig{
-		maxMsgSize: defautMaxKafkaSize,
+		maxMsgSize: defautMaxMsgSize,
 	}
 }
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

tidb support big transaction, and the binlog's size may bigger than 1G, so need to update the grpc's max message size.

### What is changed and how it works?

update the max message size to `math.Int32`(2G)

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Related changes

 - Need to cherry-pick to the release branch