### PR TITLE
drainer: fix filter skip checkpoint problem

### DIFF
--- a/pkg/util/ts.go
+++ b/pkg/util/ts.go
@@ -19,6 +19,7 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
 	"github.com/pingcap/tidb/store/tikv/oracle"
+	"github.com/pingcap/tipb/go-binlog"
 	pd "github.com/tikv/pd/client"
 	"go.uber.org/zap"
 	"golang.org/x/net/context"
@@ -53,6 +54,15 @@ func GetTSO(pdCli pd.Client) (int64, error) {
 	ts := int64(oracle.ComposeTS(physical, logical))
 
 	return ts, nil
+}
+
+// GenFakeBinlog generates a fake binlog from given tso
+func GenFakeBinlog(ts int64) *binlog.Binlog {
+	return &binlog.Binlog{
+		StartTs:  ts,
+		Tp:       binlog.BinlogType_Rollback,
+		CommitTs: ts,
+	}
 }
 
 // TSOToRoughTime translates tso to rough time that used to display

--- a/pump/server.go
+++ b/pump/server.go
@@ -469,13 +469,7 @@ func (s *Server) genFakeBinlog() (*pb.Binlog, error) {
 		return nil, errors.Trace(err)
 	}
 
-	bl := &binlog.Binlog{
-		StartTs:  ts,
-		Tp:       binlog.BinlogType_Rollback,
-		CommitTs: ts,
-	}
-
-	return bl, nil
+	return util.GenFakeBinlog(ts), nil
 }
 
 func (s *Server) writeFakeBinlog() (*pb.Binlog, error) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
1. When pump continuously writes binlogs, it won't write any fake binlog
2. When drainer filters dml/ddl binlogs, it won't update checkpoint using filtered binlog's commit_ts.

If we continuously write TiDB but filter most tables, drainer's checkpoint tso won't update in a long time has some bad effects:
1. make users think drainer is stuck
2. triggers drainer checkpoint not change alert
3. waste time to recover from a much former checkpoint

### What is changed and how it works?
Rewrite filtered binlogs to fake binlogs (commit ts = filtered binlog's commit ts) and send to drainer.
To avoid too many fake binlogs, we only re-generate fake binlogs after **AT LEAST 3 SECONDS**. 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - Has exported function/method change

Side effects

 - Possible performance regression

Related changes

 - Need to cherry-pick to the release branch

Release note

 - No release note