### PR TITLE
drainer: fix collation clustered pk as wrong value

### DIFF
--- a/drainer/translator/translator.go
+++ b/drainer/translator/translator.go
@@ -101,6 +101,11 @@ func insertRowToDatums(table *model.TableInfo, row []byte) (datums map[int64]typ
 				continue
 			}
 			tblIdxCol := table.Columns[idxCol.Offset]
+			if _, exists := datums[tblIdxCol.ID]; exists {
+				// use row column instead of pk column if row column exists
+				// e.g. new collation's pk just be sortKey, but row column have full data.
+				continue
+			}
 			datums[tblIdxCol.ID] = pk[idxColOrdinal]
 		}
 	} else {

--- a/tests/dailytest/case.go
+++ b/tests/dailytest/case.go
@@ -45,6 +45,7 @@ var caseClusteredIndexInsert = []string{
 	"create table cluster_t6(a varchar(100), b varchar(100), d varchar(100), c varchar(100), primary key(c(1), a(1), b)) collate utf8mb4_general_ci",
 	"create table cluster_t7(c1 timestamp, c2 datetime, c3 int, primary key(c1, c2, c3) clustered)",
 	"create table cluster_t8(c1 float, c2 enum('a', 'b'), c3 bit, c4 SET('a', 'b'), c5 time, primary key(c1, c2, c3, c4, c5) clustered)",
+	"create table cluster_t9(c1 char(64) COLLATE utf8mb4_unicode_ci NOT NULL, primary key(c1) clustered)",
 
 	"insert into cluster_t1(a, b, d, c) values ('aaa', 'bbb', 'ddd', 'ccc'), ('111', '222', '444', '333')",
 	"insert into cluster_t2(a, b, d, c) values ('aaa', 'bbb', 'ddd', 'ccc'), ('111', '222', '444', '333')",
@@ -54,6 +55,7 @@ var caseClusteredIndexInsert = []string{
 	"insert into cluster_t6(a, b, d, c) values ('aaa', 'bbb', 'ddd', 'ccc'), ('111', '222', '444', '333')",
 	"insert into cluster_t7(c1, c2, c3) values ('1996-11-13 10:38:39', '9472-11-22 10:36:06', 1709134011)",
 	"insert into cluster_t8(c1, c2, c3, c4, c5) values (1.1, 'a', 1, 'b', '01:01:01')",
+	"insert into cluster_t9(c1) values ('1020')",
 }
 
 var caseClusteredIndexUpdateNoPK = []string{

--- a/tests/dailytest/case.go
+++ b/tests/dailytest/case.go
@@ -37,12 +37,12 @@ var caseAutoRandomClean = []string{
 }
 
 var caseClusteredIndexInsert = []string{
-	"create table cluster_t1(a varchar(100), b varchar(100), d varchar(100), c varchar(100), primary key(c)) collate utf8mb4_general_ci",
-	"create table cluster_t2(a varchar(100), b varchar(100), d varchar(100), c varchar(100), primary key(c, b)) collate utf8mb4_general_ci",
-	"create table cluster_t3(a varchar(100), b varchar(100), d varchar(100), c varchar(100), primary key(c, a, b)) collate utf8mb4_general_ci",
-	"create table cluster_t4(a varchar(100), b varchar(100), d varchar(100), c varchar(100), primary key(c(1))) collate utf8mb4_general_ci",
-	"create table cluster_t5(a varchar(100), b varchar(100), d varchar(100), c varchar(100), primary key(c, b(1))) collate utf8mb4_general_ci",
-	"create table cluster_t6(a varchar(100), b varchar(100), d varchar(100), c varchar(100), primary key(c(1), a(1), b)) collate utf8mb4_general_ci",
+	"create table cluster_t1(a varchar(100), b varchar(100), d varchar(100), c varchar(100), primary key(c) clustered) collate utf8mb4_general_ci",
+	"create table cluster_t2(a varchar(100), b varchar(100), d varchar(100), c varchar(100), primary key(c, b) clustered) collate utf8mb4_general_ci",
+	"create table cluster_t3(a varchar(100), b varchar(100), d varchar(100), c varchar(100), primary key(c, a, b) clustered) collate utf8mb4_general_ci",
+	"create table cluster_t4(a varchar(100), b varchar(100), d varchar(100), c varchar(100), primary key(c(1)) clustered) collate utf8mb4_general_ci",
+	"create table cluster_t5(a varchar(100), b varchar(100), d varchar(100), c varchar(100), primary key(c, b(1)) clustered) collate utf8mb4_general_ci",
+	"create table cluster_t6(a varchar(100), b varchar(100), d varchar(100), c varchar(100), primary key(c(1), a(1), b) clustered) collate utf8mb4_general_ci",
 	"create table cluster_t7(c1 timestamp, c2 datetime, c3 int, primary key(c1, c2, c3) clustered)",
 	"create table cluster_t8(c1 float, c2 enum('a', 'b'), c3 bit, c4 SET('a', 'b'), c5 time, primary key(c1, c2, c3, c4, c5) clustered)",
 	"create table cluster_t9(c1 char(64) COLLATE utf8mb4_unicode_ci NOT NULL, primary key(c1) clustered)",


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

close https://github.com/pingcap/tidb/issues/24890

### What is changed and how it works?

for new collation, pk column will be sortedKey(suitable for CI compare rule), row-column will restore raw data

use row's column instead of pk's column if row's column exists

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - n/a
 
Side effects

 -  n/a

Related changes

 - n/a

### Release note <!-- bugfixes or new feature need a release note -->

- Fix clustered index table replica wrong value for collation PK