### PR TITLE
ddl: save checkpoint with schemaVersion

### DIFF
--- a/drainer/checkpoint/checkpoint.go
+++ b/drainer/checkpoint/checkpoint.go
@@ -31,10 +31,13 @@ type CheckPoint interface {
 	Load() error
 
 	// Save saves checkpoint information.
-	Save(commitTS int64, secondaryTS int64, consistent bool) error
+	Save(commitTS int64, secondaryTS int64, consistent bool, version int64) error
 
 	// TS gets checkpoint commit timestamp.
 	TS() int64
+
+	// SchemaVersion gets checkpoint current schemaversion.
+	SchemaVersion() int64
 
 	// IsConsistent return the Consistent status saved.
 	IsConsistent() bool

--- a/drainer/checkpoint/checkpoint.go
+++ b/drainer/checkpoint/checkpoint.go
@@ -64,7 +64,7 @@ func NewCheckPoint(cfg *Config) (CheckPoint, error) {
 		return nil, errors.Annotatef(err, "initialize %s type checkpoint with config %+v", cfg.CheckpointType, cfg)
 	}
 
-	log.Info("initialize checkpoint", zap.String("type", cfg.CheckpointType), zap.Int64("checkpoint", cp.TS()), zap.Reflect("cfg", cfg))
+	log.Info("initialize checkpoint", zap.String("type", cfg.CheckpointType), zap.Int64("checkpoint", cp.TS()), zap.Int64("version", cp.SchemaVersion()), zap.Reflect("cfg", cfg))
 
 	return cp, nil
 }

--- a/drainer/checkpoint/file.go
+++ b/drainer/checkpoint/file.go
@@ -93,7 +93,9 @@ func (sp *FileCheckPoint) Save(ts, secondaryTS int64, consistent bool, version i
 
 	sp.CommitTS = ts
 	sp.ConsistentSaved = consistent
-	sp.Version = version
+	if version > sp.Versoin {
+		sp.Version = version
+	}
 
 	var buf bytes.Buffer
 	e := toml.NewEncoder(&buf)

--- a/drainer/checkpoint/file.go
+++ b/drainer/checkpoint/file.go
@@ -93,7 +93,7 @@ func (sp *FileCheckPoint) Save(ts, secondaryTS int64, consistent bool, version i
 
 	sp.CommitTS = ts
 	sp.ConsistentSaved = consistent
-	if version > sp.Versoin {
+	if version > sp.Version {
 		sp.Version = version
 	}
 

--- a/drainer/checkpoint/file.go
+++ b/drainer/checkpoint/file.go
@@ -33,7 +33,7 @@ type FileCheckPoint struct {
 
 	ConsistentSaved bool  `toml:"consistent" json:"consistent"`
 	CommitTS        int64 `toml:"commitTS" json:"commitTS"`
-	Version 	    int64   `toml:"schema-version" json:"schema-version"`
+	Version         int64 `toml:"schema-version" json:"schema-version"`
 }
 
 // NewFile creates a new FileCheckpoint.

--- a/drainer/checkpoint/file.go
+++ b/drainer/checkpoint/file.go
@@ -33,6 +33,7 @@ type FileCheckPoint struct {
 
 	ConsistentSaved bool  `toml:"consistent" json:"consistent"`
 	CommitTS        int64 `toml:"commitTS" json:"commitTS"`
+	Version 	    int64   `toml:"schema-version" json:"schema-version"`
 }
 
 // NewFile creates a new FileCheckpoint.
@@ -82,7 +83,7 @@ func (sp *FileCheckPoint) Load() error {
 }
 
 // Save implements CheckPoint.Save interface
-func (sp *FileCheckPoint) Save(ts, secondaryTS int64, consistent bool) error {
+func (sp *FileCheckPoint) Save(ts, secondaryTS int64, consistent bool, version int64) error {
 	sp.Lock()
 	defer sp.Unlock()
 
@@ -92,6 +93,7 @@ func (sp *FileCheckPoint) Save(ts, secondaryTS int64, consistent bool) error {
 
 	sp.CommitTS = ts
 	sp.ConsistentSaved = consistent
+	sp.Version = version
 
 	var buf bytes.Buffer
 	e := toml.NewEncoder(&buf)
@@ -114,6 +116,14 @@ func (sp *FileCheckPoint) TS() int64 {
 	defer sp.RUnlock()
 
 	return sp.CommitTS
+}
+
+// SchemaVersion implements CheckPoint.SchemaVersion interface.
+func (sp *FileCheckPoint) SchemaVersion() int64 {
+	sp.RLock()
+	defer sp.RUnlock()
+
+	return sp.Version
 }
 
 // IsConsistent implements CheckPoint interface

--- a/drainer/checkpoint/file_test.go
+++ b/drainer/checkpoint/file_test.go
@@ -33,7 +33,7 @@ func (t *testCheckPointSuite) TestFile(c *C) {
 
 	testTs := int64(1)
 	// save ts
-	err = meta.Save(testTs, 0, false)
+	err = meta.Save(testTs, 0, false, 0)
 	c.Assert(err, IsNil)
 	// check ts
 	ts := meta.TS()
@@ -41,7 +41,7 @@ func (t *testCheckPointSuite) TestFile(c *C) {
 	c.Assert(meta.IsConsistent(), Equals, false)
 
 	// check consistent true case.
-	err = meta.Save(testTs, 0, true)
+	err = meta.Save(testTs, 0, true, 0)
 	c.Assert(err, IsNil)
 	ts = meta.TS()
 	c.Assert(ts, Equals, testTs)
@@ -70,6 +70,6 @@ func (t *testCheckPointSuite) TestFile(c *C) {
 	err = meta.Close()
 	c.Assert(err, IsNil)
 	c.Assert(errors.Cause(meta.Load()), Equals, ErrCheckPointClosed)
-	c.Assert(errors.Cause(meta.Save(0, 0, true)), Equals, ErrCheckPointClosed)
+	c.Assert(errors.Cause(meta.Save(0, 0, true, 0)), Equals, ErrCheckPointClosed)
 	c.Assert(errors.Cause(meta.Close()), Equals, ErrCheckPointClosed)
 }

--- a/drainer/checkpoint/mysql.go
+++ b/drainer/checkpoint/mysql.go
@@ -41,7 +41,7 @@ type MysqlCheckPoint struct {
 	ConsistentSaved bool             `toml:"consistent" json:"consistent"`
 	CommitTS        int64            `toml:"commitTS" json:"commitTS"`
 	TsMap           map[string]int64 `toml:"ts-map" json:"ts-map"`
-	Version         int64              `toml:"schema-version" json:"schema-version"`
+	Version         int64            `toml:"schema-version" json:"schema-version"`
 }
 
 var _ CheckPoint = &MysqlCheckPoint{}
@@ -173,6 +173,7 @@ func (sp *MysqlCheckPoint) TS() int64 {
 
 	return sp.CommitTS
 }
+
 // SchemaVersion implements CheckPoint.SchemaVersion interface.
 func (sp *MysqlCheckPoint) SchemaVersion() int64 {
 	sp.RLock()

--- a/drainer/checkpoint/mysql.go
+++ b/drainer/checkpoint/mysql.go
@@ -137,7 +137,7 @@ func (sp *MysqlCheckPoint) Save(ts, secondaryTS int64, consistent bool, version 
 
 	sp.CommitTS = ts
 	sp.ConsistentSaved = consistent
-	if version > sp.Versoin {
+	if version > sp.Version {
 		sp.Version = version
 	}
 

--- a/drainer/checkpoint/mysql.go
+++ b/drainer/checkpoint/mysql.go
@@ -137,7 +137,9 @@ func (sp *MysqlCheckPoint) Save(ts, secondaryTS int64, consistent bool, version 
 
 	sp.CommitTS = ts
 	sp.ConsistentSaved = consistent
-	sp.Version = version
+	if version > sp.Versoin {
+		sp.Version = version
+	}
 
 	if secondaryTS > 0 {
 		sp.TsMap["primary-ts"] = ts

--- a/drainer/checkpoint/mysql_test.go
+++ b/drainer/checkpoint/mysql_test.go
@@ -50,7 +50,7 @@ func (s *saveSuite) TestShouldSaveCheckpoint(c *C) {
 	c.Assert(err, IsNil)
 	mock.ExpectExec("replace into db.tbl.*").WillReturnResult(sqlmock.NewResult(0, 0))
 	cp := MysqlCheckPoint{db: db, schema: "db", table: "tbl"}
-	err = cp.Save(1111, 0, false)
+	err = cp.Save(1111, 0, false, 0)
 	c.Assert(err, IsNil)
 }
 
@@ -64,7 +64,7 @@ func (s *saveSuite) TestShouldUpdateTsMap(c *C) {
 		table:  "tbl",
 		TsMap:  make(map[string]int64),
 	}
-	err = cp.Save(65536, 3333, false)
+	err = cp.Save(65536, 3333, false, 0)
 	c.Assert(err, IsNil)
 	c.Assert(cp.TsMap["primary-ts"], Equals, int64(65536))
 	c.Assert(cp.TsMap["secondary-ts"], Equals, int64(3333))

--- a/drainer/relay.go
+++ b/drainer/relay.go
@@ -150,7 +150,7 @@ func feedByRelayLog(r relay.Reader, ld loader.Loader, cp checkpoint.CheckPoint) 
 		return errors.Trace(readerErr)
 	}
 
-	err := cp.Save(lastSuccessTS, 0 /* secondaryTS */, true /*consistent*/)
+	err := cp.Save(lastSuccessTS, 0 /* secondaryTS */, true /*consistent*/, 0)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/drainer/relay_test.go
+++ b/drainer/relay_test.go
@@ -74,7 +74,7 @@ var _ loader.Loader = &noOpLoader{}
 func (s *relaySuite) TestFeedByRealyLog(c *check.C) {
 	cp, err := checkpoint.NewFile(0 /* initialCommitTS */, c.MkDir()+"/checkpoint")
 	c.Assert(err, check.IsNil)
-	err = cp.Save(0, 0, false)
+	err = cp.Save(0, 0, false, 0)
 	c.Assert(err, check.IsNil)
 	c.Assert(cp.IsConsistent(), check.Equals, false)
 

--- a/drainer/sync/syncer.go
+++ b/drainer/sync/syncer.go
@@ -31,7 +31,7 @@ type Item struct {
 	// Each item has a schemaVersion. with amend txn feature the prewrite DML's SchemaVersion could change.
 	// which makes restart & reload history DDL with previous SchemaVersion not reliable.
 	// so we should save this version as checkpoint.
-	SchemaVersion   int64
+	SchemaVersion int64
 
 	// the applied TS executed in downstream, only for tidb
 	AppliedTS int64

--- a/drainer/sync/syncer.go
+++ b/drainer/sync/syncer.go
@@ -28,6 +28,11 @@ type Item struct {
 	Table         string
 	RelayLogPos   pb.Pos
 
+	// Each item has a schemaVersion. with amend txn feature the prewrite DML's SchemaVersion could change.
+	// which makes restart & reload history DDL with previous SchemaVersion not reliable.
+	// so we should save this version as checkpoint.
+	SchemaVersion   int64
+
 	// the applied TS executed in downstream, only for tidb
 	AppliedTS int64
 	// should skip to replicate this item at downstream

--- a/drainer/syncer.go
+++ b/drainer/syncer.go
@@ -256,7 +256,7 @@ func (s *Syncer) savePoint(ts, secondaryTS, version int64) {
 		log.Error("save ts is less than checkpoint ts %d", zap.Int64("save ts", ts), zap.Int64("checkpoint ts", s.cp.TS()))
 	}
 
-	log.Info("write save point", zap.Int64("ts", ts))
+	log.Info("write save point", zap.Int64("ts", ts), zap.Int64("version", version))
 	err := s.cp.Save(ts, secondaryTS, false, version)
 	if err != nil {
 		log.Fatal("save checkpoint failed", zap.Int64("ts", ts), zap.Error(err))

--- a/drainer/syncer.go
+++ b/drainer/syncer.go
@@ -259,7 +259,7 @@ func (s *Syncer) savePoint(ts, secondaryTS, version int64) {
 	log.Info("write save point", zap.Int64("ts", ts), zap.Int64("version", version))
 	err := s.cp.Save(ts, secondaryTS, false, version)
 	if err != nil {
-		log.Error("save checkpoint failed", zap.Int64("ts", ts), zap.Int64("version", version), zap.Error(err))
+		log.Fatal("save checkpoint failed", zap.Int64("ts", ts), zap.Int64("version", version), zap.Error(err))
 	}
 
 	checkpointTSOGauge.Set(float64(oracle.ExtractPhysical(uint64(ts))))

--- a/drainer/syncer.go
+++ b/drainer/syncer.go
@@ -259,7 +259,7 @@ func (s *Syncer) savePoint(ts, secondaryTS, version int64) {
 	log.Info("write save point", zap.Int64("ts", ts), zap.Int64("version", version))
 	err := s.cp.Save(ts, secondaryTS, false, version)
 	if err != nil {
-		log.Fatal("save checkpoint failed", zap.Int64("ts", ts), zap.Error(err))
+		log.Error("save checkpoint failed", zap.Int64("ts", ts), zap.Int64("version", version), zap.Error(err))
 	}
 
 	checkpointTSOGauge.Set(float64(oracle.ExtractPhysical(uint64(ts))))

--- a/drainer/syncer.go
+++ b/drainer/syncer.go
@@ -284,7 +284,7 @@ func (s *Syncer) run() error {
 
 	s.enableSafeModeInitializationPhase()
 
-	err = s.schema.handlePreviousDDLJobIfNeed(s.cp.SchemaVersion())
+	err = s.schema.handlePreviousDDLJobIfNeed(s.cp.SchemaVersion()+1)
 	if err != nil {
 		err = errors.Annotate(err, "handlePreviousDDLJobIfNeed failed")
 		return err


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix #1032 

### What is changed and how it works?
save schemaVersion to checkpoint.
with amend txn enabled. `prewrite.SchemeVersion` could out of date.
so when drainer restart, we need to compare `checkpoint'SchemaVersion` and `prewrite.SchemaVersion`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Manual test (add detailed scripts or steps below)


Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to be included in the release note

Release note
- Fix the issue that when amend txn enabled. Drainer chooses the wrong schema version of DDL to generate the wrong SQL.