### PR TITLE
test: remove outdated tidb-instance-id

### DIFF
--- a/tests/reparo/sync_diff_inspector.toml
+++ b/tests/reparo/sync_diff_inspector.toml
@@ -17,8 +17,6 @@ sample-percent = 100
 # the name of the file which saves sqls used to fix different data
 fix-sql-file = "/tmp/tidb_binlog_test/fix.sql"
 
-tidb-instance-id = "source-1"
-
 use-checksum=true
 
 [[check-tables]]

--- a/tests/restart/sync_diff_inspector.toml
+++ b/tests/restart/sync_diff_inspector.toml
@@ -17,8 +17,6 @@ sample-percent = 100
 # the name of the file which saves sqls used to fix different data
 fix-sql-file = "/tmp/tidb_binlog_test/fix.sql"
 
-tidb-instance-id = "source-1"
-
 use-checksum=true
 
 [[check-tables]]


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
In order to depend on the newest `sync_diff_inspector` we need to remove the outdated config field `tidb-instance-id` from sync_diff's config

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Code changes

Side effects


Related changes

Release note
- No release note