### PR TITLE
Fix not quote db name in file data ddl

### DIFF
--- a/drainer/translator/pb.go
+++ b/drainer/translator/pb.go
@@ -16,6 +16,7 @@ package translator
 import (
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	"github.com/golang/protobuf/proto"
@@ -48,7 +49,7 @@ func TiBinlogToPbBinlog(infoGetter TableInfoGetter, schema string, table string,
 		if isCreateDatabase {
 			sql += ";"
 		} else {
-			sql = fmt.Sprintf("use %s; %s;", schema, sql)
+			sql = fmt.Sprintf("use %s; %s;", quoteName(schema), sql)
 		}
 
 		pbBinlog.Tp = pb.BinlogType_DDL
@@ -302,4 +303,12 @@ func packEvent(schemaName, tableName string, tp pb.EventType, rowData [][]byte) 
 	}
 
 	return event
+}
+
+func escapeName(name string) string {
+	return strings.Replace(name, "`", "``", -1)
+}
+
+func quoteName(name string) string {
+	return "`" + escapeName(name) + "`"
 }

--- a/drainer/translator/pb_test.go
+++ b/drainer/translator/pb_test.go
@@ -36,7 +36,7 @@ func (t *testPbSuite) TestDDL(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	c.Log("get ddl: ", string(pbBinog.GetDdlQuery()))
-	expected := fmt.Sprintf("use %s; %s;", t.Schema, string(t.TiBinlog.GetDdlQuery()))
+	expected := fmt.Sprintf("use `%s`; %s;", t.Schema, string(t.TiBinlog.GetDdlQuery()))
 	c.Assert(pbBinog, check.DeepEquals, &pb.Binlog{
 		Tp:       pb.BinlogType_DDL,
 		CommitTs: t.TiBinlog.GetCommitTs(),

--- a/tests/reparo/config.toml
+++ b/tests/reparo/config.toml
@@ -10,5 +10,5 @@ batch = 10
 host = "127.0.0.1"
 user = "root"
 password = ""
-name = "reparo_test"
+name = "reparo-test"
 port = 4000

--- a/tests/reparo/run.sh
+++ b/tests/reparo/run.sh
@@ -14,7 +14,9 @@ run_drainer "$args" &
 
 GO111MODULE=on go build -o out
 
-run_sql "CREATE DATABASE IF NOT EXISTS \`reparo_test\`"
+sleep 5
+
+run_sql "CREATE DATABASE IF NOT EXISTS \`reparo-test\`"
 
 ./out -config ./config.toml > ${OUT_DIR-/tmp}/$TEST_NAME.out 2>&1
 
@@ -27,6 +29,6 @@ sleep 15
 check_data ./sync_diff_inspector.toml 
 
 # clean up
-run_sql "DROP DATABASE IF EXISTS \`reparo_test\`"
+run_sql "DROP DATABASE IF EXISTS \`reparo-test\`"
 
 killall drainer

--- a/tests/reparo/sync_diff_inspector.toml
+++ b/tests/reparo/sync_diff_inspector.toml
@@ -22,7 +22,7 @@ tidb-instance-id = "source-1"
 use-checksum=true
 
 [[check-tables]]
-schema = "reparo_test"
+schema = "reparo-test"
 tables = ["~.*"]
 
 [target-db]


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fix #955
db name is not quoted when we format the DDL, so when it contains some reserved characters，we will fail to parse the DDL.

### What is changed and how it works?
quote the db name when formatting the DDL.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test


Code changes



Side effects

Related changes

 - Need to cherry-pick to the release branch
 - Need to be included in the release note

### Release note
- Fix reparo fails to parse DDL when the database name contains the reserved characters.