### PR TITLE
Add a tool to parse and print relay log content

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 ### Makefile for tidb-binlog
-.PHONY: build test check update clean pump drainer fmt reparo integration_test arbiter binlogctl
+.PHONY: build test check update clean pump drainer fmt reparo integration_test arbiter binlogctl relayprinter
 
 PROJECT=tidb-binlog
 
@@ -53,6 +53,9 @@ reparo:
 
 binlogctl:
 	$(GOBUILD) -ldflags '$(LDFLAGS)' -o bin/binlogctl cmd/binlogctl/main.go
+
+relayprinter:
+	$(GOBUILD) -ldflags '$(LDFLAGS)' -o bin/relayprinter cmd/relayprinter/main.go
 
 install:
 	go install ./...

--- a/cmd/relayprinter/main.go
+++ b/cmd/relayprinter/main.go
@@ -1,0 +1,55 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/pingcap/log"
+	"github.com/pingcap/tidb-binlog/pkg/version"
+	"github.com/pingcap/tidb-binlog/relayprinter"
+	"go.uber.org/zap"
+)
+
+func main() {
+	cfg := relayprinter.NewConfig()
+	if err := cfg.Parse(os.Args[1:]); err != nil {
+		log.Fatal("verify flags failed, see 'relayprinter --help'.", zap.Error(err))
+	}
+
+	version.PrintVersionInfo("relay-printer")
+
+	sc := make(chan os.Signal, 1)
+	signal.Notify(sc,
+		syscall.SIGHUP,
+		syscall.SIGINT,
+		syscall.SIGTERM,
+		syscall.SIGQUIT)
+
+	p := relayprinter.NewPrinter(cfg)
+
+	go func() {
+		sig := <-sc
+		log.Info("got signal to exit.", zap.Stringer("signal", sig))
+		p.Close()
+		os.Exit(0)
+	}()
+
+	if err := p.Process(); err != nil {
+		log.Error("relay-printer process failed", zap.Error(err))
+	}
+	p.Close()
+}

--- a/cmd/relayprinter/relayprinter.toml
+++ b/cmd/relayprinter/relayprinter.toml
@@ -1,0 +1,23 @@
+# directory to relay log files
+data-dir = "/dir/to/relay/log"
+
+# specific file to handle, empty for all files
+# file = "binlog-0000000000000067-20201111050014"
+
+# do-db priority over do-table if have same db name
+# and we support regular expression , start with '~' declare use regular expression.
+#
+# do-db = ["~^b.*","s1"]
+# [[do-table]]
+# db-name = "test"
+# tbl-name = "log"
+
+# [[do-table]]
+# db-name = "test"
+# tbl-name = "~^a.*"
+
+# ignore-db = ["~^c.*","s2"]
+# [[ignore-table]]
+# db-name = "test"
+# tbl-name = "~^a.*"
+

--- a/pkg/loader/executor.go
+++ b/pkg/loader/executor.go
@@ -201,7 +201,7 @@ func (e *executor) bulkReplace(inserts []*DML) error {
 
 	var builder strings.Builder
 
-	cols := "(" + buildColumnList(info.columns) + ")"
+	cols := "(" + BuildColumnList(info.columns) + ")"
 	builder.WriteString("REPLACE INTO " + inserts[0].TableName() + cols + " VALUES ")
 
 	holder := fmt.Sprintf("(%s)", holderString(len(info.columns)))

--- a/pkg/loader/load.go
+++ b/pkg/loader/load.go
@@ -400,7 +400,7 @@ func (s *loaderImpl) execDDL(ddl *DDL) error {
 		}
 
 		if len(ddl.Database) > 0 && !isCreateDatabaseDDL(ddl.SQL) {
-			_, err = tx.Exec(fmt.Sprintf("use %s;", quoteName(ddl.Database)))
+			_, err = tx.Exec(fmt.Sprintf("use %s;", QuoteName(ddl.Database)))
 			if err != nil {
 				if rbErr := tx.Rollback(); rbErr != nil {
 					log.Error("Rollback failed", zap.Error(rbErr))

--- a/pkg/loader/model.go
+++ b/pkg/loader/model.go
@@ -170,12 +170,12 @@ func (dml *DML) updateSQL() (sql string, args []interface{}) {
 
 	fmt.Fprintf(builder, "UPDATE %s SET ", dml.TableName())
 
-	for _, name := range dml.columnNames() {
+	for _, name := range dml.ColumnNames() {
 		if len(args) > 0 {
 			builder.WriteByte(',')
 		}
 		arg := dml.Values[name]
-		fmt.Fprintf(builder, "%s = ?", quoteName(name))
+		fmt.Fprintf(builder, "%s = ?", QuoteName(name))
 		args = append(args, arg)
 	}
 
@@ -196,9 +196,9 @@ func (dml *DML) buildWhere(builder *strings.Builder) (args []interface{}) {
 			builder.WriteString(" AND ")
 		}
 		if wargs[i] == nil {
-			builder.WriteString(quoteName(wnames[i]) + " IS NULL")
+			builder.WriteString(QuoteName(wnames[i]) + " IS NULL")
 		} else {
-			builder.WriteString(quoteName(wnames[i]) + " = ?")
+			builder.WriteString(QuoteName(wnames[i]) + " = ?")
 			args = append(args, wargs[i])
 		}
 	}
@@ -235,7 +235,7 @@ func (dml *DML) whereSlice() (colNames []string, args []interface{}) {
 	}
 
 	// Fallback to use all columns
-	names := dml.columnNames()
+	names := dml.ColumnNames()
 	return names, dml.whereValues(names)
 }
 
@@ -250,7 +250,7 @@ func (dml *DML) deleteSQL() (sql string, args []interface{}) {
 	return
 }
 
-func (dml *DML) columnNames() []string {
+func (dml *DML) ColumnNames() []string {
 	names := make([]string, 0, len(dml.Values))
 
 	for name := range dml.Values {
@@ -262,8 +262,8 @@ func (dml *DML) columnNames() []string {
 }
 
 func (dml *DML) replaceSQL() (sql string, args []interface{}) {
-	names := dml.columnNames()
-	sql = fmt.Sprintf("REPLACE INTO %s(%s) VALUES(%s)", dml.TableName(), buildColumnList(names), holderString(len(names)))
+	names := dml.ColumnNames()
+	sql = fmt.Sprintf("REPLACE INTO %s(%s) VALUES(%s)", dml.TableName(), BuildColumnList(names), holderString(len(names)))
 	for _, name := range names {
 		v := dml.Values[name]
 		args = append(args, v)

--- a/pkg/loader/util.go
+++ b/pkg/loader/util.go
@@ -173,7 +173,7 @@ func quoteSchema(schema string, table string) string {
 	return fmt.Sprintf("`%s`.`%s`", escapeName(schema), escapeName(table))
 }
 
-func quoteName(name string) string {
+func QuoteName(name string) string {
 	return "`" + escapeName(name) + "`"
 }
 
@@ -208,13 +208,13 @@ func splitDMLs(dmls []*DML, size int) (res [][]*DML) {
 	return
 }
 
-func buildColumnList(names []string) string {
+func BuildColumnList(names []string) string {
 	var b strings.Builder
 	for i, name := range names {
 		if i > 0 {
 			b.WriteString(",")
 		}
-		b.WriteString(quoteName(name))
+		b.WriteString(QuoteName(name))
 
 	}
 

--- a/relayprinter/config.go
+++ b/relayprinter/config.go
@@ -1,0 +1,128 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package relayprinter
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/pingcap/errors"
+	"github.com/pingcap/log"
+	"github.com/pingcap/tidb-binlog/pkg/filter"
+	"github.com/pingcap/tidb-binlog/pkg/util"
+	"github.com/pingcap/tidb-binlog/pkg/version"
+	"go.uber.org/zap"
+)
+
+// Config is the main configuration for the relay printer tool.
+type Config struct {
+	*flag.FlagSet `toml:"-" json:"-"`
+	Dir           string `toml:"data-dir" json:"data-dir"` // directory to relay log files
+	File          string `toml:"file" json:"file"`         // specific file to handle, empty for all files
+
+	DoTables []filter.TableName `toml:"do-table" json:"do-table"`
+	DoDBs    []string           `toml:"do-db" json:"do-db"`
+
+	IgnoreTables []filter.TableName `toml:"ignore-table" json:"ignore-table"`
+	IgnoreDBs    []string           `toml:"ignore-db" json:"ignore-db"`
+
+	configFile   string
+	printVersion bool
+}
+
+// NewConfig creates a Config instance.
+func NewConfig() *Config {
+	c := &Config{}
+	c.FlagSet = flag.NewFlagSet("relay-printer", flag.ContinueOnError)
+	fs := c.FlagSet
+	fs.Usage = func() {
+		fmt.Fprintln(os.Stderr, "Usage of relay-printer:")
+		fs.PrintDefaults()
+	}
+
+	fs.StringVar(&c.Dir, "data-dir", "", "directory to relay log files")
+	fs.StringVar(&c.File, "file", "", "specific file to handle, empty for all files")
+	fs.StringVar(&c.configFile, "config", "", "path to the configuration file")
+	fs.BoolVar(&c.printVersion, "V", false, "print relay-printer version info")
+
+	return c
+}
+
+func (c *Config) String() string {
+	cfgBytes, err := json.Marshal(c)
+	if err != nil {
+		log.Error("marshal config failed", zap.Error(err))
+	}
+
+	return string(cfgBytes)
+}
+
+func (c *Config) Parse(args []string) error {
+	// Parse first to get the config file
+	perr := c.FlagSet.Parse(args)
+	switch perr {
+	case nil:
+	case flag.ErrHelp:
+		os.Exit(0)
+	default:
+		os.Exit(2)
+	}
+
+	if c.printVersion {
+		fmt.Println(version.GetRawVersionInfo())
+		os.Exit(0)
+	}
+
+	if c.configFile != "" {
+		// Load config file if specified
+		if err := c.configFromFile(c.configFile); err != nil {
+			return errors.Trace(err)
+		}
+	}
+
+	// Parse again to replace with command line options
+	if err := c.FlagSet.Parse(args); err != nil {
+		return errors.Trace(err)
+	}
+	if len(c.FlagSet.Args()) > 0 {
+		return errors.Errorf("'%s' is not a valid flag", c.FlagSet.Arg(0))
+	}
+	c.adjustDoDBAndTable()
+
+	return errors.Trace(c.validate())
+}
+
+func (c *Config) configFromFile(path string) error {
+	return util.StrictDecodeFile(path, "relay-printer", c)
+}
+
+func (c *Config) adjustDoDBAndTable() {
+	for i := 0; i < len(c.DoTables); i++ {
+		c.DoTables[i].Table = strings.ToLower(c.DoTables[i].Table)
+		c.DoTables[i].Schema = strings.ToLower(c.DoTables[i].Schema)
+	}
+	for i := 0; i < len(c.DoDBs); i++ {
+		c.DoDBs[i] = strings.ToLower(c.DoDBs[i])
+	}
+}
+
+func (c *Config) validate() error {
+	if c.Dir == "" {
+		return errors.New("data-dir is empty")
+	}
+	return nil
+}

--- a/relayprinter/printer.go
+++ b/relayprinter/printer.go
@@ -1,0 +1,101 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package relayprinter
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/pingcap/errors"
+	"github.com/pingcap/log"
+	"github.com/pingcap/tidb-binlog/pkg/binlogfile"
+	"github.com/pingcap/tipb/go-binlog"
+	"go.uber.org/zap"
+)
+
+// Printer is used to print the content of relay log files.
+type Printer struct {
+	cfg    *Config
+	wg     sync.WaitGroup
+	cancel context.CancelFunc
+}
+
+// NewPrinter creates a new Printer instance.
+func NewPrinter(cfg *Config) *Printer {
+	return &Printer{
+		cfg: cfg,
+	}
+}
+
+// Process prints contents of relay log files.
+func (p *Printer) Process() error {
+	var suffix uint64
+	if p.cfg.File != "" {
+		var err error
+		suffix, _, err = binlogfile.ParseBinlogName(p.cfg.File)
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+
+	binlogger, err := binlogfile.OpenBinlogger(p.cfg.Dir, binlogfile.SegmentSizeBytes)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	p.cancel = cancel
+	bCh, eCh := binlogger.ReadAll(ctx)
+
+	p.wg.Add(1)
+	go func() {
+		defer p.wg.Done()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case blg := <-bCh:
+				if suffix != 0 {
+					if blg.Pos.Suffix < suffix {
+						// NOTE: `binlogger.ReadFrom` is not suitable to read all binlog items from the specified file,
+						// so we use `binlogger.ReadAll` to read all of them but do not process them.
+						continue
+					} else if blg.Pos.Suffix > suffix {
+						return // all contents in the specified file have been processed.
+					}
+				}
+				p.print(blg)
+			case err2 := <-eCh:
+				// abort process for any error.
+				log.Error("got an error while processing", zap.Error(err2))
+			}
+		}
+	}()
+
+	return nil
+}
+
+// Close closes the Printer instance.
+func (p *Printer) Close() {
+	if p.cancel != nil {
+		p.cancel()
+		p.cancel = nil
+	}
+	p.wg.Wait()
+}
+
+func (p *Printer) print(blg *binlog.Entity) {
+	fmt.Println(blg)
+}

--- a/relayprinter/printer.go
+++ b/relayprinter/printer.go
@@ -16,10 +16,13 @@ package relayprinter
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb-binlog/pkg/binlogfile"
+	"github.com/pingcap/tidb-binlog/pkg/loader"
+	obinlog "github.com/pingcap/tidb-tools/tidb-binlog/slave_binlog_proto/go-binlog"
 	"github.com/pingcap/tipb/go-binlog"
 )
 
@@ -63,7 +66,10 @@ func (p *Printer) Process() error {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case blg := <-bCh:
+		case blg, ok := <-bCh:
+			if !ok {
+				return nil
+			}
 			if suffix != 0 {
 				if blg.Pos.Suffix < suffix {
 					// NOTE: `binlogger.ReadFrom` is not suitable to read all binlog items from the specified file,
@@ -73,10 +79,12 @@ func (p *Printer) Process() error {
 					return nil // all contents in the specified file have been processed.
 				}
 			}
-			p.print(blg)
-		case err2 := <-eCh:
+			if err = p.print(blg); err != nil {
+				return err
+			}
+		case err = <-eCh:
 			// abort process for any error.
-			return err2
+			return err
 		}
 	}
 
@@ -92,6 +100,89 @@ func (p *Printer) Close() {
 	p.wg.Wait()
 }
 
-func (p *Printer) print(blg *binlog.Entity) {
-	fmt.Println(blg)
+// print prints the contents of binlog entity.
+func (p *Printer) print(blg *binlog.Entity) error {
+	oblg := new(obinlog.Binlog)
+	if err := oblg.Unmarshal(blg.Payload); err != nil {
+		return err
+	}
+
+	txn, err := loader.SecondaryBinlogToTxn(oblg)
+	if err != nil {
+		return err
+	}
+	txn.Metadata = oblg.CommitTs
+
+	// TODO: filter
+
+	fmt.Printf("# at %s\n", blg.Pos.String())
+	fmt.Printf("# commitTS:%d\n", oblg.CommitTs)
+
+	switch oblg.Type {
+	case obinlog.BinlogType_DDL:
+		fmt.Printf("# schema:%s table:%s\n", *oblg.DdlData.SchemaName, *oblg.DdlData.TableName)
+		fmt.Printf("%s\n\n", oblg.DdlData.DdlQuery)
+	case obinlog.BinlogType_DML:
+		for _, dml := range txn.DMLs {
+			fmt.Printf("# schema: %s table:%s\n", dml.Database, dml.Table)
+
+			cols := dml.ColumnNames()
+			values := make([]interface{}, 0, len(cols))
+			valuesStr := make([]string, 0, len(cols))
+			for _, col := range cols {
+				values = append(values, dml.Values[col])
+				valuesStr = append(valuesStr, fmt.Sprintf("%v", dml.Values[col]))
+			}
+
+			switch dml.Tp {
+			case loader.InsertDMLType:
+				fmt.Println("# INSERET")
+				fmt.Printf("# values: %v\n", dml.Values)
+				fmt.Printf("INSERT INTO %s\n  (%s)\nVALUES\n  (%v)\n", dml.TableName(), loader.BuildColumnList(cols), strings.Join(valuesStr, ","))
+			case loader.UpdateDMLType:
+				oldValues := make([]interface{}, 0, len(cols))
+				for _, col := range cols {
+					oldValues = append(oldValues, dml.OldValues[col])
+				}
+
+				fmt.Println("# UPDATE")
+				fmt.Printf("# old alues: %v\n", dml.OldValues)
+				fmt.Printf("# new values: %v\n", dml.Values)
+				fmt.Printf("UPDATE %s SET\n", dml.TableName())
+				for i, col := range cols {
+					fmt.Printf("  %s = %s", loader.QuoteName(col), valuesStr[i])
+					if i < len(cols)-1 {
+						fmt.Printf(",\n")
+					}
+				}
+				fmt.Printf("\nWHERE\n")
+				printWhere(cols, oldValues)
+			case loader.DeleteDMLType:
+				fmt.Println("# DELETE")
+				fmt.Printf("# values: %v\n", dml.Values)
+				fmt.Printf("DELETE FROM %s WHERE\n", dml.TableName())
+				printWhere(cols, values)
+			case loader.UnknownDMLType:
+				return errors.Errorf("invalid DML type %d", dml.Tp)
+			}
+			fmt.Println() // newline
+		}
+	}
+
+	return nil
+}
+
+func printWhere(cols []string, values []interface{}) {
+	for i, col := range cols {
+		if values[i] == nil {
+			fmt.Printf("  %s IS NULL", loader.QuoteName(col))
+		} else {
+			fmt.Printf("  %s = %v", loader.QuoteName(col), values[i])
+		}
+		if i < len(cols)-1 {
+			fmt.Printf(" AND \n")
+		} else {
+			fmt.Println()
+		}
+	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

add a tool (`relayprinter`) to parse and print relay log content

### What is changed and how it works?

- use `binlogfile.OpenBinlogger` to read binlog entities

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Code changes

 - Has exported function/method change
 - Has interface methods change

Side effects

### Release note
- No Release note.
