### PR TITLE
fix sync-ddl control

### DIFF
--- a/drainer/syncer.go
+++ b/drainer/syncer.go
@@ -456,49 +456,50 @@ ForLoop:
 				continue
 			}
 
+			var (
+				shouldSkip    bool
+				schema, table string
+			)
 			sql := b.job.Query
-			var schema, table string
 			schema, table, err = s.schema.getSchemaTableAndDelete(b.job.BinlogInfo.SchemaVersion)
 			if err != nil {
 				err = errors.Trace(err)
 				break ForLoop
 			}
-
-			if s.filter.SkipSchemaAndTable(schema, table) {
-				log.Info("skip ddl by block allow filter", zap.String("schema", schema), zap.String("table", table),
-					zap.String("sql", sql), zap.Int64("commit ts", commitTS))
-				appendFakeBinlogIfNeeded(nil, commitTS)
-				continue
-			}
-
-			// shouldSkip is used specially for database dsyncers like tidb/mysql/oracle
-			// although we skip some ddls, but we still need to update table info
-			// ignore means whether we should should this ddl event after binlogFilter
-			var (
-				shouldSkip, ignore bool
-				stmt               ast.StmtNode
-			)
-
-			if stmt, ignore, err = skipDDLEvent(sql, schema, table, p, s.binlogFilter); err != nil {
-				break ForLoop
-			} else if ignore {
-				log.Info("skip ddl by binlog event filter", zap.String("schema", schema), zap.String("table", table),
-					zap.String("sql", sql), zap.Int64("commit ts", commitTS))
-				// A empty sql force it to evict the downstream table info.
-				if s.cfg.DestDBType == "tidb" || s.cfg.DestDBType == "mysql" || s.cfg.DestDBType == "oracle" {
-					shouldSkip = true
-				} else {
+			if s.cfg.SyncDDL {
+				if s.filter.SkipSchemaAndTable(schema, table) {
+					log.Info("skip ddl by block allow filter", zap.String("schema", schema), zap.String("table", table),
+						zap.String("sql", sql), zap.Int64("commit ts", commitTS))
 					appendFakeBinlogIfNeeded(nil, commitTS)
 					continue
 				}
-			} else if !ignore && s.cfg.DestDBType == "oracle" {
-				if _, ok := stmt.(*ast.TruncateTableStmt); !ok && s.cfg.SyncDDL {
-					err = errors.Errorf("unsupported ddl %s, you should skip commit ts %d", sql, commitTS)
-					break ForLoop
-				}
-			}
 
-			if !s.cfg.SyncDDL {
+				// shouldSkip is used specially for database dsyncers like tidb/mysql/oracle
+				// although we skip some ddls, but we still need to update table info
+				// ignore means whether we should should this ddl event after binlogFilter
+				var (
+					ignore bool
+					stmt   ast.StmtNode
+				)
+				if stmt, ignore, err = skipDDLEvent(sql, schema, table, p, s.binlogFilter); err != nil {
+					break ForLoop
+				} else if ignore {
+					log.Info("skip ddl by binlog event filter", zap.String("schema", schema), zap.String("table", table),
+						zap.String("sql", sql), zap.Int64("commit ts", commitTS))
+					// A empty sql force it to evict the downstream table info.
+					if s.cfg.DestDBType == "tidb" || s.cfg.DestDBType == "mysql" || s.cfg.DestDBType == "oracle" {
+						shouldSkip = true
+					} else {
+						appendFakeBinlogIfNeeded(nil, commitTS)
+						continue
+					}
+				} else if !ignore && s.cfg.DestDBType == "oracle" {
+					if _, ok := stmt.(*ast.TruncateTableStmt); !ok {
+						err = errors.Errorf("unsupported ddl %s, you should skip commit ts %d", sql, commitTS)
+						break ForLoop
+					}
+				}
+			} else {
 				log.Info("skip ddl by SyncDDL setting to false", zap.String("schema", schema), zap.String("table", table),
 					zap.String("sql", sql), zap.Int64("commit ts", commitTS))
 				// A empty sql force it to evict the downstream table info.

--- a/drainer/syncer.go
+++ b/drainer/syncer.go
@@ -492,7 +492,7 @@ ForLoop:
 					continue
 				}
 			} else if !ignore && s.cfg.DestDBType == "oracle" {
-				if _, ok := stmt.(*ast.TruncateTableStmt); !ok {
+				if _, ok := stmt.(*ast.TruncateTableStmt); !ok && s.cfg.SyncDDL {
 					err = errors.Errorf("unsupported ddl %s, you should skip commit ts %d", sql, commitTS)
 					break ForLoop
 				}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->
### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #1129

### What is changed and how it works?
add SyncDDL switcher to the process  that is whether drainer server should stop when non 'truncate table **' statement sync to drainer.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note

### Release note

<!-- bugfix or new feature needs a release note -->

- No release note
