### PR TITLE
Update go & replace ioutils

### DIFF
--- a/arbiter/config_test.go
+++ b/arbiter/config_test.go
@@ -16,7 +16,7 @@ package arbiter
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 	"runtime"
 	"strings"
@@ -127,7 +127,7 @@ func (t *TestConfigSuite) TestParseConfigFileWithInvalidArgs(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	configFilename := path.Join(c.MkDir(), "arbiter_config_invalid.toml")
-	err = ioutil.WriteFile(configFilename, buf.Bytes(), 0644)
+	err = os.WriteFile(configFilename, buf.Bytes(), 0644)
 	c.Assert(err, check.IsNil)
 
 	args := []string{

--- a/binlogctl/meta.go
+++ b/binlogctl/meta.go
@@ -25,7 +25,6 @@ import (
 	"github.com/pingcap/log"
 	"github.com/pingcap/tidb-binlog/pkg/flags"
 	"github.com/pingcap/tidb-binlog/pkg/util"
-	"github.com/siddontang/go/ioutil2"
 	pd "github.com/tikv/pd/client"
 	"go.uber.org/zap"
 )
@@ -103,7 +102,7 @@ func saveMeta(metaFileName string, ts int64, timeZone string) error {
 		}
 	}
 
-	err = ioutil2.WriteFileAtomic(metaFileName, buf.Bytes(), 0644)
+	err = util.WriteFileAtomic(metaFileName, buf.Bytes(), 0644)
 	if err != nil {
 		return errors.Annotatef(err, "save meta %+v into %s", meta, metaFileName)
 	}

--- a/binlogctl/meta_test.go
+++ b/binlogctl/meta_test.go
@@ -15,7 +15,7 @@ package binlogctl
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
 	"path"
 	"strings"
 
@@ -41,7 +41,7 @@ func (s *metaSuite) TestSaveMeta(c *C) {
 	err := saveMeta(filename, 123, "Local")
 	c.Assert(err, IsNil)
 
-	b, err := ioutil.ReadFile(filename)
+	b, err := os.ReadFile(filename)
 	c.Assert(err, IsNil)
 	lines := strings.Split(strings.TrimSpace(string(b)), "\n")
 	c.Assert(lines, HasLen, 3)
@@ -83,7 +83,7 @@ func (s *metaSuite) TestGenerateMetaInfo(c *C) {
 	err := GenerateMetaInfo(cfg)
 	c.Assert(err, IsNil)
 
-	b, err := ioutil.ReadFile(path.Join(dir, "savepoint"))
+	b, err := os.ReadFile(path.Join(dir, "savepoint"))
 	c.Assert(err, IsNil)
 	lines := strings.Split(strings.TrimSpace(string(b)), "\n")
 	c.Assert(lines, HasLen, 1)

--- a/cmd/arbiter/main.go
+++ b/cmd/arbiter/main.go
@@ -14,7 +14,7 @@
 package main
 
 import (
-	"io/ioutil"
+	"io"
 	stdlog "log"
 	"net/http"
 	_ "net/http/pprof"
@@ -44,7 +44,7 @@ func main() {
 	// We have set sarama.Logger in util.InitLogger.
 	if !cfg.OpenSaramaLog {
 		// may too many noise, discard sarama log now
-		sarama.Logger = stdlog.New(ioutil.Discard, "[Sarama] ", stdlog.LstdFlags)
+		sarama.Logger = stdlog.New(io.Discard, "[Sarama] ", stdlog.LstdFlags)
 	}
 
 	log.Info("start arbiter...", zap.Reflect("config", cfg))

--- a/drainer/checkpoint/file.go
+++ b/drainer/checkpoint/file.go
@@ -15,12 +15,12 @@ package checkpoint
 
 import (
 	"bytes"
+	"github.com/pingcap/tidb-binlog/pkg/util"
 	"os"
 	"sync"
 
 	"github.com/BurntSushi/toml"
 	"github.com/pingcap/errors"
-	"github.com/siddontang/go/ioutil2"
 )
 
 // FileCheckPoint is local CheckPoint struct.
@@ -104,7 +104,7 @@ func (sp *FileCheckPoint) Save(ts, secondaryTS int64, consistent bool, version i
 		return errors.Annotate(err, "encode checkpoint failed")
 	}
 
-	err = ioutil2.WriteFileAtomic(sp.name, buf.Bytes(), 0644)
+	err = util.WriteFileAtomic(sp.name, buf.Bytes(), 0644)
 	if err != nil {
 		return errors.Annotatef(err, "write file %s failed", sp.name)
 	}

--- a/drainer/checkpoint/file.go
+++ b/drainer/checkpoint/file.go
@@ -15,12 +15,12 @@ package checkpoint
 
 import (
 	"bytes"
-	"github.com/pingcap/tidb-binlog/pkg/util"
 	"os"
 	"sync"
 
 	"github.com/BurntSushi/toml"
 	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb-binlog/pkg/util"
 )
 
 // FileCheckPoint is local CheckPoint struct.

--- a/drainer/config_test.go
+++ b/drainer/config_test.go
@@ -16,7 +16,7 @@ package drainer
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 	"testing"
 	"time"
@@ -143,7 +143,7 @@ func (t *testDrainerSuite) TestEnableDisable(c *C) {
 		for _, enableFile := range []*bool{nil, &truev, &falsev} {
 			for _, disableFlag := range []*bool{nil, &truev, &falsev} {
 				for _, disableFile := range []*bool{nil, &truev, &falsev} {
-					f, err := ioutil.TempFile("", "test-enable")
+					f, err := os.CreateTemp("", "test-enable")
 					c.Assert(err, check.IsNil)
 
 					fmt.Fprintf(f, "[syncer]\n")
@@ -270,7 +270,7 @@ func (t *testDrainerSuite) TestConfigParsingFileWithInvalidOptions(c *C) {
 	c.Assert(err, IsNil)
 
 	configFilename := path.Join(c.MkDir(), "drainer_config_invalid.toml")
-	err = ioutil.WriteFile(configFilename, buf.Bytes(), 0644)
+	err = os.WriteFile(configFilename, buf.Bytes(), 0644)
 	c.Assert(err, IsNil)
 
 	args := []string{

--- a/drainer/server_test.go
+++ b/drainer/server_test.go
@@ -16,7 +16,7 @@ package drainer
 import (
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -55,7 +55,7 @@ func (t *testServerSuite) TestGetLatestTS(c *C) {
 	resp := w.Result()
 	c.Assert(resp.StatusCode, Equals, http.StatusOK)
 
-	body, _ := ioutil.ReadAll(resp.Body)
+	body, _ := io.ReadAll(resp.Body)
 	var decoded util.Response
 	err := json.Unmarshal(body, &decoded)
 	c.Assert(err, IsNil)
@@ -168,7 +168,7 @@ func (s *applyActionSuite) TestShouldCheckNodeID(c *C) {
 	s.router.ServeHTTP(w, req)
 
 	resp := w.Result()
-	body, _ := ioutil.ReadAll(resp.Body)
+	body, _ := io.ReadAll(resp.Body)
 	c.Assert(resp.StatusCode, Equals, http.StatusOK)
 
 	var decoded util.Response
@@ -187,7 +187,7 @@ func (s *applyActionSuite) TestShouldCheckState(c *C) {
 	s.router.ServeHTTP(w, req)
 
 	resp := w.Result()
-	body, _ := ioutil.ReadAll(resp.Body)
+	body, _ := io.ReadAll(resp.Body)
 	c.Assert(resp.StatusCode, Equals, http.StatusOK)
 
 	var decoded util.Response
@@ -211,7 +211,7 @@ func (s *applyActionSuite) TestShouldApplyAction(c *C) {
 		s.router.ServeHTTP(w, req)
 
 		resp := w.Result()
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 
 		c.Assert(resp.StatusCode, Equals, http.StatusOK)
 
@@ -313,7 +313,7 @@ func (s *newServerSuite) TearDownTest(c *C) {
 }
 
 func (s *newServerSuite) TestCannotCreateDataDir(c *C) {
-	tmpfile, err := ioutil.TempFile("", "test")
+	tmpfile, err := os.CreateTemp("", "test")
 	if err != nil {
 		c.Fatal("Failed to create temp file.")
 	}

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,6 @@ require (
 	github.com/prometheus/client_model v0.2.0
 	github.com/rcrowley/go-metrics v0.0.0-20190826022208-cac0b30c2563
 	github.com/samuel/go-zookeeper v0.0.0-20170815201139-e6b59f6144be
-	github.com/siddontang/go v0.0.0-20180604090527-bdc77568d726
 	github.com/soheilhy/cmux v0.1.4
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20190625010220-02440ea7a285

--- a/go.mod
+++ b/go.mod
@@ -52,4 +52,4 @@ require (
 	sigs.k8s.io/yaml v1.2.0 // indirect
 )
 
-go 1.13
+go 1.16

--- a/go.sum
+++ b/go.sum
@@ -90,7 +90,6 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa h1:OaNxuTZr7kxeODyLWsRMC+OD03aFUH+mW6r2d+MWa5Y=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
-github.com/codahale/hdrhistogram v0.9.0 h1:9GjrtRI+mLEFPtTfR/AZhcxp+Ii8NZYWq5104FbZQY0=
 github.com/codahale/hdrhistogram v0.9.0/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/colinmarc/hdfs/v2 v2.1.1/go.mod h1:M3x+k8UKKmxtFu++uAZ0OtDU8jR3jnaZIAc6yK4Ue0c=
 github.com/coocood/bbloom v0.0.0-20190830030839-58deb6228d64 h1:W1SHiII3e0jVwvaQFglwu3kS9NLxOeTpvik7MbKCyuQ=
@@ -169,7 +168,6 @@ github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHqu
 github.com/frankban/quicktest v1.4.1/go.mod h1:36zfPVQyHxymz4cH7wlDmVwDrJuljRB60qkgn7rorfQ=
 github.com/frankban/quicktest v1.11.1 h1:stwUsXhUGliQs9t0ZS39BWCltFdOHgABiIlihop8AD4=
 github.com/frankban/quicktest v1.11.1/go.mod h1:K+q6oSqb0W0Ininfk863uOk1lMy69l/P6txr3mVT54s=
-github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsouza/fake-gcs-server v1.17.0 h1:OeH75kBZcZa3ZE+zz/mFdJ2btt9FgqfjI7gIh9+5fvk=
 github.com/fsouza/fake-gcs-server v1.17.0/go.mod h1:D1rTE4YCyHFNa99oyJJ5HyclvN/0uQR+pM/VdlL83bw=
@@ -556,8 +554,6 @@ github.com/shurcooL/httpgzip v0.0.0-20190720172056-320755c1c1b0/go.mod h1:919Lwc
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/shurcooL/vfsgen v0.0.0-20181202132449-6a9ea43bcacd h1:ug7PpSOB5RBPK1Kg6qskGBoP3Vnj/aNYFTznWvlkGo0=
 github.com/shurcooL/vfsgen v0.0.0-20181202132449-6a9ea43bcacd/go.mod h1:TrYk7fJVaAttu97ZZKrO9UbRa8izdowaMIZcxYMbVaw=
-github.com/siddontang/go v0.0.0-20180604090527-bdc77568d726 h1:xT+JlYxNGqyT+XcU8iUrN18JYed2TvG9yN5ULG2jATM=
-github.com/siddontang/go v0.0.0-20180604090527-bdc77568d726/go.mod h1:3yhqj7WBBfRhbBlzyOC3gUxftwsU0u8gqevxwIHQpMw=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
@@ -647,7 +643,6 @@ github.com/xitongsys/parquet-go v1.5.1/go.mod h1:xUxwM8ELydxh4edHGegYq1pA8NnMKDx
 github.com/xitongsys/parquet-go v1.5.5-0.20201110004701-b09c49d6d457 h1:tBbuFCtyJNKT+BFAv6qjvTFpVdy97IYNaBwGUXifIUs=
 github.com/xitongsys/parquet-go v1.5.5-0.20201110004701-b09c49d6d457/go.mod h1:pheqtXeHQFzxJk45lRQ0UIGIivKnLXvialZSFWs81A8=
 github.com/xitongsys/parquet-go-source v0.0.0-20190524061010-2b72cbee77d5/go.mod h1:xxCx7Wpym/3QCo6JhujJX51dzSXrwmb0oH6FQb39SEA=
-github.com/xitongsys/parquet-go-source v0.0.0-20200817004010-026bad9b25d0 h1:a742S4V5A15F93smuVxA60LQWsrCnN8bKeWDBARU1/k=
 github.com/xitongsys/parquet-go-source v0.0.0-20200817004010-026bad9b25d0/go.mod h1:HYhIKsdns7xz80OgkbgJYrtQY7FjHWHKH6cvN7+czGE=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yookoala/realpath v1.0.0/go.mod h1:gJJMA9wuX7AcqLy1+ffPatSCySA1FQ2S8Ya9AIoYBpE=

--- a/pkg/binlogfile/binlogger_test.go
+++ b/pkg/binlogfile/binlogger_test.go
@@ -16,7 +16,6 @@ package binlogfile
 import (
 	"encoding/binary"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"time"
@@ -272,7 +271,7 @@ func (s *testBinloggerSuite) TestGCByTime(c *C) {
 }
 
 func (s *testBinloggerSuite) TestSeekBinlog(c *C) {
-	f, err := ioutil.TempFile(os.TempDir(), "testOffset")
+	f, err := os.CreateTemp(os.TempDir(), "testOffset")
 	c.Assert(err, IsNil)
 	defer func() {
 		f.Close()

--- a/pkg/binlogfile/file_test.go
+++ b/pkg/binlogfile/file_test.go
@@ -14,7 +14,6 @@
 package binlogfile
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"reflect"
@@ -34,7 +33,7 @@ var _ = Suite(&testFileSuite{})
 type testFileSuite struct{}
 
 func (t *testFileSuite) TestCreate(c *C) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	defer os.RemoveAll(tmpdir)
 	c.Assert(err, IsNil)
 
@@ -60,7 +59,7 @@ func (t *testFileSuite) TestReadNorExistDir(c *C) {
 }
 
 func (t *testFileSuite) TestCreateDirAll(c *C) {
-	tmpdir, err := ioutil.TempDir(os.TempDir(), "foo")
+	tmpdir, err := os.MkdirTemp(os.TempDir(), "foo")
 	c.Assert(err, IsNil)
 	defer os.RemoveAll(tmpdir)
 
@@ -68,7 +67,7 @@ func (t *testFileSuite) TestCreateDirAll(c *C) {
 	err = CreateDirAll(tmpdir2)
 	c.Assert(err, IsNil)
 
-	err = ioutil.WriteFile(path.Join(tmpdir2, "text.txt"), []byte("test text"), file.PrivateFileMode)
+	err = os.WriteFile(path.Join(tmpdir2, "text.txt"), []byte("test text"), file.PrivateFileMode)
 	c.Assert(err, IsNil)
 
 	err = CreateDirAll(tmpdir2)
@@ -77,7 +76,7 @@ func (t *testFileSuite) TestCreateDirAll(c *C) {
 }
 
 func (t *testFileSuite) TestExist(c *C) {
-	f, err := ioutil.TempFile(os.TempDir(), "fileutil")
+	f, err := os.CreateTemp(os.TempDir(), "fileutil")
 	c.Assert(err, IsNil)
 	f.Close()
 

--- a/pkg/file/lock_test.go
+++ b/pkg/file/lock_test.go
@@ -14,7 +14,6 @@
 package file
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -38,7 +37,7 @@ func (t *testLockSuite) TestLockAndUnlock(c *C) {
 	c.Assert(err, NotNil)
 
 	// create test file
-	f, err := ioutil.TempFile("", "lock")
+	f, err := os.CreateTemp("", "lock")
 	c.Assert(err, IsNil)
 	f.Close()
 	defer func() {

--- a/pkg/security/security.go
+++ b/pkg/security/security.go
@@ -16,7 +16,7 @@ package security
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/pingcap/errors"
@@ -41,7 +41,7 @@ func (c *Config) ToTLSConfig() (tlsConfig *tls.Config, err error) {
 	// Create a certificate pool from the certificate authority
 	certPool := x509.NewCertPool()
 	var ca []byte
-	ca, err = ioutil.ReadFile(c.SSLCA)
+	ca, err = os.ReadFile(c.SSLCA)
 	if err != nil {
 		return nil, errors.Errorf("could not read ca certificate: %s", err)
 	}

--- a/pkg/security/security_test.go
+++ b/pkg/security/security_test.go
@@ -16,7 +16,7 @@ package security_test
 import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -102,13 +102,13 @@ func (s *testSecuritySuite) TestToTLSConfig(c *C) {
 		SSLKey:  filepath.Join(temp, "ssl.key"),
 	}
 
-	err := ioutil.WriteFile(dummyConfig.SSLCA, []byte(testCa), 0644)
+	err := os.WriteFile(dummyConfig.SSLCA, []byte(testCa), 0644)
 	c.Assert(err, IsNil)
 
-	err = ioutil.WriteFile(dummyConfig.SSLCert, []byte(testCert), 0644)
+	err = os.WriteFile(dummyConfig.SSLCert, []byte(testCert), 0644)
 	c.Assert(err, IsNil)
 
-	err = ioutil.WriteFile(dummyConfig.SSLKey, []byte(testKey), 0600)
+	err = os.WriteFile(dummyConfig.SSLKey, []byte(testKey), 0600)
 	c.Assert(err, IsNil)
 
 	config, err := dummyConfig.ToTLSConfig()
@@ -146,7 +146,7 @@ func (s *testSecuritySuite) TestInvalidTLSConfig(c *C) {
 	_, err := dummyConfig.ToTLSConfig()
 	c.Assert(err, ErrorMatches, "could not read ca certificate.*")
 
-	err = ioutil.WriteFile(dummyConfig.SSLCA, []byte("invalid certificate"), 0644)
+	err = os.WriteFile(dummyConfig.SSLCA, []byte("invalid certificate"), 0644)
 	c.Assert(err, IsNil)
 
 	_, err = dummyConfig.ToTLSConfig()
@@ -155,21 +155,21 @@ func (s *testSecuritySuite) TestInvalidTLSConfig(c *C) {
 	dummyConfig.SSLCert = filepath.Join(temp, "invalid-ssl.crt")
 	dummyConfig.SSLKey = filepath.Join(temp, "invalid-ssl.key")
 
-	err = ioutil.WriteFile(dummyConfig.SSLCert, []byte("invalid certificate"), 0644)
+	err = os.WriteFile(dummyConfig.SSLCert, []byte("invalid certificate"), 0644)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(dummyConfig.SSLKey, []byte("invalid key"), 0600)
+	err = os.WriteFile(dummyConfig.SSLKey, []byte("invalid key"), 0600)
 	c.Assert(err, IsNil)
 
 	// make ca valid.
-	err = ioutil.WriteFile(dummyConfig.SSLCA, []byte(testCa), 0644)
+	err = os.WriteFile(dummyConfig.SSLCA, []byte(testCa), 0644)
 	c.Assert(err, IsNil)
 	_, err = dummyConfig.ToTLSConfig()
 	c.Assert(err, ErrorMatches, "could not load client key pair.*")
 
 	// make cert/key valid can check again.
-	err = ioutil.WriteFile(dummyConfig.SSLCert, []byte(testCert), 0644)
+	err = os.WriteFile(dummyConfig.SSLCert, []byte(testCert), 0644)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(dummyConfig.SSLKey, []byte(testKey), 0600)
+	err = os.WriteFile(dummyConfig.SSLKey, []byte(testKey), 0600)
 	c.Assert(err, IsNil)
 	_, err = dummyConfig.ToTLSConfig()
 	c.Assert(err, IsNil)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -306,6 +306,7 @@ func WaitUntilTimeout(name string, fn func(), timeout time.Duration) {
 	}
 }
 
+// WriteFileAtomic writes file to temp and atomically move when everything else succeeds.
 func WriteFileAtomic(filename string, data []byte, perm os.FileMode) error {
 	dir, name := path.Dir(filename), path.Base(filename)
 	f, err := os.CreateTemp(dir, name)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -313,16 +313,23 @@ func WriteFileAtomic(filename string, data []byte, perm os.FileMode) error {
 	if err != nil {
 		return err
 	}
+
 	n, err := f.Write(data)
 	f.Close()
-	if err == nil && n < len(data) {
+	if err != nil {
+		return err
+	}
+
+	if n < len(data) {
 		err = io.ErrShortWrite
 	} else {
 		err = os.Chmod(f.Name(), perm)
 	}
+
 	if err != nil {
 		os.Remove(f.Name())
 		return err
 	}
+
 	return os.Rename(f.Name(), filename)
 }

--- a/pump/config_test.go
+++ b/pump/config_test.go
@@ -15,7 +15,6 @@ package pump
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path"
 	"time"
@@ -106,7 +105,7 @@ func (s *testConfigSuite) TestConfigParsingFileFlags(c *C) {
 	c.Assert(err, IsNil)
 
 	configFilename := path.Join(c.MkDir(), "pump_config.toml")
-	err = ioutil.WriteFile(configFilename, buf.Bytes(), 0644)
+	err = os.WriteFile(configFilename, buf.Bytes(), 0644)
 	c.Assert(err, IsNil)
 
 	args := []string{
@@ -143,7 +142,7 @@ func (s *testConfigSuite) TestConfigParsingFileWithInvalidArgs(c *C) {
 	c.Assert(err, IsNil)
 
 	configFilename := path.Join(c.MkDir(), "pump_config_invalid.toml")
-	err = ioutil.WriteFile(configFilename, buf.Bytes(), 0644)
+	err = os.WriteFile(configFilename, buf.Bytes(), 0644)
 	c.Assert(err, IsNil)
 
 	args := []string{
@@ -180,7 +179,7 @@ func (s *testConfigSuite) TestConfigParsingIntegerDuration(c *C) {
 	c.Assert(err, IsNil)
 
 	configFilename := path.Join(c.MkDir(), "pump_config_gc_int.toml")
-	err = ioutil.WriteFile(configFilename, buf.Bytes(), 0644)
+	err = os.WriteFile(configFilename, buf.Bytes(), 0644)
 	c.Assert(err, IsNil)
 
 	args := []string{
@@ -234,7 +233,7 @@ func (s *testConfigSuite) TestConfigParsingStringDuration(c *C) {
 	c.Assert(err, IsNil)
 
 	configFilename := path.Join(c.MkDir(), "pump_config_gc_str.toml")
-	err = ioutil.WriteFile(configFilename, buf.Bytes(), 0644)
+	err = os.WriteFile(configFilename, buf.Bytes(), 0644)
 	c.Assert(err, IsNil)
 
 	args := []string{

--- a/pump/node.go
+++ b/pump/node.go
@@ -16,7 +16,6 @@ package pump
 import (
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/url"
 	"os"
@@ -275,7 +274,7 @@ func readLocalNodeID(dataDir string) (string, error) {
 	} else if fi.IsDir() {
 		return "", errors.Errorf("Local nodeID path is a directory: %s", dataDir)
 	}
-	data, err := ioutil.ReadFile(nodeIDPath)
+	data, err := os.ReadFile(nodeIDPath)
 	if err != nil {
 		return "", errors.Annotate(err, "local nodeID file is collapsed")
 	}
@@ -309,7 +308,7 @@ func generateLocalNodeID(dataDir string, listenAddr string) (string, error) {
 	nodeID := FormatNodeID(id)
 
 	nodeIDPath := filepath.Join(dataDir, nodeIDFile)
-	if err := ioutil.WriteFile(nodeIDPath, []byte(nodeID), file.PrivateFileMode); err != nil {
+	if err := os.WriteFile(nodeIDPath, []byte(nodeID), file.PrivateFileMode); err != nil {
 		return "", errors.Trace(err)
 	}
 	return id, nil

--- a/pump/node_test.go
+++ b/pump/node_test.go
@@ -15,7 +15,6 @@ package pump
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -119,7 +118,7 @@ func (s *ReadLocalNodeIDSuite) TestIsDirectory(c *C) {
 func (s *ReadLocalNodeIDSuite) TestCanReadNodeID(c *C) {
 	dir := c.MkDir()
 	nodeIDPath := filepath.Join(dir, nodeIDFile)
-	if err := ioutil.WriteFile(nodeIDPath, []byte(" this-node\n"), 0644); err != nil {
+	if err := os.WriteFile(nodeIDPath, []byte(" this-node\n"), 0644); err != nil {
 		c.Fatal("Fail to write file for testing")
 	}
 	nodeID, err := readLocalNodeID(dir)

--- a/pump/server_test.go
+++ b/pump/server_test.go
@@ -17,7 +17,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"net/http"
 	"path"
@@ -750,7 +750,7 @@ WAIT:
 			// should receive valid and correct node status info
 			c.Assert(resp, NotNil)
 			defer resp.Body.Close()
-			bodyByte, err := ioutil.ReadAll(resp.Body)
+			bodyByte, err := io.ReadAll(resp.Body)
 			c.Assert(err, IsNil)
 
 			nodesStatus := &HTTPStatus{}
@@ -824,7 +824,7 @@ func httpRequest(c *C, method, url string) string {
 	c.Assert(err, IsNil)
 	c.Assert(resp, NotNil)
 	defer resp.Body.Close()
-	bodyByte, err := ioutil.ReadAll(resp.Body)
+	bodyByte, err := io.ReadAll(resp.Body)
 	c.Assert(err, IsNil)
 	bodyStr := string(bodyByte)
 	return bodyStr

--- a/pump/storage/log_test.go
+++ b/pump/storage/log_test.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"hash/crc32"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path"
@@ -199,7 +198,7 @@ func (lfs *LogFileSuit) TestCorruption(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	rd := bufio.NewReader(io.NewSectionReader(lf.fd, 0, int64(size)))
-	data, err := ioutil.ReadAll(rd)
+	data, err := io.ReadAll(rd)
 	c.Assert(err, check.IsNil)
 	c.Log(data)
 

--- a/pump/storage/vlog.go
+++ b/pump/storage/vlog.go
@@ -17,7 +17,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -225,7 +224,7 @@ func (vlog *valueLog) open(path string, opt *Options) error {
 }
 
 func (vlog *valueLog) openOrCreateFiles() error {
-	files, err := ioutil.ReadDir(vlog.dirPath)
+	files, err := os.ReadDir(vlog.dirPath)
 	if err != nil {
 		return errors.Annotatef(err, "error while read dir: %s", vlog.dirPath)
 	}

--- a/reparo/config_test.go
+++ b/reparo/config_test.go
@@ -16,7 +16,7 @@ package reparo
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 	"runtime"
 
@@ -102,7 +102,7 @@ func (s *testConfigSuite) TestParseConfigFileWithInvalidArgs(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	configFilename := path.Join(c.MkDir(), "reparo_config_invalid.toml")
-	err = ioutil.WriteFile(configFilename, buf.Bytes(), 0644)
+	err = os.WriteFile(configFilename, buf.Bytes(), 0644)
 	c.Assert(err, check.IsNil)
 
 	args := []string{

--- a/tools/check/go.mod
+++ b/tools/check/go.mod
@@ -5,4 +5,4 @@ require (
 	github.com/mgechev/revive v0.0.0-20191017201419-88015ccf8e97 // indirect
 )
 
-go 1.13
+go 1.16


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix #1043 

### What is changed and how it works?

Update go version to 1.16

.. as well as replace usage of `ioutils` which deprecated in Go 1.16 and `ioutil2` which is lack of maintenance.


### Release note

No release note.