### PR TITLE
*: add auto sync configuration in creating etcd client

### DIFF
--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -47,9 +47,10 @@ func NewClient(cli *clientv3.Client, root string) *Client {
 // NewClientFromCfg returns a wrapped etcd client
 func NewClientFromCfg(endpoints []string, dialTimeout time.Duration, root string, security *tls.Config) (*Client, error) {
 	cli, err := clientv3.New(clientv3.Config{
-		Endpoints:   endpoints,
-		DialTimeout: dialTimeout,
-		TLS:         security,
+		Endpoints:        endpoints,
+		DialTimeout:      dialTimeout,
+		TLS:              security,
+		AutoSyncInterval: 30 * time.Second,
 	})
 	if err != nil {
 		return nil, errors.Trace(err)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close https://github.com/pingcap/tidb-binlog/issues/1236

### What is changed and how it works?
Add `AutoSyncInterval` configuration in creating etcd client.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - None

Code changes

 - None

Side effects

 - None

Related changes

 - None

### Release note

<!-- bugfix or new feature needs a release note -->
```release-note
fix the problem that drainer/pump can't work when pd's topology changes
```
