### PR TITLE
*: fix drainer can't send request correctly to pump when set compressor=gzip

### DIFF
--- a/drainer/util.go
+++ b/drainer/util.go
@@ -44,7 +44,7 @@ import (
 
 const (
 	maxKafkaMsgSize = 1 << 30
-	maxGrpcMsgSize  = int(^uint(0) >> 1)
+	maxGrpcMsgSize  = int(^uint(0)>>1) - 4*1024*1024 // max grpc message size, leave 4MB as buffer, see https://github.com/pingcap/tidb-binlog/issues/1152
 )
 
 // taskGroup is a wrapper of `sync.WaitGroup`.

--- a/drainer/util.go
+++ b/drainer/util.go
@@ -44,7 +44,9 @@ import (
 
 const (
 	maxKafkaMsgSize = 1 << 30
-	maxGrpcMsgSize  = int(^uint(0)>>1) - 4*1024*1024 // max grpc message size, leave 4MB as buffer, see https://github.com/pingcap/tidb-binlog/issues/1152
+	// max grpc message size, leave 4MB as buffer. Because when grpc decompresses messages, it will leave a few buffer
+	// for this, which overflows the int64: https://github.com/grpc/grpc-go/blob/v1.44.0/rpc_util.go#L742
+	maxGrpcMsgSize = int(^uint(0)>>1) - 4*1024*1024
 )
 
 // taskGroup is a wrapper of `sync.WaitGroup`.

--- a/pump/config.go
+++ b/pump/config.go
@@ -35,7 +35,7 @@ const (
 	defaultEtcdDialTimeout   = 5 * time.Second
 	defaultEtcdURLs          = "http://127.0.0.1:2379"
 	defaultListenAddr        = "127.0.0.1:8250"
-	defaultMaxMsgSize        = int(^uint(0) >> 1) // max grpc message size
+	defaultMaxMsgSize        = int(^uint(0)>>1) - 4*1024*1024 // max grpc message size, leave 4MB as buffer, see https://github.com/pingcap/tidb-binlog/issues/1152
 	defaultHeartbeatInterval = 2
 	defaultGC                = "7"
 	defaultDataDir           = "data.pump"

--- a/pump/config.go
+++ b/pump/config.go
@@ -32,10 +32,12 @@ import (
 )
 
 const (
-	defaultEtcdDialTimeout   = 5 * time.Second
-	defaultEtcdURLs          = "http://127.0.0.1:2379"
-	defaultListenAddr        = "127.0.0.1:8250"
-	defaultMaxMsgSize        = int(^uint(0)>>1) - 4*1024*1024 // max grpc message size, leave 4MB as buffer, see https://github.com/pingcap/tidb-binlog/issues/1152
+	defaultEtcdDialTimeout = 5 * time.Second
+	defaultEtcdURLs        = "http://127.0.0.1:2379"
+	defaultListenAddr      = "127.0.0.1:8250"
+	// max grpc message size, leave 4MB as buffer. Because when grpc decompresses messages, it will leave a few buffer
+	// for this, which overflows the int64: https://github.com/grpc/grpc-go/blob/v1.44.0/rpc_util.go#L742
+	defaultMaxMsgSize        = int(^uint(0)>>1) - 4*1024*1024
 	defaultHeartbeatInterval = 2
 	defaultGC                = "7"
 	defaultDataDir           = "data.pump"

--- a/tests/cache_table/run.sh
+++ b/tests/cache_table/run.sh
@@ -4,7 +4,7 @@ set -e
 
 cd "$(dirname "$0")"
 
-run_drainer &
+run_drainer --compressor gzip &
 
 sleep 3
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close https://github.com/pingcap/tidb-binlog/issues/1152

### What is changed and how it works?
See https://github.com/pingcap/tidb-binlog/issues/1152#issuecomment-1216233918, add 4MB buffer for max grpc message size.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 Test playground with compressor, works correctly.

Related changes

 - Need to cherry-pick to the release branch

### Release note

<!-- bugfix or new feature needs a release note -->

- fix drainer can't send request correctly to pump when set compressor=gzip