### PR TITLE
Add the commit ts in the exec ddl failed log

### DIFF
--- a/drainer/sync/syncer.go
+++ b/drainer/sync/syncer.go
@@ -14,6 +14,8 @@
 package sync
 
 import (
+	"fmt"
+
 	"github.com/pingcap/tidb-binlog/drainer/translator"
 	pb "github.com/pingcap/tipb/go-binlog"
 )
@@ -32,6 +34,10 @@ type Item struct {
 	// currently only used for signal the syncer to learn that the downstream schema is changed
 	// when we don't replicate DDL.
 	ShouldSkip bool
+}
+
+func (i *Item) String() string {
+	return fmt.Sprintf("commit ts: %v", i.Binlog.CommitTs)
 }
 
 // Syncer sync binlog item to downstream

--- a/drainer/syncer.go
+++ b/drainer/syncer.go
@@ -377,7 +377,7 @@ ForLoop:
 				lastAddComitTS = binlog.GetCommitTs()
 				err = s.dsyncer.Sync(&dsync.Item{Binlog: binlog, PrewriteValue: preWrite})
 				if err != nil {
-					err = errors.Annotatef(err, "add to dsyncer, commit ts %d", binlog.CommitTs)
+					err = errors.Annotatef(err, "failed to add item")
 					break ForLoop
 				}
 				executeHistogram.Observe(time.Since(beginTime).Seconds())

--- a/pkg/loader/load.go
+++ b/pkg/loader/load.go
@@ -747,7 +747,6 @@ func (b *batchManager) execAccumulatedDMLs() (err error) {
 func (b *batchManager) execDDL(txn *Txn) error {
 	if err := b.fExecDDL(txn.DDL); err != nil {
 		if !pkgsql.IgnoreDDLError(err) {
-			log.Error("exec failed", zap.String("sql", txn.DDL.SQL), zap.Error(err))
 			return errors.Trace(err)
 		}
 		log.Warn("ignore ddl", zap.Error(err), zap.String("ddl", txn.DDL.SQL))
@@ -769,6 +768,12 @@ func (b *batchManager) put(txn *Txn) error {
 			return errors.Trace(err)
 		}
 		if err := b.execDDL(txn); err != nil {
+			meta := zap.Skip()
+			if s, ok := txn.Metadata.(fmt.Stringer); txn.Metadata != nil && ok {
+				meta = zap.Stringer("metadata", s)
+			}
+
+			log.Error("exec failed", zap.String("sql", txn.DDL.SQL), meta, zap.Error(err))
 			return errors.Trace(err)
 		}
 		return nil

--- a/tests/filter/run.sh
+++ b/tests/filter/run.sh
@@ -33,7 +33,9 @@ run_sql "CREATE TABLE test.do_not_name(id int);"
 run_sql "CREATE TABLE test.do_ignore_name(id int);"
 
 # Test this DDL about tiflash will not abort the replication.
-run_sql "ALTER TABLE test.do_start1 SET TIFLASH REPLICA 3 LOCATION LABELS \"rack\", \"host\", \"abc\"";
+# ERROR 1105 (HY000) at line 1: the tiflash replica count: 3 should be less than the total tiflash server count: 0
+# need to setup tiflash now
+# run_sql "ALTER TABLE test.do_start1 SET TIFLASH REPLICA 3 LOCATION LABELS \"rack\", \"host\", \"abc\"";
 
 run_sql "INSERT INTO test.do_start1(id) VALUES (1);"
 run_sql "INSERT INTO test.do_name(id) VALUES (1);"


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Add the commit ts in the exec ddl failed log

### What is changed and how it works?
Add the commit ts in the exec ddl failed log

before:
```
[2020/07/30 10:55:44.726 +08:00] [INFO] [schema.go:452] ["Finished dropping column"] [job="ID:74647, Type:drop column, State:synced, SchemaState:none, SchemaID:1926, TableID:64516, RowCount:0, ArgLen:0, start time: 2020-06-18 13:31:13.836 +0800 CST, Err:<nil>, ErrCount:0, SnapshotVersion:0"]
[2020/07/30 10:55:44.729 +08:00] [INFO] [syncer.go:445] ["add ddl item to syncer, you can add this commit ts to `ignore-txn-commit-ts` to skip this ddl if needed"] [sql="recover table ads_rpt_app_new_remain_stat"] ["commit ts"=418180461697695746]                          [2020/07/30 10:55:49.901 +08:00] [ERROR] [load.go:687] ["exec failed"] [sql="recover table ads_rpt_app_new_remain_stat"] [error="Error 1105: Can't find dropped/truncated table 'ads_rpt_app_new_remain_stat' in GC safe point 2020-07-30 10:43:04 +0800 CST"] [errorVerbose="Error 1105: Can't find dropped/truncated table 'ads_rpt_app_new_remain_stat' in GC safe point 2020-07-30 10:43:04 +0800 CST
github.com/pingcap/errors.AddStack                                                                                                                                                                                                                                                  /home/jenkins/agent/workspace/release_tidb_3.1/go/pkg/mod/github.com/pingcap/errors@v0.11.5-0.20190809092503-95897b64e011/errors.go:174
github.com/pingcap/errors.Trace
    /home/jenkins/agent/workspace/release_tidb_3.1/go/pkg/mod/github.com/pingcap/errors@v0.11.5-0.20190809092503-95897b64e011/juju_adaptor.go:15
github.com/pingcap/tidb-binlog/pkg/loader.(*loaderImpl).execDDL
    /home/jenkins/agent/workspace/release_tidb_3.1/go/src/github.com/pingcap/tidb-binlog/pkg/loader/load.go:383
github.com/pingcap/tidb-binlog/pkg/loader.(*batchManager).execDDL
    /home/jenkins/agent/workspace/release_tidb_3.1/go/src/github.com/pingcap/tidb-binlog/pkg/loader/load.go:685
github.com/pingcap/tidb-binlog/pkg/loader.(*batchManager).put
    /home/jenkins/agent/workspace/release_tidb_3.1/go/src/github.com/pingcap/tidb-binlog/pkg/loader/load.go:708
github.com/pingcap/tidb-binlog/pkg/loader.(*loaderImpl).Run
    /home/jenkins/agent/workspace/release_tidb_3.1/go/src/github.com/pingcap/tidb-binlog/pkg/loader/load.go:561
github.com/pingcap/tidb-binlog/drainer/sync.(*MysqlSyncer).run
    /home/jenkins/agent/workspace/release_tidb_3.1/go/src/github.com/pingcap/tidb-binlog/drainer/sync/mysql.go:225
runtime.goexit
    /usr/local/go/src/runtime/asm_amd64.s:1357"]
[2020/07/30 10:55:49.901 +08:00] [INFO] [load.go:808] ["txnManager has been closed"]
[2020/07/30 10:55:49.901 +08:00] [INFO] [load.go:504] ["Run()... in Loader quit"]
[2020/07/30 10:55:49.901 +08:00] [INFO] [mysql.go:221] ["Successes chan quit"]                                                                                                                                                                                                  [2020/07/30 10:55:49.901 +08:00] [INFO] [load.go:752] ["run()... in txnManager quit"]
[2020/07/30 10:55:49.901 +08:00] [INFO] [syncer.go:252] ["handleSuccess quit"]
[2020/07/30 10:55:49.901 +08:00] [ERROR] [syncer.go:460] ["Failed to close syncer"] [error="Error 1105: Can't find dropped/truncated table 'ads_rpt_app_new_remain_stat' in GC safe point 2020-07-30 10:43:04 +0800 CST"] [errorVerbose="Error 1105: Can't find dropped/truncated table 'ads_rpt_app_new_remain_stat' in GC safe point 2020-07-30 10:43:04 +0800 CST
github.com/pingcap/errors.AddStack
    /home/jenkins/agent/workspace/release_tidb_3.1/go/pkg/mod/github.com/pingcap/errors@v0.11.5-0.20190809092503-95897b64e011/errors.go:174
github.com/pingcap/errors.Trace
    /home/jenkins/agent/workspace/release_tidb_3.1/go/pkg/mod/github.com/pingcap/errors@v0.11.5-0.20190809092503-95897b64e011/juju_adaptor.go:15
github.com/pingcap/tidb-binlog/pkg/loader.(*loaderImpl).execDDL
    /home/jenkins/agent/workspace/release_tidb_3.1/go/src/github.com/pingcap/tidb-binlog/pkg/loader/load.go:383
github.com/pingcap/tidb-binlog/pkg/loader.(*batchManager).execDDL
    /home/jenkins/agent/workspace/release_tidb_3.1/go/src/github.com/pingcap/tidb-binlog/pkg/loader/load.go:685
github.com/pingcap/tidb-binlog/pkg/loader.(*batchManager).put
    /home/jenkins/agent/workspace/release_tidb_3.1/go/src/github.com/pingcap/tidb-binlog/pkg/loader/load.go:708
github.com/pingcap/tidb-binlog/pkg/loader.(*loaderImpl).Run
    /home/jenkins/agent/workspace/release_tidb_3.1/go/src/github.com/pingcap/tidb-binlog/pkg/loader/load.go:561
github.com/pingcap/tidb-binlog/drainer/sync.(*MysqlSyncer).run
    /home/jenkins/agent/workspace/release_tidb_3.1/go/src/github.com/pingcap/tidb-binlog/drainer/sync/mysql.go:225
runtime.goexit
    /usr/local/go/src/runtime/asm_amd64.s:1357"]
[2020/07/30 10:55:49.902 +08:00] [ERROR] [server.go:289] ["syncer exited abnormal"] [error="add to dsyncer, commit ts 418180461789446149: Error 1105: Can't find dropped/truncated table 'ads_rpt_app_new_remain_stat' in GC safe point 2020-07-30 10:43:04 +0800 CST"] [errorVerbose="Error 1105: Can't find dropped/truncated table 'ads_rpt_app_new_remain_stat' in GC safe point 2020-07-30 10:43:04 +0800 CST
github.com/pingcap/errors.AddStack
    /home/jenkins/agent/workspace/release_tidb_3.1/go/pkg/mod/github.com/pingcap/errors@v0.11.5-0.20190809092503-95897b64e011/errors.go:174
github.com/pingcap/errors.Trace
    /home/jenkins/agent/workspace/release_tidb_3.1/go/pkg/mod/github.com/pingcap/errors@v0.11.5-0.20190809092503-95897b64e011/juju_adaptor.go:15
github.com/pingcap/tidb-binlog/pkg/loader.(*loaderImpl).execDDL
    /home/jenkins/agent/workspace/release_tidb_3.1/go/src/github.com/pingcap/tidb-binlog/pkg/loader/load.go:383
github.com/pingcap/tidb-binlog/pkg/loader.(*batchManager).execDDL
    /home/jenkins/agent/workspace/release_tidb_3.1/go/src/github.com/pingcap/tidb-binlog/pkg/loader/load.go:685                                                                                                                                                                 github.com/pingcap/tidb-binlog/pkg/loader.(*batchManager).put                                                                                                                                                                                                                       /home/jenkins/agent/workspace/release_tidb_3.1/go/src/github.com/pingcap/tidb-binlog/pkg/loader/load.go:708
github.com/pingcap/tidb-binlog/pkg/loader.(*loaderImpl).Run                                                                                                                                                                                                                         /home/jenkins/agent/workspace/release_tidb_3.1/go/src/github.com/pingcap/tidb-binlog/pkg/loader/load.go:561
github.com/pingcap/tidb-binlog/drainer/sync.(*MysqlSyncer).run
    /home/jenkins/agent/workspace/release_tidb_3.1/go/src/github.com/pingcap/tidb-binlog/drainer/sync/mysql.go:225
runtime.goexit
    /usr/local/go/src/runtime/asm_amd64.s:1357
add to dsyncer, commit ts 418180461789446149"]
[2020/07/30 10:55:49.902 +08:00] [INFO] [util.go:66] [Exit] [name=syncer]
[2020/07/30 10:55:49.902 +08:00] [INFO] [server.go:425] ["begin to close drainer server"]
[2020/07/30 10:55:49.904 +08:00] [INFO] [server.go:390] ["has already update status"] [id=gz_ns_m5_db_mysql_tikv_1_172.101:8249]
[2020/07/30 10:55:49.904 +08:00] [INFO] [server.go:429] ["commit status done"]
[2020/07/30 10:55:49.904 +08:00] [INFO] [pump.go:77] ["pump is closing"] [id=gz_ns_m5_db_mysql_tikv_2_172.104:8250]
[2020/07/30 10:55:49.904 +08:00] [INFO] [pump.go:77] ["pump is closing"] [id=GZ-NS-M5-DB-mysql-tikv-4-171.115:8250]
[2020/07/30 10:55:49.904 +08:00] [INFO] [util.go:66] [Exit] [name=heartbeat]
[2020/07/30 10:55:49.904 +08:00] [INFO] [collector.go:133] ["publishBinlogs quit"]
[2020/07/30 10:55:49.904 +08:00] [INFO] [util.go:66] [Exit] [name=collect]
[2020/07/30 10:55:49.904 +08:00] [INFO] [main.go:73] ["drainer exit"]
 
```
note the `error="add to dsyncer, commit ts 418180461789446149` may confuse user to use which commit ts to skip the failed ddl. This commit ts is the newly added item and returns the err meet before and save of the `Syncer` Internally.

after this pr:
```
[2020/08/03 18:21:47.546 +08:00] [INFO] [syncer.go:260] ["write save point"] [ts=418499816950595586]
[2020/08/03 18:21:50.508 +08:00] [INFO] [collector.go:287] ["get ddl job"] [job="ID:48, Type:recover table, State:synced, SchemaState:public, SchemaID:1, TableID:45, RowCount:0, ArgLen:0, start time: 2020-08-03 18:21:49.382 +0800 CST, Err:[meta:1146]table doesn't exist, ErrCount:1, SnapshotVersion:0"]                                                                                                                                                                                                                                                  [2020/08/03 18:21:50.508 +08:00] [INFO] [syncer.go:445] ["add ddl item to syncer, you can add this commit ts to `ignore-txn-commit-ts` to skip this ddl if needed"] [sql="recover table a"] ["commit ts"=418499817749610498]
[2020/08/03 18:21:55.530 +08:00] [ERROR] [load.go:714] ["exec failed"] [sql="recover table a"] [metadata="commit ts: 418499817749610498"] [error="Error 1064: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'recover table a' at line 1"] [errorVerbose="Error 1064: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'recover table a' at line 1\ngithub.com/pingcap/errors.AddStack\n\t/Users/huangjiahao/go/pkg/mod/github.com/pingcap/errors@v0.11.5-0.20190809092503-95897b64e011/errors.go:174\ngithub.com/pingcap/errors.Trace\n\t/Users/huangjiahao/go/pkg/mod/github.com/pingcap/errors@v0.11.5-0.20190809092503-95897b64e011/juju_adaptor.go:15\ngithub.com/pingcap/tidb-binlog/pkg/loader.(*loaderImpl).execDDL\n\t/Users/huangjiahao/go/src/github.com/pingcap/tidb-binlog/pkg/loader/load.go:383\ngithub.com/pingcap/tidb-binlog/pkg/loader.(*batchManager).execDDL\n\t/Users/huangjiahao/go/src/github.com/pingcap/tidb-binlog/pkg/loader/load.go:685\ngithub.com/pingcap/tidb-binlog/pkg/loader.(*batchManager).put\n\t/Users/huangjiahao/go/src/github.com/pingcap/tidb-binlog/pkg/loader/load.go:707\ngithub.com/pingcap/tidb-binlog/pkg/loader.(*loaderImpl).Run\n\t/Users/huangjiahao/go/src/github.com/pingcap/tidb-binlog/pkg/loader/load.go:561\ngithub.com/pingcap/tidb-binlog/drainer/sync.(*MysqlSyncer).run\n\t/Users/huangjiahao/go/src/github.com/pingcap/tidb-binlog/drainer/sync/mysql.go:225\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1373"]                        [2020/08/03 18:21:55.531 +08:00] [INFO] [load.go:814] ["txnManager has been closed"]
[2020/08/03 18:21:55.531 +08:00] [INFO] [load.go:504] ["Run()... in Loader quit"]
[2020/08/03 18:21:55.531 +08:00] [INFO] [mysql.go:221] ["Successes chan quit"]
[2020/08/03 18:21:55.531 +08:00] [INFO] [load.go:758] ["run()... in txnManager quit"]
[2020/08/03 18:21:55.531 +08:00] [INFO] [syncer.go:252] ["handleSuccess quit"]
[2020/08/03 18:21:55.531 +08:00] [ERROR] [syncer.go:460] ["Failed to close syncer"] [error="Error 1064: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'recover table a' at line 1"] [errorVerbose="Error 1064: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'recover table a' at line 1\ngithub.com/pingcap/errors.AddStack\n\t/Users/huangjiahao/go/pkg/mod/github.com/pingcap/errors@v0.11.5-0.20190809092503-95897b64e011/errors.go:174\ngithub.com/pingcap/errors.Trace\n\t/Users/huangjiahao/go/pkg/mod/github.com/pingcap/errors@v0.11.5-0.20190809092503-95897b64e011/juju_adaptor.go:15\ngithub.com/pingcap/tidb-binlog/pkg/loader.(*loaderImpl).execDDL\n\t/Users/huangjiahao/go/src/github.com/pingcap/tidb-binlog/pkg/loader/load.go:383\ngithub.com/pingcap/tidb-binlog/pkg/loader.(*batchManager).execDDL\n\t/Users/huangjiahao/go/src/github.com/pingcap/tidb-binlog/pkg/loader/load.go:685\ngithub.com/pingcap/tidb-binlog/pkg/loader.(*batchManager).put\n\t/Users/huangjiahao/go/src/github.com/pingcap/tidb-binlog/pkg/loader/load.go:707\ngithub.com/pingcap/tidb-binlog/pkg/loader.(*loaderImpl).Run\n\t/Users/huangjiahao/go/src/github.com/pingcap/tidb-binlog/pkg/loader/load.go:561\ngithub.com/pingcap/tidb-binlog/drainer/sync.(*MysqlSyncer).run\n\t/Users/huangjiahao/go/src/github.com/pingcap/tidb-binlog/drainer/sync/mysql.go:225\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1373"]
[2020/08/03 18:21:55.531 +08:00] [ERROR] [server.go:289] ["syncer exited abnormal"] [error="Error 1064: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'recover table a' at line 1"] [errorVerbose="Error 1064: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'recover table a' at line 1\ngithub.com/pingcap/errors.AddStack\n\t/Users/huangjiahao/go/pkg/mod/github.com/pingcap/errors@v0.11.5-0.20190809092503-95897b64e011/errors.go:174\ngithub.com/pingcap/errors.Trace\n\t/Users/huangjiahao/go/pkg/mod/github.com/pingcap/errors@v0.11.5-0.20190809092503-95897b64e011/juju_adaptor.go:15\ngithub.com/pingcap/tidb-binlog/pkg/loader.(*loaderImpl).execDDL\n\t/Users/huangjiahao/go/src/github.com/pingcap/tidb-binlog/pkg/loader/load.go:383\ngithub.com/pingcap/tidb-binlog/pkg/loader.(*batchManager).execDDL\n\t/Users/huangjiahao/go/src/github.com/pingcap/tidb-binlog/pkg/loader/load.go:685\ngithub.com/pingcap/tidb-binlog/pkg/loader.(*batchManager).put\n\t/Users/huangjiahao/go/src/github.com/pingcap/tidb-binlog/pkg/loader/load.go:707\ngithub.com/pingcap/tidb-binlog/pkg/loader.(*loaderImpl).Run\n\t/Users/huangjiahao/go/src/github.com/pingcap/tidb-binlog/pkg/loader/load.go:561\ngithub.com/pingcap/tidb-binlog/drainer/sync.(*MysqlSyncer).run\n\t/Users/huangjiahao/go/src/github.com/pingcap/tidb-binlog/drainer/sync/mysql.go:225\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1373"]
[2020/08/03 18:21:55.531 +08:00] [INFO] [util.go:66] [Exit] [name=syncer]
[2020/08/03 18:21:55.531 +08:00] [INFO] [server.go:425] ["begin to close drainer server"]
[2020/08/03 18:21:55.532 +08:00] [INFO] [server.go:390] ["has already update status"] [id=drainer_0]
[2020/08/03 18:21:55.532 +08:00] [INFO] [server.go:429] ["commit status done"]
[2020/08/03 18:21:55.532 +08:00] [INFO] [util.go:66] [Exit] [name=heartbeat]
[2020/08/03 18:21:55.533 +08:00] [INFO] [pump.go:77] ["pump is closing"] [id=pump_0]
[2020/08/03 18:21:55.533 +08:00] [INFO] [collector.go:133] ["publishBinlogs quit"]
[2020/08/03 18:21:55.533 +08:00] [INFO] [util.go:66] [Exit] [name=collect]
[2020/08/03 18:21:55.533 +08:00] [INFO] [main.go:73] ["drainer exit"]
[2020/08/03 18:21:55.533 +08:00] [INFO] [server.go:444] ["drainer exit"]
```

### Check List <!--REMOVE the items that are not applicable-->

### Release note
- No release note