### PR TITLE
Enable allow_auto_random_explicit_insert if it's suppported

### DIFF
--- a/tests/dailytest/case.go
+++ b/tests/dailytest/case.go
@@ -28,7 +28,7 @@ import (
 
 // https://pingcap.com/docs-cn/dev/reference/sql/attributes/auto-random/
 var caseAutoRandom = []string{
-	"create table t (a int primary key auto_random, b varchar(255))",
+	"create table t (a bigint primary key auto_random, b varchar(255))",
 	"insert into t(b) values('11')",
 }
 

--- a/tests/kafka/kafka.go
+++ b/tests/kafka/kafka.go
@@ -58,7 +58,7 @@ func main() {
 		panic(err)
 	}
 
-	sinkDB, err := util.CreateSinkDB()
+	sinkDB, err := loader.CreateDB("root", "", "127.0.0.1", 3306, nil)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
pick #975
After https://github.com/pingcap/tidb/pull/17102 unable to replicate auto random table.

the pr add a session system var `allow_auto_random_explicit_insert`, default is false, must enable for insert value explicit, or can't
replicate. This is unfriendly for replication or restores tools. 

the test is disabled in #971 temporarily.

### What is changed and how it works?
Enable `allow_auto_random_explicit_insert` if ths sys var is supported. 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test
 - Manual test (add detailed scripts or steps below)
test with version support and not support this var.

### Release note
- Enable `allow_auto_random_explicit_insert` automatic.

