### PR TITLE
test: make ca's CN not same with host's CN

### DIFF
--- a/drainer/pump_test.go
+++ b/drainer/pump_test.go
@@ -80,12 +80,12 @@ func (s *pumpSuite) TestPullBinlog(c *C) {
 
 	// ascending commitTs order
 	pullBinlogCommitTSChecker(commitTsArray, ret, binlogBytesChan, c)
-	time.Sleep(10 * time.Microsecond)
+	time.Sleep(100 * time.Microsecond)
 	c.Assert(p.latestTS, Equals, commitTsArray[len(commitTsArray)-1])
 
 	// should omit disorder binlog item, latestTs should be 29
 	pullBinlogCommitTSChecker(wrongCommitTsArray, ret, binlogBytesChan, c)
-	time.Sleep(10 * time.Microsecond)
+	time.Sleep(100 * time.Microsecond)
 	c.Assert(p.latestTS, Equals, wrongCommitTsArray[len(wrongCommitTsArray)-2])
 }
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -34,7 +34,7 @@ DNS.1 = localhost
 IP.1 = 127.0.0.1
 EOF
     openssl ecparam -out "$TT/ca.key" -name prime256v1 -genkey
-    openssl req -new -batch -sha256 -subj '/CN=binlog' -key "$TT/ca.key" -out "$TT/ca.csr"
+    openssl req -new -batch -sha256 -subj '/CN=ca' -key "$TT/ca.key" -out "$TT/ca.csr"
     openssl x509 -req -sha256 -days 2 -in "$TT/ca.csr" -signkey "$TT/ca.key" -out "$TT/ca.pem" 2> /dev/null
 
     for name in tidb pd tikv pump drainer client; do


### PR DESCRIPTION
Signed-off-by: nolouch <nolouch@gmail.com>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
integration test always failed with TLS auth failed.

### What is changed and how it works?
ref https://github.com/pingcap/tidb-binlog/issues/1049

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 ### Release note 

 - No release note