### PR TITLE
drainer/translater: fix the bug that drainer writes incorrect time data

### DIFF
--- a/drainer/pump.go
+++ b/drainer/pump.go
@@ -177,7 +177,7 @@ func (p *Pump) PullBinlog(pctx context.Context, last int64) chan MergeItem {
 				p.reportErr(pctx, err)
 				return
 			}
-			resp.Entity.Payload = resp.Entity.Payload[:0]
+			resp.Entity.Payload = nil // GC
 
 			millisecond := time.Now().UnixNano()/1000000 - oracle.ExtractPhysical(uint64(binlog.CommitTs))
 			binlogReachDurationHistogram.WithLabelValues(p.nodeID).Observe(float64(millisecond) / 1000.0)

--- a/drainer/pump.go
+++ b/drainer/pump.go
@@ -165,7 +165,8 @@ func (p *Pump) PullBinlog(pctx context.Context, last int64) chan MergeItem {
 			payloadSize := len(resp.Entity.Payload)
 			readBinlogSizeHistogram.WithLabelValues(p.nodeID).Observe(float64(payloadSize))
 			if len(resp.Entity.Payload) >= 10*1024*1024 {
-				log.Info("receive big size binlog", zap.String("size", humanize.Bytes(uint64(payloadSize))))
+				p.logger.Info("receive big size binlog before unmarshal", zap.String("size", humanize.Bytes(uint64(payloadSize))),
+					zap.Int64("start ts", resp.Entity.Meta.StartTs), zap.Int64("commit ts", resp.Entity.Meta.CommitTs))
 			}
 
 			binlog := new(pb.Binlog)
@@ -176,6 +177,7 @@ func (p *Pump) PullBinlog(pctx context.Context, last int64) chan MergeItem {
 				p.reportErr(pctx, err)
 				return
 			}
+			resp.Entity.Payload = resp.Entity.Payload[:0]
 
 			millisecond := time.Now().UnixNano()/1000000 - oracle.ExtractPhysical(uint64(binlog.CommitTs))
 			binlogReachDurationHistogram.WithLabelValues(p.nodeID).Observe(float64(millisecond) / 1000.0)

--- a/drainer/sync/kafka.go
+++ b/drainer/sync/kafka.go
@@ -22,10 +22,11 @@ import (
 	"github.com/Shopify/sarama"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
-	"github.com/pingcap/tidb-binlog/drainer/translator"
-	"github.com/pingcap/tidb-binlog/pkg/util"
 	obinlog "github.com/pingcap/tidb-tools/tidb-binlog/proto/go-binlog"
 	"go.uber.org/zap"
+
+	"github.com/pingcap/tidb-binlog/drainer/translator"
+	"github.com/pingcap/tidb-binlog/pkg/util"
 )
 
 var maxWaitTimeToSendMSG = time.Second * 30
@@ -68,7 +69,7 @@ func NewKafka(cfg *DBConfig, tableInfoGetter translator.TableInfoGetter) (*Kafka
 		topic:      topic,
 		ackWindow:  newAckWindow(),
 		shutdown:   make(chan struct{}),
-		baseSyncer: newBaseSyncer(tableInfoGetter),
+		baseSyncer: newBaseSyncer(tableInfoGetter, nil),
 	}
 
 	config, err := util.NewSaramaConfig(cfg.KafkaVersion, "kafka.")

--- a/drainer/sync/mysql.go
+++ b/drainer/sync/mysql.go
@@ -14,13 +14,18 @@
 package sync
 
 import (
+	"context"
 	"database/sql"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
+	"github.com/pingcap/tidb-tools/pkg/dbutil"
+	"github.com/pingcap/tidb/types"
 	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/zap"
 
 	"github.com/pingcap/tidb-binlog/drainer/loopbacksync"
 	"github.com/pingcap/tidb-binlog/drainer/relay"
@@ -132,11 +137,20 @@ func NewMysqlSyncer(
 		return nil, errors.Trace(err)
 	}
 
+	tzStr := ""
+	if len(cfg.Params) > 0 {
+		tzStr = cfg.Params["time_zone"]
+	}
+	timeZone, err := str2TimezoneOrFromDB(tzStr, db)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	s := &MysqlSyncer{
 		db:         db,
 		loader:     loader,
 		relayer:    relayer,
-		baseSyncer: newBaseSyncer(tableInfoGetter),
+		baseSyncer: newBaseSyncer(tableInfoGetter, timeZone),
 	}
 
 	go s.run()
@@ -167,6 +181,57 @@ func relaxSQLMode(db *sql.DB) (oldMode string, newMode string, err error) {
 	return
 }
 
+func str2TimezoneOrFromDB(tzStr string, db *sql.DB) (*time.Location, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	var err error
+	if len(tzStr) == 0 {
+		dur, err := dbutil.GetTimeZoneOffset(ctx, db)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		tzStr = dbutil.FormatTimeZoneOffset(dur)
+	}
+	if tzStr == "SYSTEM" || tzStr == "Local" {
+		return nil, errors.New("'SYSTEM' or 'Local' time_zone is not supported")
+	}
+
+	loc, err := time.LoadLocation(tzStr)
+	if err == nil {
+		return loc, nil
+	}
+
+	// The value can be given as a string indicating an offset from UTC, such as '+10:00' or '-6:00'.
+	// The time zone's value should in [-12:59,+14:00].
+	// See: https://dev.mysql.com/doc/refman/8.0/en/time-zone-support.html#time-zone-variables
+	if strings.HasPrefix(tzStr, "+") || strings.HasPrefix(tzStr, "-") {
+		d, err := types.ParseDuration(nil, tzStr[1:], 0)
+		if err == nil {
+			if tzStr[0] == '-' {
+				if d.Duration > 12*time.Hour+59*time.Minute {
+					return nil, errors.Errorf("invalid timezone %s", tzStr)
+				}
+			} else {
+				if d.Duration > 14*time.Hour {
+					return nil, errors.Errorf("invalid timezone %s", tzStr)
+				}
+			}
+
+			ofst := int(d.Duration / time.Second)
+			if tzStr[0] == '-' {
+				ofst = -ofst
+			}
+			name := dbutil.FormatTimeZoneOffset(d.Duration)
+			return time.FixedZone(name, ofst), nil
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	log.Info("use timezone", zap.String("location", loc.String()))
+	return loc, nil
+}
+
 // SetSafeMode make the MysqlSyncer to use safe mode or not
 func (m *MysqlSyncer) SetSafeMode(mode bool) bool {
 	m.loader.SetSafeMode(mode)
@@ -184,7 +249,7 @@ func (m *MysqlSyncer) Sync(item *Item) error {
 		item.RelayLogPos = pos
 	}
 
-	txn, err := translator.TiBinlogToTxn(m.tableInfoGetter, item.Schema, item.Table, item.Binlog, item.PrewriteValue, item.ShouldSkip)
+	txn, err := translator.TiBinlogToTxn(m.tableInfoGetter, item.Schema, item.Table, item.Binlog, item.PrewriteValue, item.ShouldSkip, m.timeZone)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/drainer/sync/mysql_test.go
+++ b/drainer/sync/mysql_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/pingcap/check"
 	"github.com/pingcap/errors"
+
 	"github.com/pingcap/tidb-binlog/drainer/relay"
 	"github.com/pingcap/tidb-binlog/drainer/translator"
 	"github.com/pingcap/tidb-binlog/pkg/binlogfile"
@@ -59,7 +60,7 @@ func (s *mysqlSuite) TestMySQLSyncerAvoidBlock(c *check.C) {
 	syncer := &MysqlSyncer{
 		db:         db,
 		loader:     fakeMySQLLoaderImpl,
-		baseSyncer: newBaseSyncer(infoGetter),
+		baseSyncer: newBaseSyncer(infoGetter, nil),
 	}
 	go syncer.run()
 	gen := translator.BinlogGenerator{}
@@ -134,7 +135,7 @@ func (s *mysqlSuite) TestMySQLSyncerWithRelayer(c *check.C) {
 		db:         db,
 		loader:     fakeMySQLLoaderImpl,
 		relayer:    relayer,
-		baseSyncer: newBaseSyncer(infoGetter),
+		baseSyncer: newBaseSyncer(infoGetter, nil),
 	}
 	defer syncer.Close()
 

--- a/drainer/sync/oracle.go
+++ b/drainer/sync/oracle.go
@@ -6,11 +6,12 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
+	router "github.com/pingcap/tidb-tools/pkg/table-router"
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/pingcap/tidb-binlog/drainer/relay"
 	"github.com/pingcap/tidb-binlog/drainer/translator"
 	"github.com/pingcap/tidb-binlog/pkg/loader"
-	router "github.com/pingcap/tidb-tools/pkg/table-router"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 var _ Syncer = &OracleSyncer{}
@@ -55,7 +56,7 @@ func NewOracleSyncer(
 		db:          db,
 		loader:      loader,
 		relayer:     relayer,
-		baseSyncer:  newBaseSyncer(tableInfoGetter),
+		baseSyncer:  newBaseSyncer(tableInfoGetter, nil),
 		tableRouter: tableRouter,
 	}
 

--- a/drainer/sync/oracle_test.go
+++ b/drainer/sync/oracle_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/pingcap/check"
 	"github.com/pingcap/errors"
+
 	"github.com/pingcap/tidb-binlog/drainer/relay"
 	"github.com/pingcap/tidb-binlog/drainer/translator"
 	"github.com/pingcap/tidb-binlog/pkg/binlogfile"
@@ -83,7 +84,7 @@ func (s *oracleSuite) TestOracleSyncerAvoidBlock(c *check.C) {
 	syncer := &OracleSyncer{
 		db:          db,
 		loader:      fakeOracleLoaderImpl,
-		baseSyncer:  newBaseSyncer(infoGetter),
+		baseSyncer:  newBaseSyncer(infoGetter, nil),
 		tableRouter: router,
 	}
 	go syncer.run()
@@ -163,7 +164,7 @@ func (s *oracleSuite) TestOracleSyncerWithRelayer(c *check.C) {
 		db:          db,
 		loader:      fakeOracleLoaderImpl,
 		relayer:     relayer,
-		baseSyncer:  newBaseSyncer(infoGetter),
+		baseSyncer:  newBaseSyncer(infoGetter, nil),
 		tableRouter: router,
 	}
 	defer syncer.Close()

--- a/drainer/sync/pb.go
+++ b/drainer/sync/pb.go
@@ -46,7 +46,7 @@ func NewPBSyncer(dir string, retentionDays int, tableInfoGetter translator.Table
 
 	s := &pbSyncer{
 		binlogger:  binlogger,
-		baseSyncer: newBaseSyncer(tableInfoGetter),
+		baseSyncer: newBaseSyncer(tableInfoGetter, nil),
 		cancel:     cancel,
 	}
 

--- a/drainer/sync/syncer.go
+++ b/drainer/sync/syncer.go
@@ -15,9 +15,11 @@ package sync
 
 import (
 	"fmt"
+	"time"
+
+	pb "github.com/pingcap/tipb/go-binlog"
 
 	"github.com/pingcap/tidb-binlog/drainer/translator"
-	pb "github.com/pingcap/tipb/go-binlog"
 )
 
 // Item contains information about binlog
@@ -64,13 +66,18 @@ type baseSyncer struct {
 	*baseError
 	success         chan *Item
 	tableInfoGetter translator.TableInfoGetter
+	timeZone        *time.Location
 }
 
-func newBaseSyncer(tableInfoGetter translator.TableInfoGetter) *baseSyncer {
+func newBaseSyncer(tableInfoGetter translator.TableInfoGetter, timeZone *time.Location) *baseSyncer {
+	if timeZone == nil {
+		timeZone = time.Local
+	}
 	return &baseSyncer{
 		baseError:       newBaseError(),
 		success:         make(chan *Item, 8),
 		tableInfoGetter: tableInfoGetter,
+		timeZone:        timeZone,
 	}
 }
 

--- a/drainer/sync/syncer_test.go
+++ b/drainer/sync/syncer_test.go
@@ -74,7 +74,7 @@ func (s *syncerSuite) SetUpTest(c *check.C) {
 
 	mysql, err := NewMysqlSyncer(cfg, infoGetter, 1, 1, nil, nil, "mysql", nil, nil, true, true)
 	c.Assert(err, check.IsNil)
-	c.Assert(mysql.timeZone, check.Equals, time.FixedZone("+08:00", 8*60*60))
+	c.Assert(mysql.timeZone, check.DeepEquals, time.FixedZone("+08:00", 8*60*60))
 	s.syncers = append(s.syncers, mysql)
 
 	// create kafka syncer

--- a/drainer/syncer.go
+++ b/drainer/syncer.go
@@ -578,7 +578,7 @@ func findLoopBackMark(dmls []*loader.DML, info *loopbacksync.LoopBackSync) (bool
 func loopBackStatus(binlog *pb.Binlog, prewriteValue *pb.PrewriteValue, infoGetter translator.TableInfoGetter, info *loopbacksync.LoopBackSync) (bool, error) {
 	var tableName string
 	var schemaName string
-	txn, err := translator.TiBinlogToTxn(infoGetter, schemaName, tableName, binlog, prewriteValue, false)
+	txn, err := translator.TiBinlogToTxn(infoGetter, schemaName, tableName, binlog, prewriteValue, false, time.Local)
 	if err != nil {
 		return false, errors.Trace(err)
 	}

--- a/drainer/translator/kafka.go
+++ b/drainer/translator/kafka.go
@@ -23,7 +23,6 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
-	"github.com/pingcap/tidb-binlog/pkg/util"
 	obinlog "github.com/pingcap/tidb-tools/tidb-binlog/proto/go-binlog"
 	"github.com/pingcap/tidb/parser/model"
 	"github.com/pingcap/tidb/parser/mysql"
@@ -31,6 +30,8 @@ import (
 	"github.com/pingcap/tidb/types"
 	pb "github.com/pingcap/tipb/go-binlog"
 	"go.uber.org/zap"
+
+	"github.com/pingcap/tidb-binlog/pkg/util"
 )
 
 // TiBinlogToSecondaryBinlog translates the format to secondary binlog
@@ -149,7 +150,7 @@ func genTable(schema string, tableInfo *model.TableInfo) (table *obinlog.Table) 
 }
 
 func insertRowToRow(ptableInfo, tableInfo *model.TableInfo, raw []byte) (row *obinlog.Row, err error) {
-	columnValues, err := insertRowToDatums(tableInfo, raw)
+	columnValues, err := insertRowToDatums(tableInfo, raw, time.Local)
 	columns := tableInfo.Columns
 
 	row = new(obinlog.Row)

--- a/drainer/translator/mysql.go
+++ b/drainer/translator/mysql.go
@@ -20,21 +20,22 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
-	"github.com/pingcap/tidb-binlog/pkg/loader"
-	"github.com/pingcap/tidb-binlog/pkg/util"
 	"github.com/pingcap/tidb/parser/model"
 	"github.com/pingcap/tidb/parser/mysql"
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/types"
 	tipb "github.com/pingcap/tipb/go-binlog"
+
+	"github.com/pingcap/tidb-binlog/pkg/loader"
+	"github.com/pingcap/tidb-binlog/pkg/util"
 )
 
 const implicitColID = -1
 
-func genDBInsert(schema string, ptable, table *model.TableInfo, row []byte) (names []string, args []interface{}, err error) {
+func genDBInsert(schema string, ptable, table *model.TableInfo, row []byte, loc *time.Location) (names []string, args []interface{}, err error) {
 	columns := writableColumns(table)
 
-	columnValues, err := insertRowToDatums(table, row)
+	columnValues, err := insertRowToDatums(table, row, loc)
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
@@ -58,13 +59,13 @@ func genDBInsert(schema string, ptable, table *model.TableInfo, row []byte) (nam
 	return names, args, nil
 }
 
-func genDBUpdate(schema string, ptable, table *model.TableInfo, row []byte, canAppendDefaultValue bool) (names []string, values []interface{}, oldValues []interface{}, err error) {
+func genDBUpdate(schema string, ptable, table *model.TableInfo, row []byte, canAppendDefaultValue bool, loc *time.Location) (names []string, values []interface{}, oldValues []interface{}, err error) {
 	columns := writableColumns(table)
 	updtDecoder := newUpdateDecoder(ptable, table, canAppendDefaultValue)
 
 	var updateColumns []*model.ColumnInfo
 
-	oldColumnValues, newColumnValues, err := updtDecoder.decode(row, time.Local)
+	oldColumnValues, newColumnValues, err := updtDecoder.decode(row, loc)
 	if err != nil {
 		return nil, nil, nil, errors.Annotatef(err, "table `%s`.`%s`", schema, table.Name)
 	}
@@ -84,11 +85,11 @@ func genDBUpdate(schema string, ptable, table *model.TableInfo, row []byte, canA
 	return
 }
 
-func genDBDelete(schema string, table *model.TableInfo, row []byte) (names []string, values []interface{}, err error) {
+func genDBDelete(schema string, table *model.TableInfo, row []byte, loc *time.Location) (names []string, values []interface{}, err error) {
 	columns := table.Columns
 	colsTypeMap := util.ToColumnTypeMap(columns)
 
-	columnValues, err := tablecodec.DecodeRowToDatumMap(row, colsTypeMap, time.Local)
+	columnValues, err := tablecodec.DecodeRowToDatumMap(row, colsTypeMap, loc)
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
@@ -104,7 +105,7 @@ func genDBDelete(schema string, table *model.TableInfo, row []byte) (names []str
 }
 
 // TiBinlogToTxn translate the format to loader.Txn
-func TiBinlogToTxn(infoGetter TableInfoGetter, schema string, table string, tiBinlog *tipb.Binlog, pv *tipb.PrewriteValue, shouldSkip bool) (txn *loader.Txn, err error) {
+func TiBinlogToTxn(infoGetter TableInfoGetter, schema string, table string, tiBinlog *tipb.Binlog, pv *tipb.PrewriteValue, shouldSkip bool, loc *time.Location) (txn *loader.Txn, err error) {
 	txn = new(loader.Txn)
 
 	if tiBinlog.DdlJobId > 0 {
@@ -144,7 +145,7 @@ func TiBinlogToTxn(infoGetter TableInfoGetter, schema string, table string, tiBi
 
 				switch mutType {
 				case tipb.MutationType_Insert:
-					names, args, err := genDBInsert(schema, pinfo, info, row)
+					names, args, err := genDBInsert(schema, pinfo, info, row, loc)
 					if err != nil {
 						return nil, errors.Annotate(err, "gen insert fail")
 					}
@@ -160,7 +161,7 @@ func TiBinlogToTxn(infoGetter TableInfoGetter, schema string, table string, tiBi
 						dml.Values[name] = args[i]
 					}
 				case tipb.MutationType_Update:
-					names, args, oldArgs, err := genDBUpdate(schema, pinfo, info, row, canAppendDefaultValue)
+					names, args, oldArgs, err := genDBUpdate(schema, pinfo, info, row, canAppendDefaultValue, loc)
 					if err != nil {
 						return nil, errors.Annotate(err, "gen update fail")
 					}
@@ -179,7 +180,7 @@ func TiBinlogToTxn(infoGetter TableInfoGetter, schema string, table string, tiBi
 					}
 
 				case tipb.MutationType_DeleteRow:
-					names, args, err := genDBDelete(schema, info, row)
+					names, args, err := genDBDelete(schema, info, row, loc)
 					if err != nil {
 						return nil, errors.Annotate(err, "gen delete fail")
 					}

--- a/drainer/translator/mysql_test.go
+++ b/drainer/translator/mysql_test.go
@@ -15,12 +15,14 @@ package translator
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/pingcap/check"
-	"github.com/pingcap/tidb-binlog/pkg/loader"
 	"github.com/pingcap/tidb/parser/model"
 	"github.com/pingcap/tidb/parser/mysql"
 	"github.com/pingcap/tidb/types"
+
+	"github.com/pingcap/tidb-binlog/pkg/loader"
 )
 
 type testMysqlSuite struct {
@@ -37,7 +39,7 @@ func (t *testMysqlSuite) TestGenColumnList(c *check.C) {
 func (t *testMysqlSuite) TestDDL(c *check.C) {
 	t.SetDDL()
 
-	txn, err := TiBinlogToTxn(t, t.Schema, t.Table, t.TiBinlog, nil, true)
+	txn, err := TiBinlogToTxn(t, t.Schema, t.Table, t.TiBinlog, nil, true, time.Local)
 	c.Assert(err, check.IsNil)
 
 	c.Assert(txn, check.DeepEquals, &loader.Txn{
@@ -51,7 +53,7 @@ func (t *testMysqlSuite) TestDDL(c *check.C) {
 }
 
 func (t *testMysqlSuite) testDML(c *check.C, tp loader.DMLType) {
-	txn, err := TiBinlogToTxn(t, t.Schema, t.Table, t.TiBinlog, t.PV, false)
+	txn, err := TiBinlogToTxn(t, t.Schema, t.Table, t.TiBinlog, t.PV, false, time.Local)
 	c.Assert(err, check.IsNil)
 
 	c.Assert(txn.DMLs, check.HasLen, 1)

--- a/drainer/translator/oracle.go
+++ b/drainer/translator/oracle.go
@@ -4,12 +4,14 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 
 	"github.com/pingcap/errors"
-	"github.com/pingcap/tidb-binlog/pkg/loader"
 	router "github.com/pingcap/tidb-tools/pkg/table-router"
 	"github.com/pingcap/tidb/parser/model"
 	tipb "github.com/pingcap/tipb/go-binlog"
+
+	"github.com/pingcap/tidb-binlog/pkg/loader"
 )
 
 // TiBinlogToOracleTxn translate the format to loader.Txn
@@ -66,7 +68,7 @@ func TiBinlogToOracleTxn(infoGetter TableInfoGetter, schema string, table string
 
 				switch mutType {
 				case tipb.MutationType_Insert:
-					names, args, err := genDBInsert(schema, pinfo, info, row)
+					names, args, err := genDBInsert(schema, pinfo, info, row, time.Local)
 					if err != nil {
 						return nil, errors.Annotate(err, "gen insert fail")
 					}
@@ -83,7 +85,7 @@ func TiBinlogToOracleTxn(infoGetter TableInfoGetter, schema string, table string
 						dml.Values[strings.ToUpper(name)] = args[i]
 					}
 				case tipb.MutationType_Update:
-					names, args, oldArgs, err := genDBUpdate(schema, pinfo, info, row, canAppendDefaultValue)
+					names, args, oldArgs, err := genDBUpdate(schema, pinfo, info, row, canAppendDefaultValue, time.Local)
 					if err != nil {
 						return nil, errors.Annotate(err, "gen update fail")
 					}
@@ -103,7 +105,7 @@ func TiBinlogToOracleTxn(infoGetter TableInfoGetter, schema string, table string
 					}
 
 				case tipb.MutationType_DeleteRow:
-					names, args, err := genDBDelete(schema, info, row)
+					names, args, err := genDBDelete(schema, info, row, time.Local)
 					if err != nil {
 						return nil, errors.Annotate(err, "gen delete fail")
 					}

--- a/drainer/translator/pb.go
+++ b/drainer/translator/pb.go
@@ -116,7 +116,7 @@ func TiBinlogToPbBinlog(infoGetter TableInfoGetter, schema string, table string,
 func genInsert(schema string, ptable, table *model.TableInfo, row []byte) (event *pb.Event, err error) {
 	columns := table.Columns
 
-	columnValues, err := insertRowToDatums(table, row)
+	columnValues, err := insertRowToDatums(table, row, time.Local)
 	if err != nil {
 		return nil, errors.Annotatef(err, "table `%s`.`%s`", schema, table.Name)
 	}

--- a/drainer/translator/translator.go
+++ b/drainer/translator/translator.go
@@ -37,7 +37,7 @@ func SetSQLMode(mode mysql.SQLMode) {
 	sqlMode = mode
 }
 
-func insertRowToDatums(table *model.TableInfo, row []byte) (datums map[int64]types.Datum, err error) {
+func insertRowToDatums(table *model.TableInfo, row []byte, loc *time.Location) (datums map[int64]types.Datum, err error) {
 	colsTypeMap := util.ToColumnTypeMap(table.Columns)
 
 	var (
@@ -69,7 +69,7 @@ func insertRowToDatums(table *model.TableInfo, row []byte) (datums map[int64]typ
 		}
 		if table.IsCommonHandle {
 			// clustered index could be complex type that need Unflatten from raw datum.
-			aPK, err = tablecodec.Unflatten(aPK, &table.Columns[commonPKInfo.Columns[i].Offset].FieldType, time.Local)
+			aPK, err = tablecodec.Unflatten(aPK, &table.Columns[commonPKInfo.Columns[i].Offset].FieldType, loc)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
@@ -77,7 +77,7 @@ func insertRowToDatums(table *model.TableInfo, row []byte) (datums map[int64]typ
 		pk = append(pk, aPK)
 	}
 
-	datums, err = tablecodec.DecodeRowToDatumMap(remain, colsTypeMap, time.Local)
+	datums, err = tablecodec.DecodeRowToDatumMap(remain, colsTypeMap, loc)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/pump/storage/storage_test.go
+++ b/pump/storage/storage_test.go
@@ -250,8 +250,10 @@ func (as *AppendSuit) testWriteBinlogAndPullBack(c *check.C, prewriteValueSize i
 			select {
 			case value := <-values:
 				getBinlog := new(pb.Binlog)
-				err := getBinlog.Unmarshal(value)
+				err := getBinlog.Unmarshal(value.Payload)
 				c.Assert(err, check.IsNil)
+				c.Assert(getBinlog.StartTs, check.Equals, value.Meta.StartTs)
+				c.Assert(getBinlog.CommitTs, check.Equals, value.Meta.CommitTs)
 				binlogs = append(binlogs, getBinlog)
 				if len(binlogs) == int(binlogNum) {
 					break PullLoop

--- a/tests/binlog/run.sh
+++ b/tests/binlog/run.sh
@@ -4,6 +4,16 @@ set -e
 
 cd "$(dirname "$0")"
 
+function revert_timezone() {
+    run_sql "SET @@global.time_zone = 'SYSTEM';"
+    down_run_sql "SET @@global.time_zone = 'SYSTEM';"
+}
+
+# set timezone to others before drainer starts
+trap revert_timezone EXIT
+run_sql "SET @@global.time_zone = 'Asia/Shanghai';"
+down_run_sql "SET @@global.time_zone = 'America/New_York';"
+
 run_drainer &
 
 GO111MODULE=on go build -o out

--- a/tests/binlog/run.sh
+++ b/tests/binlog/run.sh
@@ -11,7 +11,7 @@ function revert_timezone() {
 
 # set timezone to others before drainer starts
 trap revert_timezone EXIT
-run_sql "SET @@global.time_zone = 'Asia/Shanghai';"
+run_sql "SET @@global.time_zone = 'Asia/Tokyo';"
 down_run_sql "SET @@global.time_zone = 'EST';"
 
 run_drainer &

--- a/tests/binlog/run.sh
+++ b/tests/binlog/run.sh
@@ -12,7 +12,7 @@ function revert_timezone() {
 # set timezone to others before drainer starts
 trap revert_timezone EXIT
 run_sql "SET @@global.time_zone = 'Asia/Shanghai';"
-down_run_sql "SET @@global.time_zone = 'America/New_York';"
+down_run_sql "SET @@global.time_zone = 'EST';"
 
 run_drainer &
 

--- a/tests/dailytest/case.go
+++ b/tests/dailytest/case.go
@@ -379,6 +379,8 @@ func RunCase(src *sql.DB, dst *sql.DB, schema string) {
 		}
 	})
 	tr.execSQLs([]string{"DROP TABLE binlog_big;"})
+
+	runTimeZoneCase(tr)
 }
 
 func caseUpdateWhileAddingCol(db *sql.DB) {
@@ -708,6 +710,74 @@ func runPKcases(tr *testRunner) {
 			})
 
 			tr.execSQLs([]string{"DROP TABLE pk"})
+		}
+	}
+}
+
+func runTimeZoneCase(tr *testRunner) {
+	// set downstream default time_zone to UTC, upstream default time_zone to Asia/Shanghai
+	const setGlobalTimeZoneSql = "SET @@global.time_zone = ?;"
+	mustExec(tr.src, setGlobalTimeZoneSql, "Asia/Shanghai")
+	defer mustExec(tr.src, setGlobalTimeZoneSql, "SYSTEM")
+	mustExec(tr.dst, setGlobalTimeZoneSql, "America/New_York")
+	defer mustExec(tr.dst, setGlobalTimeZoneSql, "SYSTEM")
+
+	cases := []struct {
+		Tp     string
+		Value  interface{}
+		Update interface{}
+	}{
+		{
+			Tp:     "TIMESTAMP",
+			Value:  "2022-04-27 04:05:07",
+			Update: "2021-04-27 04:05:06",
+		},
+		{
+			Tp:     "DATETIME",
+			Value:  "2022-04-27 04:05:07",
+			Update: "2021-04-27 04:05:06",
+		},
+		{
+			Tp:     "DATE",
+			Value:  "2022-04-27",
+			Update: "2022-04-26",
+		},
+		{
+			Tp:     "TIME",
+			Value:  "04:05:07",
+			Update: "04:05:06",
+		},
+		{
+			Tp:     "YEAR",
+			Value:  "2022",
+			Update: "2021",
+		},
+	}
+	for _, c := range cases {
+		for _, ispk := range []string{"", "PRIMARY KEY NONCLUSTERED", "PRIMARY KEY CLUSTERED"} {
+			var caseSql string
+			tr.run(func(src *sql.DB) {
+				caseSql = fmt.Sprintf("CREATE TABLE tz(t %s %s)", c.Tp, ispk)
+				mustExec(src, caseSql)
+				caseSql = "INSERT INTO tz(t) values( ? )"
+				mustExec(src, caseSql, c.Value)
+			})
+			if len(ispk) == 0 {
+				tr.run(func(src *sql.DB) {
+					// insert a null value
+					mustExec(src, caseSql, nil)
+				})
+			}
+			tr.run(func(src *sql.DB) {
+				caseSql = "UPDATE tz set t = ? where t = ?"
+				mustExec(src, caseSql, c.Update, c.Value)
+			})
+			tr.run(func(src *sql.DB) {
+				caseSql = "DELETE from tz where t = ?"
+				mustExec(src, caseSql, c.Update)
+			})
+
+			tr.execSQLs([]string{"DROP TABLE tz"})
 		}
 	}
 }

--- a/tests/dailytest/case.go
+++ b/tests/dailytest/case.go
@@ -715,13 +715,6 @@ func runPKcases(tr *testRunner) {
 }
 
 func runTimeZoneCase(tr *testRunner) {
-	// set downstream default time_zone to UTC, upstream default time_zone to Asia/Shanghai
-	const setGlobalTimeZoneSql = "SET @@global.time_zone = ?;"
-	mustExec(tr.src, setGlobalTimeZoneSql, "Asia/Shanghai")
-	defer mustExec(tr.src, setGlobalTimeZoneSql, "SYSTEM")
-	mustExec(tr.dst, setGlobalTimeZoneSql, "America/New_York")
-	defer mustExec(tr.dst, setGlobalTimeZoneSql, "SYSTEM")
-
 	cases := []struct {
 		Tp     string
 		Value  interface{}

--- a/tests/dailytest/case.go
+++ b/tests/dailytest/case.go
@@ -748,26 +748,26 @@ func runTimeZoneCase(tr *testRunner) {
 	}
 	for _, c := range cases {
 		for _, ispk := range []string{"", "PRIMARY KEY NONCLUSTERED", "PRIMARY KEY CLUSTERED"} {
-			var caseSql string
+			var caseSQL string
 			tr.run(func(src *sql.DB) {
-				caseSql = fmt.Sprintf("CREATE TABLE tz(t %s %s)", c.Tp, ispk)
-				mustExec(src, caseSql)
-				caseSql = "INSERT INTO tz(t) values( ? )"
-				mustExec(src, caseSql, c.Value)
+				caseSQL = fmt.Sprintf("CREATE TABLE tz(t %s %s)", c.Tp, ispk)
+				mustExec(src, caseSQL)
+				caseSQL = "INSERT INTO tz(t) values( ? )"
+				mustExec(src, caseSQL, c.Value)
 			})
 			if len(ispk) == 0 {
 				tr.run(func(src *sql.DB) {
 					// insert a null value
-					mustExec(src, caseSql, nil)
+					mustExec(src, caseSQL, nil)
 				})
 			}
 			tr.run(func(src *sql.DB) {
-				caseSql = "UPDATE tz set t = ? where t = ?"
-				mustExec(src, caseSql, c.Update, c.Value)
+				caseSQL = "UPDATE tz set t = ? where t = ?"
+				mustExec(src, caseSQL, c.Update, c.Value)
 			})
 			tr.run(func(src *sql.DB) {
-				caseSql = "DELETE from tz where t = ?"
-				mustExec(src, caseSql, c.Update)
+				caseSQL = "DELETE from tz where t = ?"
+				mustExec(src, caseSQL, c.Update)
 			})
 
 			tr.execSQLs([]string{"DROP TABLE tz"})


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close https://github.com/pingcap/tidb-binlog/issues/1159

### What is changed and how it works?
Adjust drainer's timestamp data to downstream's timezone for mysql/tidb.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - Has exported function/method change

Side effects

- None

Related changes

 - Need to cherry-pick to the release branch

### Release note

<!-- bugfix or new feature needs a release note -->

- fix the bug that drainer writes incorrect time data when drainer and downstream database are not in a seem time zone
