### PR TITLE
reparo: fix can't decode bit type data

### DIFF
--- a/reparo/syncer/util.go
+++ b/reparo/syncer/util.go
@@ -46,7 +46,8 @@ func formatValue(value types.Datum, tp byte) types.Datum {
 	case mysql.TypeSet:
 		value = types.NewDatum(value.GetMysqlSet().Value)
 	case mysql.TypeBit:
-		value = types.NewDatum(value.GetMysqlBit())
+		// see drainer/translator/mysql.go formatData
+		value = types.NewDatum(value.GetUint64())
 	}
 
 	return value

--- a/reparo/syncer/util_test.go
+++ b/reparo/syncer/util_test.go
@@ -15,8 +15,7 @@ var _ = check.Suite(&testUtilSuite{})
 func (s *testUtilSuite) TestFormatValue(c *check.C) {
 	datetime, err := time.Parse("20060102150405", "20190415121212")
 	c.Assert(err, check.IsNil)
-	bitVal, err2 := types.NewBitLiteral("b'10010'")
-	c.Assert(err2, check.IsNil)
+	bitVal := uint64(12)
 
 	testCases := []struct {
 		value     interface{}
@@ -81,8 +80,8 @@ func (s *testUtilSuite) TestFormatValue(c *check.C) {
 		{
 			value:     bitVal,
 			tp:        mysql.TypeBit,
-			expectStr: "0x12",
-			expectVal: types.BinaryLiteral([]byte{0x12}),
+			expectStr: "12",
+			expectVal: uint64(12),
 		},
 	}
 

--- a/tests/dailytest/db.go
+++ b/tests/dailytest/db.go
@@ -222,7 +222,12 @@ func genColumnData(table *table, column *column) (string, error) {
 	isUnsigned := mysql.HasUnsignedFlag(tp.Flag)
 
 	switch tp.Tp {
-	case mysql.TypeTiny, mysql.TypeBit:
+	case mysql.TypeBit:
+		if randInt(0, 1) == 0 {
+			return "b'0'", nil
+		}
+		return "b'1'", nil
+	case mysql.TypeTiny:
 		var data int64
 		if isUnique {
 			data = uniqInt64Value(column, 0, math.MaxUint8)

--- a/tests/dailytest/db.go
+++ b/tests/dailytest/db.go
@@ -23,8 +23,9 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
-	"github.com/pingcap/tidb-binlog/tests/util"
 	"github.com/pingcap/tidb/parser/mysql"
+
+	"github.com/pingcap/tidb-binlog/tests/util"
 )
 
 func intRangeValue(column *column, min int64, max int64) (int64, int64) {
@@ -221,7 +222,7 @@ func genColumnData(table *table, column *column) (string, error) {
 	isUnsigned := mysql.HasUnsignedFlag(tp.Flag)
 
 	switch tp.Tp {
-	case mysql.TypeTiny:
+	case mysql.TypeTiny, mysql.TypeBit:
 		var data int64
 		if isUnique {
 			data = uniqInt64Value(column, 0, math.MaxUint8)

--- a/tests/reparo/binlog.go
+++ b/tests/reparo/binlog.go
@@ -75,7 +75,9 @@ func main() {
 		`
 	create table ntest2(
 		a int,
-		b bit(20),
+		b double NOT NULL DEFAULT 2.0,
+		c varchar(10) NOT NULL,
+		d bit(20)
 	);
 	`}
 

--- a/tests/reparo/binlog.go
+++ b/tests/reparo/binlog.go
@@ -20,6 +20,7 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
+
 	"github.com/pingcap/tidb-binlog/tests/dailytest"
 	"github.com/pingcap/tidb-binlog/tests/util"
 )
@@ -69,6 +70,12 @@ func main() {
 		b double NOT NULL DEFAULT 2.0,
 		c varchar(10) NOT NULL,
 		d time unique
+	);
+	`,
+		`
+	create table ntest2(
+		a int,
+		b bit(20),
 	);
 	`}
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
close https://github.com/pingcap/tidb-binlog/issues/1096

### What is changed and how it works?
in https://github.com/pingcap/tidb-binlog/pull/655, drainer will write Uint64 datum for mysql bit type. align reparo's behaviour

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes


Side effects


Related changes

 - Need to cherry-pick to the release branch
 - Need to be included in the release note