### PR TITLE
drainer: if all DML is filtered, return `true` `ignore`

### DIFF
--- a/drainer/syncer.go
+++ b/drainer/syncer.go
@@ -660,7 +660,9 @@ func skipDMLEvent(pv *pb.PrewriteValue, schema *Schema, filter *filter.Filter, b
 			mutation.DeletedRows = mutation.DeletedRows[0:filteredDeleteIdx]
 		}
 
-		muts = append(muts, mutation)
+		if len(mutation.Sequence) > 0 {
+			muts = append(muts, mutation)
+		}
 	}
 
 	pv.Mutations = muts

--- a/drainer/syncer_test.go
+++ b/drainer/syncer_test.go
@@ -54,7 +54,7 @@ func (s *syncerSuite) TestFilterTable(c *check.C) {
 	// append one mutation that will not be dropped
 	var keepID int64 = 2
 	schema.tableIDToName[keepID] = TableName{Schema: "keep", Table: "keep"}
-	pv.Mutations = append(pv.Mutations, pb.TableMutation{TableId: keepID})
+	pv.Mutations = append(pv.Mutations, pb.TableMutation{TableId: keepID, Sequence: []pb.MutationType{pb.MutationType_Insert}})
 
 	ignore, err = skipDMLEvent(pv, schema, filter, nil)
 	c.Assert(err, check.IsNil)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #1317

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note

### Release note

<!-- bugfix or new feature needs a release note -->

- No release note

```release-note
If the whole transaction is filtered, release the memory
```
