### PR TITLE
loader: clear txns and dmls buffer to free memory

### DIFF
--- a/pkg/loader/load.go
+++ b/pkg/loader/load.go
@@ -739,8 +739,16 @@ func (b *batchManager) execAccumulatedDMLs() (err error) {
 	if b.fDMLsSuccessCallback != nil {
 		b.fDMLsSuccessCallback(b.txns...)
 	}
-	b.txns = nil
-	b.dmls = nil
+
+	// set elements to nil for gc
+	for i := range b.txns {
+		b.txns[i] = nil
+	}
+	for i := range b.dmls {
+		b.dmls[i] = nil
+	}
+	b.txns = b.txns[:0]
+	b.dmls = b.dmls[:0]
 	return nil
 }
 

--- a/pkg/loader/load.go
+++ b/pkg/loader/load.go
@@ -739,8 +739,8 @@ func (b *batchManager) execAccumulatedDMLs() (err error) {
 	if b.fDMLsSuccessCallback != nil {
 		b.fDMLsSuccessCallback(b.txns...)
 	}
-	b.txns = b.txns[:0]
-	b.dmls = b.dmls[:0]
+	b.txns = nil
+	b.dmls = nil
 	return nil
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
close #1087 

### What is changed and how it works?
nil the txns and dmls slice so golang can gc the big txn

Related changes

 - Need to be included in the release note

### Release note

 - fix drainer memory leak after a big transaction