### PR TITLE
Fix unknown type for mediumint

### DIFF
--- a/drainer/translator/kafka.go
+++ b/drainer/translator/kafka.go
@@ -229,7 +229,8 @@ func DatumToColumn(colInfo *model.ColumnInfo, datum types.Datum) (col *obinlog.C
 		col.StringValue = proto.String(str)
 
 	// numeric type
-	case "int", "bigint", "smallint", "tinyint":
+	// https://dev.mysql.com/doc/refman/8.0/en/integer-types.html
+	case "int", "bigint", "smallint", "tinyint", "mediumint":
 		str := fmt.Sprintf("%v", datum.GetValue())
 		if mysql.HasUnsignedFlag(colInfo.Flag) {
 			val, err := strconv.ParseUint(str, 10, 64)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix unknown type for mediumint
![396b28843d4192463271d1217bb16b56c962b9bf](https://user-images.githubusercontent.com/1681864/81162525-e911ba00-8fbf-11ea-9e1c-1993f8c87fa0.png)

### What is changed and how it works?
Handle `mediumint` type and write value as IntValue or UintValue instead of reaching the default case:
https://github.com/pingcap/tidb-binlog/blob/dcc904712318c1a2d2a567ee99a7bfeb742809ca/drainer/translator/kafka.go#L275

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->


 - Manual test (add detailed scripts or steps below)
insert a `mediumint` type data and check data.

Code changes



Side effects

Related changes
 - Need to cherry-pick to the release branch
 - Need to be included in the release note
### Release note
- Fix unknown type of mediumint when transforming to the format writer to Kafka.
