### PR TITLE
sync/kafka: handle success messages in order

### DIFF
--- a/drainer/sync/kafka_test.go
+++ b/drainer/sync/kafka_test.go
@@ -1,0 +1,54 @@
+package sync
+
+import (
+	"github.com/pingcap/check"
+	pb "github.com/pingcap/tipb/go-binlog"
+)
+
+var _ = check.Suite(&kafkaSuite{})
+
+type kafkaSuite struct {
+}
+
+func newMockItem(ts int64) *Item {
+	return &Item{Binlog: &pb.Binlog{CommitTs: ts}}
+}
+
+func (s kafkaSuite) TestAckWindow(c *check.C) {
+	win := newAckWindow()
+	_, ok := win.getReadyItem()
+	c.Assert(ok, check.IsFalse)
+
+	win.appendTS(1, 101)
+	win.appendTS(3, 102)
+	win.appendTS(7, 103)
+	_, ok = win.getReadyItem()
+	c.Assert(ok, check.IsFalse)
+	c.Assert(win.unackedCount, check.Equals, 3)
+	c.Assert(win.unackedSize, check.Equals, 306)
+
+	win.handleSuccess(newMockItem(3))
+	_, ok = win.getReadyItem()
+	c.Assert(ok, check.IsFalse)
+	c.Assert(win.unackedCount, check.Equals, 2)
+	c.Assert(win.unackedSize, check.Equals, 204)
+
+	win.handleSuccess(newMockItem(7))
+	_, ok = win.getReadyItem()
+	c.Assert(ok, check.IsFalse)
+	c.Assert(win.unackedCount, check.Equals, 1)
+	c.Assert(win.unackedSize, check.Equals, 101)
+
+	win.handleSuccess(newMockItem(1))
+	c.Assert(win.unackedCount, check.Equals, 0)
+	c.Assert(win.unackedSize, check.Equals, 0)
+	item, ok := win.getReadyItem()
+	c.Assert(ok, check.IsTrue)
+	c.Assert(item.Binlog.GetCommitTs(), check.Equals, int64(1))
+	item, ok = win.getReadyItem()
+	c.Assert(ok, check.IsTrue)
+	c.Assert(item.Binlog.GetCommitTs(), check.Equals, int64(3))
+	item, ok = win.getReadyItem()
+	c.Assert(ok, check.IsTrue)
+	c.Assert(item.Binlog.GetCommitTs(), check.Equals, int64(7))
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close https://github.com/pingcap/tidb-binlog/issues/1136

### What is changed and how it works?

Add `ackWindow` to handle success message from `AsyncProducer` in order. `ackWindow` is a sliding window
 that ensure in-order delivery success item. It appends unacked commit ts on the window rightmost  and pop ready acked item from the window leftmost. If the first item is unacked, it doesn't delivery anything.

## Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Side effects

 - Possible performance regression
 - Increased code complexity


Related changes

 - Need to cherry-pick to the release branch


### Release note

<!-- bugfix or new feature needs a release note -->

- sync/kafka: handle success messages in order
