### PR TITLE
drainer: fix datetime/time clustered index column replication error

### DIFF
--- a/drainer/translator/translator.go
+++ b/drainer/translator/translator.go
@@ -74,6 +74,13 @@ func insertRowToDatums(table *model.TableInfo, row []byte) (datums map[int64]typ
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
+		if table.IsCommonHandle {
+			// clustered index could be complex type that need Unflatten from raw datum.
+			aPK, err = tablecodec.Unflatten(aPK, &table.Columns[commonPKInfo.Columns[i].Offset].FieldType, time.Local)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+		}
 		pk = append(pk, aPK)
 	}
 

--- a/tests/dailytest/case.go
+++ b/tests/dailytest/case.go
@@ -43,6 +43,8 @@ var caseClusteredIndexInsert = []string{
 	"create table cluster_t4(a varchar(100), b varchar(100), d varchar(100), c varchar(100), primary key(c(1))) collate utf8mb4_general_ci",
 	"create table cluster_t5(a varchar(100), b varchar(100), d varchar(100), c varchar(100), primary key(c, b(1))) collate utf8mb4_general_ci",
 	"create table cluster_t6(a varchar(100), b varchar(100), d varchar(100), c varchar(100), primary key(c(1), a(1), b)) collate utf8mb4_general_ci",
+	"create table cluster_t7(c1 timestamp, c2 datetime, c3 int, primary key(c1, c2, c3) clustered)",
+	"create table cluster_t8(c1 float, c2 enum('a', 'b'), c3 bit, c4 SET('a', 'b'), c5 time, primary key(c1, c2, c3, c4, c5) clustered)",
 
 	"insert into cluster_t1(a, b, d, c) values ('aaa', 'bbb', 'ddd', 'ccc'), ('111', '222', '444', '333')",
 	"insert into cluster_t2(a, b, d, c) values ('aaa', 'bbb', 'ddd', 'ccc'), ('111', '222', '444', '333')",
@@ -50,6 +52,8 @@ var caseClusteredIndexInsert = []string{
 	"insert into cluster_t4(a, b, d, c) values ('aaa', 'bbb', 'ddd', 'ccc'), ('111', '222', '444', '333')",
 	"insert into cluster_t5(a, b, d, c) values ('aaa', 'bbb', 'ddd', 'ccc'), ('111', '222', '444', '333')",
 	"insert into cluster_t6(a, b, d, c) values ('aaa', 'bbb', 'ddd', 'ccc'), ('111', '222', '444', '333')",
+	"insert into cluster_t7(c1, c2, c3) values ('1996-11-13 10:38:39', '9472-11-22 10:36:06', 1709134011)",
+	"insert into cluster_t8(c1, c2, c3, c4, c5) values (1.1, 'a', 1, 'b', '01:01:01')",
 }
 
 var caseClusteredIndexUpdateNoPK = []string{


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

closes #1042

introduced by #1040

`DecodeOne` only decode column as Raw datum...so date/datetime...will be judged as int

so it make new added test case in PR fail



### What is changed and how it works?

need call tablecodec to Unflatten raw datum to "real" datum

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - n/a

Side effects

 - n/a

Related changes

 - Need to cherry-pick to the release branch

### Release note <!-- bugfixes or new feature need a release note -->

- Fix clustered index table replica fail for some type columns