### PR TITLE
Specify status port of tidb in tests

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -71,9 +71,11 @@ cluster-ssl-key = "$OUT_DIR/cert/tidb.key"
 EOF
 
     port=${1-4000}
+    sport=${2-10080}
     echo "Starting TiDB at port: $port..."
     tidb-server \
         -P $port \
+        -status $sport \
         -config "$OUT_DIR/tidb-config.toml" \
         --store tikv \
         --path 127.0.0.1:2379 \
@@ -191,8 +193,8 @@ EOF
 
     sleep 5
 
-    start_upstream_tidb 4000
-    start_upstream_tidb 4001
+    start_upstream_tidb 4000 10080
+    start_upstream_tidb 4001 10081
 
     echo "Starting Downstream TiDB..."
     tidb-server \


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix fails to start up tidb in integration test

### What is changed and how it works?
Specify the status port of tidb

The old version will ignore the error if fails to listen on the status
    port, now it will reject to start.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->





Related changes
 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note

### Release note
- No Release note.