### PR TITLE
drainer: rtrim char type column in sql

### DIFF
--- a/pkg/loader/model.go
+++ b/pkg/loader/model.go
@@ -270,12 +270,21 @@ func (dml *DML) buildOracleWhere(builder *strings.Builder, oracleHolderPos int) 
 		if wargs[i] == nil || wargs[i] == "" {
 			builder.WriteString(escapeName(wnames[i]) + " IS NULL")
 		} else {
-			builder.WriteString(fmt.Sprintf("%s = :%d", escapeName(wnames[i]), pOracleHolderPos))
+			builder.WriteString(fmt.Sprintf("%s = :%d", dml.processOracleColumn(escapeName(wnames[i])), pOracleHolderPos))
 			pOracleHolderPos++
 			args = append(args, wargs[i])
 		}
 	}
 	return
+}
+
+func (dml *DML) processOracleColumn(colName string) string {
+	dataType, _ := dml.info.dataTypeMap[colName]
+	switch dataType {
+	case "CHAR", "NCHAR":
+		return fmt.Sprintf("RTRIM(%s)", colName)
+	}
+	return colName
 }
 
 func (dml *DML) whereValues(names []string) (values []interface{}) {

--- a/pkg/loader/model.go
+++ b/pkg/loader/model.go
@@ -392,7 +392,7 @@ func (dml *DML) oracleDeleteNewValueSQL() (sql string, args []interface{}) {
 		if colValues[i] == nil || colValues[i] == "" {
 			builder.WriteString(escapeName(colNames[i]) + " IS NULL")
 		} else {
-			builder.WriteString(fmt.Sprintf("%s = :%d", colNames[i], oracleHolderPos))
+			builder.WriteString(fmt.Sprintf("%s = :%d", dml.processOracleColumn(escapeName(colNames[i])), oracleHolderPos))
 			oracleHolderPos++
 			args = append(args, colValues[i])
 		}

--- a/pkg/loader/model.go
+++ b/pkg/loader/model.go
@@ -279,7 +279,7 @@ func (dml *DML) buildOracleWhere(builder *strings.Builder, oracleHolderPos int) 
 }
 
 func (dml *DML) processOracleColumn(colName string) string {
-	dataType, _ := dml.info.dataTypeMap[colName]
+	dataType := dml.info.dataTypeMap[colName]
 	switch dataType {
 	case "CHAR", "NCHAR":
 		return fmt.Sprintf("RTRIM(%s)", colName)

--- a/pkg/loader/model.go
+++ b/pkg/loader/model.go
@@ -223,7 +223,7 @@ func (dml *DML) updateOracleSQL() (sql string, args []interface{}) {
 			builder.WriteByte(',')
 		}
 		arg := dml.Values[name]
-		fmt.Fprintf(builder, "%s = :%d", escapeName(name), oracleHolderPos)
+		fmt.Fprintf(builder, "%s = :%d", name, oracleHolderPos)
 		oracleHolderPos++
 		args = append(args, arg)
 	}
@@ -268,9 +268,9 @@ func (dml *DML) buildOracleWhere(builder *strings.Builder, oracleHolderPos int) 
 			builder.WriteString(" AND ")
 		}
 		if wargs[i] == nil || wargs[i] == "" {
-			builder.WriteString(escapeName(wnames[i]) + " IS NULL")
+			builder.WriteString(wnames[i] + " IS NULL")
 		} else {
-			builder.WriteString(fmt.Sprintf("%s = :%d", dml.processOracleColumn(escapeName(wnames[i])), pOracleHolderPos))
+			builder.WriteString(fmt.Sprintf("%s = :%d", dml.processOracleColumn(wnames[i]), pOracleHolderPos))
 			pOracleHolderPos++
 			args = append(args, wargs[i])
 		}
@@ -390,9 +390,9 @@ func (dml *DML) oracleDeleteNewValueSQL() (sql string, args []interface{}) {
 			builder.WriteString(" AND ")
 		}
 		if colValues[i] == nil || colValues[i] == "" {
-			builder.WriteString(escapeName(colNames[i]) + " IS NULL")
+			builder.WriteString(colNames[i] + " IS NULL")
 		} else {
-			builder.WriteString(fmt.Sprintf("%s = :%d", dml.processOracleColumn(escapeName(colNames[i])), oracleHolderPos))
+			builder.WriteString(fmt.Sprintf("%s = :%d", dml.processOracleColumn(colNames[i]), oracleHolderPos))
 			oracleHolderPos++
 			args = append(args, colValues[i])
 		}

--- a/pkg/loader/model_test.go
+++ b/pkg/loader/model_test.go
@@ -271,6 +271,59 @@ func (s *SQLSuite) TestUpdateMarkSQL(c *check.C) {
 	c.Assert(mock.ExpectationsWereMet(), check.IsNil)
 }
 
+func (s *SQLSuite) TestOracleUpdateSQLCharType(c *check.C) {
+	dml := DML{
+		Tp:       UpdateDMLType,
+		Database: "db",
+		Table:    "tbl",
+		Values: map[string]interface{}{
+			"ID":      123,
+			"NAME":    "pc",
+			"OFFER":   "oo",
+			"ADDRESS": "aa",
+		},
+		OldValues: map[string]interface{}{
+			"ID":      123,
+			"NAME":    "pingcap",
+			"OFFER":   "o",
+			"ADDRESS": "a",
+		},
+		info: &tableInfo{
+			columns: []string{"ID", "NAME", "OFFER", "ADDRESS"},
+			dataTypeMap: map[string]string{
+				"ID":      "VARCHAR2",
+				"NAME":    "VARCHAR2",
+				"OFFER":   "CHAR",
+				"ADDRESS": "NCHAR",
+			},
+		},
+		UpColumnsInfoMap: map[string]*model.ColumnInfo{
+			"ID": {
+				FieldType: types.FieldType{Tp: mysql.TypeInt24}},
+			"NAME": {
+				FieldType: types.FieldType{Tp: mysql.TypeVarString}},
+			"OFFER": {
+				FieldType: types.FieldType{Tp: mysql.TypeVarString}},
+			"ADDRESS": {
+				FieldType: types.FieldType{Tp: mysql.TypeVarString}},
+		},
+		DestDBType: OracleDB,
+	}
+	sql, args := dml.sql()
+	c.Assert(
+		sql, check.Equals,
+		"UPDATE db.tbl SET ADDRESS = :1,ID = :2,NAME = :3,OFFER = :4 WHERE RTRIM(ADDRESS) = :5 AND ID = :6 AND NAME = :7 AND RTRIM(OFFER) = :8 AND rownum <=1")
+	c.Assert(args, check.HasLen, 8)
+	c.Assert(args[0], check.Equals, "aa")
+	c.Assert(args[1], check.Equals, 123)
+	c.Assert(args[2], check.Equals, "pc")
+	c.Assert(args[3], check.Equals, "oo")
+	c.Assert(args[4], check.Equals, "a")
+	c.Assert(args[5], check.Equals, 123)
+	c.Assert(args[6], check.Equals, "pingcap")
+	c.Assert(args[7], check.Equals, "o")
+}
+
 func (s *SQLSuite) TestOracleUpdateSQL(c *check.C) {
 	dml := DML{
 		Tp:       UpdateDMLType,
@@ -387,6 +440,49 @@ func (s *SQLSuite) TestOracleUpdateSQLPrimaryKey(c *check.C) {
 	c.Assert(args[0], check.Equals, 123)
 	c.Assert(args[1], check.Equals, "pc")
 	c.Assert(args[2], check.Equals, 123)
+}
+
+func (s *SQLSuite) TestOracleDeleteSQLCharType(c *check.C) {
+	dml := DML{
+		Tp:       DeleteDMLType,
+		Database: "db",
+		Table:    "tbl",
+		Values: map[string]interface{}{
+			"ID":      123,
+			"NAME":    "pc",
+			"OFFER":   "o",
+			"ADDRESS": "a",
+		},
+		info: &tableInfo{
+			columns: []string{"ID", "NAME", "OFFER", "ADDRESS"},
+			dataTypeMap: map[string]string{
+				"ID":      "VARCHAR2",
+				"NAME":    "VARCHAR2",
+				"OFFER":   "CHAR",
+				"ADDRESS": "NCHAR",
+			},
+		},
+		UpColumnsInfoMap: map[string]*model.ColumnInfo{
+			"ID": {
+				FieldType: types.FieldType{Tp: mysql.TypeInt24}},
+			"NAME": {
+				FieldType: types.FieldType{Tp: mysql.TypeVarString}},
+			"OFFER": {
+				FieldType: types.FieldType{Tp: mysql.TypeVarString}},
+			"ADDRESS": {
+				FieldType: types.FieldType{Tp: mysql.TypeVarString}},
+		},
+		DestDBType: OracleDB,
+	}
+	sql, args := dml.sql()
+	c.Assert(
+		sql, check.Equals,
+		"DELETE FROM db.tbl WHERE RTRIM(ADDRESS) = :1 AND ID = :2 AND NAME = :3 AND RTRIM(OFFER) = :4 AND rownum <=1")
+	c.Assert(args, check.HasLen, 4)
+	c.Assert(args[0], check.Equals, "a")
+	c.Assert(args[1], check.Equals, 123)
+	c.Assert(args[2], check.Equals, "pc")
+	c.Assert(args[3], check.Equals, "o")
 }
 
 func (s *SQLSuite) TestOracleDeleteSQL(c *check.C) {
@@ -670,4 +766,48 @@ func (s *SQLSuite) TestOracleDeleteNewValueSQLEmptyString(c *check.C) {
 	c.Assert(args, check.HasLen, 2)
 	c.Assert(args[0], check.Equals, 123)
 	c.Assert(args[1], check.Equals, "456")
+}
+
+func (s *SQLSuite) TestOracleDeleteNewValueSQLCharType(c *check.C) {
+	dml := DML{
+		Tp:       InsertDMLType,
+		Database: "db",
+		Table:    "tbl",
+		Values: map[string]interface{}{
+			"ID":   123,
+			"ID2":  "456",
+			"NAME": "n",
+			"C2":   "c",
+		},
+		info: &tableInfo{
+			columns: []string{"ID", "ID2", "NAME", "C2"},
+			dataTypeMap: map[string]string{
+				"ID":   "VARCHAR2",
+				"ID2":  "VARCHAR2",
+				"NAME": "CHAR",
+				"C2":   "NCHAR",
+			},
+		},
+		UpColumnsInfoMap: map[string]*model.ColumnInfo{
+			"ID": {
+				FieldType: types.FieldType{Tp: mysql.TypeInt24}},
+			"ID2": {
+				FieldType: types.FieldType{Tp: mysql.TypeVarString}},
+			"NAME": {
+				FieldType: types.FieldType{Tp: mysql.TypeVarString}},
+			"C2": {
+				FieldType: types.FieldType{Tp: mysql.TypeVarString}},
+		},
+		DestDBType: OracleDB,
+	}
+
+	sql, args := dml.oracleDeleteNewValueSQL()
+	c.Assert(
+		sql, check.Equals,
+		"DELETE FROM db.tbl WHERE RTRIM(C2) = :1 AND ID = :2 AND ID2 = :3 AND RTRIM(NAME) = :4 AND rownum <=1")
+	c.Assert(args, check.HasLen, 4)
+	c.Assert(args[0], check.Equals, "c")
+	c.Assert(args[1], check.Equals, 123)
+	c.Assert(args[2], check.Equals, "456")
+	c.Assert(args[3], check.Equals, "n")
 }

--- a/pkg/loader/util.go
+++ b/pkg/loader/util.go
@@ -306,7 +306,7 @@ func buildColumnList(names []string, destDBType DBType) string {
 			b.WriteString(",")
 		}
 		if destDBType == OracleDB {
-			b.WriteString(escapeName(name))
+			b.WriteString(name)
 		} else {
 			b.WriteString(quoteName(name))
 		}

--- a/pkg/loader/util_test.go
+++ b/pkg/loader/util_test.go
@@ -90,15 +90,15 @@ func (cs *UtilSuite) TestGetOracleTableInfo(c *check.C) {
 	c.Assert(err, check.IsNil)
 	defer db.Close()
 
-	columnRows := sqlmock.NewRows([]string{"column_name"}).
-		AddRow("C1").
-		AddRow("C2").
-		AddRow("C3").
-		AddRow("C4").
-		AddRow("C5").
-		AddRow("C6").
-		AddRow("C7").
-		AddRow("C8")
+	columnRows := sqlmock.NewRows([]string{"column_name", "data_type"}).
+		AddRow("C1", "VARCHAR2").
+		AddRow("C2", "VARCHAR2").
+		AddRow("C3", "VARCHAR2").
+		AddRow("C4", "VARCHAR2").
+		AddRow("C5", "VARCHAR2").
+		AddRow("C6", "NUMBER").
+		AddRow("C7", "CHAR").
+		AddRow("C8", "NCHAR")
 	mock.ExpectQuery(regexp.QuoteMeta(colsOracleSQL)).WithArgs("test", "t3").WillReturnRows(columnRows)
 
 	indexRows := sqlmock.NewRows([]string{"index_type", "index_name", "column_position", "column_name"}).
@@ -124,6 +124,16 @@ func (cs *UtilSuite) TestGetOracleTableInfo(c *check.C) {
 			{name: "T3_PK", columns: []string{"C1", "C2"}},
 			{name: "T3_C3_C4_UINDEX", columns: []string{"C3", "C4"}},
 			{name: "T3_C5_C6_UINDEX", columns: []string{"C5", "C6"}},
+		},
+		dataTypeMap: map[string]string{
+			"C1": "VARCHAR2",
+			"C2": "VARCHAR2",
+			"C3": "VARCHAR2",
+			"C4": "VARCHAR2",
+			"C5": "VARCHAR2",
+			"C6": "NUMBER",
+			"C7": "CHAR",
+			"C8": "NCHAR",
 		},
 	})
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?

Issue Number: ref #1164

### What is changed and how it works?
when table defined the char type column, rtrim function will be used in sql

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note

### Release note

<!-- bugfix or new feature needs a release note -->

- No release note
