### PR TITLE
drainer: skip 'alter table cache|nocache' DDL jobs

### DIFF
--- a/drainer/schema.go
+++ b/drainer/schema.go
@@ -315,6 +315,8 @@ func skipUnsupportedDDLJob(job *model.Job) bool {
 	// 	return true
 	case model.ActionLockTable, model.ActionUnlockTable:
 		return true
+	case model.ActionAlterCacheTable, model.ActionAlterNoCacheTable:
+		return true
 	case model.ActionAlterTableAttributes, model.ActionAlterTablePartitionAttributes:
 		return true
 	}

--- a/tests/cache_table/drainer.toml
+++ b/tests/cache_table/drainer.toml
@@ -1,0 +1,17 @@
+data-dir = '/tmp/tidb_binlog_test/data.drainer'
+
+[syncer]
+txn-batch = 1
+worker-count = 1
+safe-mode = false
+db-type = 'mysql'
+replicate-do-db = ['cache_table']
+
+[syncer.to]
+host = '127.0.0.1'
+user = 'root'
+password = ''
+port = 3306
+
+[syncer.to.checkpoint]
+schema = "cache_table_checkpoint"

--- a/tests/cache_table/drainer.toml
+++ b/tests/cache_table/drainer.toml
@@ -5,7 +5,7 @@ txn-batch = 1
 worker-count = 1
 safe-mode = false
 db-type = 'mysql'
-replicate-do-db = ['cache_table']
+replicate-do-db = ['cache_test']
 
 [syncer.to]
 host = '127.0.0.1'

--- a/tests/cache_table/run.sh
+++ b/tests/cache_table/run.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+set -e
+
+cd "$(dirname "$0")"
+
+run_drainer &
+
+sleep 3
+
+run_sql 'CREATE DATABASE cache_test;'
+run_sql 'CREATE TABLE cache_test.t1( a int, b varchar(128));'
+run_sql "INSERT INTO cache_test.t1 (a,b) VALUES(1,'a'),(2,'b'),(3,'c'),(4,'d');"
+run_sql "ALTER TABLE cache_test.t1 CACHE;"
+run_sql "INSERT INTO cache_test.t1 (a,b) VALUES(5,'e'),(6,'f'),(7,'g'),(8,'h');"
+run_sql "ALTER TABLE cache_test.t1 NOCACHE"
+
+sleep 3
+
+down_run_sql 'SELECT a, b FROM cache_test.t1 order by a'
+check_contains 'a: 7'
+check_contains 'b: g'
+check_contains 'a: 8'
+check_contains 'b: h'
+
+run_sql 'DROP DATABASE cache_test'
+
+killall drainer


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close https://github.com/pingcap/tidb/issues/31105

### What is changed and how it works?

Actually, this PR want to add an integration test to make sure `alter table cache` works with the tools.
It's ignored in the TiDB side already .

For testing of this feature https://github.com/pingcap/tidb/issues/25293

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - [X] Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note
