### PR TITLE
drainer: skip lock/unlock table DDL

### DIFF
--- a/drainer/schema.go
+++ b/drainer/schema.go
@@ -289,7 +289,8 @@ func (s *Schema) handlePreviousDDLJobIfNeed(version int64) error {
 			continue
 		}
 
-		if skipFlash(job) {
+		if skipUnsupportedDDLJob(job) {
+			log.Info("skip unsupported DDL job", zap.Stringer("job", job))
 			continue
 		}
 
@@ -306,12 +307,14 @@ func (s *Schema) handlePreviousDDLJobIfNeed(version int64) error {
 	return nil
 }
 
-func skipFlash(job *model.Job) bool {
+func skipUnsupportedDDLJob(job *model.Job) bool {
 	switch job.Type {
 	case model.ActionUpdateTiFlashReplicaStatus: // empty job.Query
 		return true
-		// case model.ActionSetTiFlashReplica:
-		// 	return true
+	// case model.ActionSetTiFlashReplica:
+	// 	return true
+	case model.ActionLockTable, model.ActionUnlockTable:
+		return true
 	}
 
 	return false

--- a/drainer/syncer.go
+++ b/drainer/syncer.go
@@ -385,7 +385,8 @@ ForLoop:
 		} else if jobID > 0 {
 			log.Debug("get ddl binlog job", zap.Stringer("job", b.job))
 
-			if skipFlash(b.job) {
+			if skipUnsupportedDDLJob(b.job) {
+				log.Info("skip unsupported DDL job", zap.Stringer("job", b.job))
 				continue
 			}
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

fix #1015

`lock/unlock table` in TiDB is an unfinished feature, skip these DDL jobs in drainer to avoid interruption.

### What is changed and how it works?

ignore `ActionLockTable` and `ActionUnlockTable` jobs.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
   1. set `enable-table-lock: true` for TiDB
   2. observe drainer can ignore `lock/unlock table` jobs and continue to run

Code changes

Side effects


### Release note
- No Release note.
