### PR TITLE
pb: update pb parser to avoid drainer failure

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -36,3 +36,9 @@ Related changes
  - Need to update the documentation
  - Need to update the `tidb-ansible` repository
  - Need to be included in the release note
+
+### Release note
+
+<!-- bugfix or new feature needs a release note -->
+
+- No release note

--- a/drainer/translator/pb.go
+++ b/drainer/translator/pb.go
@@ -22,15 +22,15 @@ import (
 	//nolint
 	"github.com/golang/protobuf/proto"
 	"github.com/pingcap/errors"
-	"github.com/pingcap/tidb-binlog/pkg/util"
-	pb "github.com/pingcap/tidb-binlog/proto/binlog"
-	"github.com/pingcap/tidb/parser/ast"
 	"github.com/pingcap/tidb/parser/model"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/codec"
 	tipb "github.com/pingcap/tipb/go-binlog"
+
+	"github.com/pingcap/tidb-binlog/pkg/util"
+	pb "github.com/pingcap/tidb-binlog/proto/binlog"
 )
 
 // TiBinlogToPbBinlog translate the binlog format
@@ -41,12 +41,7 @@ func TiBinlogToPbBinlog(infoGetter TableInfoGetter, schema string, table string,
 
 	if tiBinlog.DdlJobId > 0 { // DDL
 		sql := string(tiBinlog.GetDdlQuery())
-		stmt, err := getParser().ParseOneStmt(sql, "", "")
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-
-		_, isCreateDatabase := stmt.(*ast.CreateDatabaseStmt)
+		isCreateDatabase := util.IsCreateDatabaseDDL(sql)
 		if isCreateDatabase {
 			sql += ";"
 		} else {

--- a/pkg/loader/load_test.go
+++ b/pkg/loader/load_test.go
@@ -320,24 +320,6 @@ func (s *getTblInfoSuite) TestShouldCacheResult(c *check.C) {
 	c.Assert(nCalled, check.Equals, 1)
 }
 
-type isCreateDBDDLSuite struct{}
-
-var _ = check.Suite(&isCreateDBDDLSuite{})
-
-func (s *isCreateDBDDLSuite) TestInvalidSQL(c *check.C) {
-	c.Assert(isCreateDatabaseDDL("INSERT INTO Y a b c;"), check.IsFalse)
-}
-
-func (s *isCreateDBDDLSuite) TestNonCreateDBSQL(c *check.C) {
-	c.Assert(isCreateDatabaseDDL("SELECT 1;"), check.IsFalse)
-	c.Assert(isCreateDatabaseDDL(`INSERT INTO tbl(id, name) VALUES(1, "test";`), check.IsFalse)
-}
-
-func (s *isCreateDBDDLSuite) TestCreateDBSQL(c *check.C) {
-	c.Assert(isCreateDatabaseDDL("CREATE DATABASE test;"), check.IsTrue)
-	c.Assert(isCreateDatabaseDDL("create database `db2`;"), check.IsTrue)
-}
-
 type needRefreshTableInfoSuite struct{}
 
 var _ = check.Suite(&needRefreshTableInfoSuite{})


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
When drainer syncing to pb meeting some unknown ddls, drainer will fail because of the unknown DDL.

### What is changed and how it works?
Ignore this pb error when checking whether ddl is `CreateDatabaseStmt`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - Has exported function/method change
 - Has exported variable/fields change

### Release note

- No release note